### PR TITLE
changed the --cogs-data-dir to reflect what is on the COG tutorial

### DIFF
--- a/bin/anvi-setup-ncbi-cogs
+++ b/bin/anvi-setup-ncbi-cogs
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(description='Download COG data from the NCBI')
-    parser.add_argument('--cog-data-dir', default=None, type=str, help="The directory for COG data to be stored. If you leave it\
+    parser.add_argument('--cogs-data-dir', default=None, type=str, help="The directory for COG data to be stored. If you leave it\
                         as is without specifying anything, the default destination for the data directory will be used to set things\
                         up. The advantage of it is that everyone will be using a single data directory, but then you may need\
                         superuser privileges to do it. Using this parameter you can choose the location of the data directory somewhere\


### PR DESCRIPTION
Followed the tutorial on http://merenlab.org/2016/10/25/cog-annotation/ and realized there was this constant error below - `anvi-setup-ncbi-cogs: error: unrecognized arguments: --cogs-data-dir .`

Just a small fix.