### PR TITLE
Changed fasta reformat

### DIFF
--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -34,12 +34,22 @@ def remove_short_contigs_from_fasta(args):
     if prefix:
         utils.is_this_name_OK_for_database('contig name prefix', prefix)
 
-    if args.input_ids:
-        filesnpaths.is_file_exists(args.input_ids)
-        input_ids = set([l.split('\t')[0].strip() for l in open(args.input_ids, 'rU').readlines()])
-        run.info('Input IDs to remove', '%d found' % len(input_ids))
+    if args.exclude_ids:
+        filesnpaths.is_file_exists(args.exclude_ids)
+        exclude_ids = set([l.split('\t')[0].strip() for l in open(args.exclude_ids, 'rU').readlines()])
+        print(exclude_ids)
+        run.info('Input IDs to remove', '%d found' % len(exclude_ids))
     else:
-        input_ids = set([])
+        exclude_ids = set([])
+
+    if args.include_ids:
+        filesnpaths.is_file_exists(args.include_ids)
+        include_ids = set([l.split('\t')[0].strip() for l in open(args.include_ids, 'rU').readlines()])
+        print(include_ids)
+        run.info('Input IDs to consider', '%d found' % len(include_ids))
+    else:
+        include_ids = set([])
+
 
     output = u.FastaOutput(args.output_file)
     fasta = u.SequenceSource(args.contigs_fasta)
@@ -54,12 +64,18 @@ def remove_short_contigs_from_fasta(args):
     total_num_contigs_removed = 0
 
     while next(fasta):
+
         l = len(fasta.seq)
 
         total_num_nucleotides += l
         total_num_contigs += 1
 
-        if input_ids and fasta.id.split()[0] in input_ids:
+        if include_ids and fasta.id.split()[0] not in include_ids:
+            total_num_nucleotides_removed += l
+            total_num_contigs_removed += 1
+            continue
+
+        if exclude_ids and fasta.id.split()[0] in exclude_ids:
             total_num_nucleotides_removed += l
             total_num_contigs_removed += 1
             continue
@@ -106,8 +122,14 @@ if __name__ == '__main__':
                         help="Minimum length of contigs to keep (contigs shorter than this value\
                               will not be included in the output file). The default is %(default)d,\
                               so nothing will be removed if you do not declare a minimum size.")
-    parser.add_argument('-i', '--input-ids', required=False, metavar='TXT FILE',
-                        help="IDs to remove from the FASTA file.")
+    parser.add_argument('-i', '--exclude-ids', required=False, metavar='TXT FILE',
+                        help="IDs to remove from the FASTA file. You cannot provide both\
+                              --include-ids and --exclude-ids.")
+    parser.add_argument('-I', '--include-ids', required=False, metavar='TXT FILE',
+                        help="If provided, all IDs not in this file will be excluded from the\
+                              reformatted FASTA file. Any additional filters (such as --min-len)\
+                              will still be applied to the IDs in this file. You cannot provide both\
+                              --exclude-ids and --include-ids.")
     parser.add_argument('-o', '--output-file', required=True, metavar='FASTA FILE',
                         help="Output file path.")
     parser.add_argument('--simplify-names', default=False, action="store_true",
@@ -122,8 +144,12 @@ if __name__ == '__main__':
                               in case you need to go back to this information later. It is not\
                               mandatory to declare one, but it is a very good idea to have it.")
 
-
     args = parser.parse_args()
+
+    if args.include_ids and args.exclude_ids:
+        e = ConfigError("Only one of --exclude-ids and --include-ids can be specified.")
+        print(e)
+        sys.exit()
 
     try:
         remove_short_contigs_from_fasta(args)


### PR DESCRIPTION
My first contribution to anvio. Please make sure I didn't screw anything up :)

Note: I changed the `input-ids` flag to `include-ids` to avoid ambiguity with `exclude-ids`. If we have tutorials or workflows with this flag, we may need to change them. Alternatively, we can leave `input-ids` as legacy and make the distinction clear in `help`.