### PR TITLE
Split coverages update

### DIFF
--- a/anvio/auxiliarydataops.py
+++ b/anvio/auxiliarydataops.py
@@ -141,12 +141,14 @@ class AuxiliaryDataForSplitCoverages(HDF5_IO):
 
     def get_all(self, sample_names=[]):
         self.progress.new('Recovering split coverages')
+        self.progress.update('...')
         sample_names = self.check_sample_names(sample_names)
 
         split_coverages = {}
         num_splits, counter = len(self.split_names_in_db), 1
         for i in range(0, num_splits):
-            self.progress.update('%d of %d splits ...' % (counter, num_splits))
+            if num_splits > 100 and counter % 100 == 0:
+                self.progress.update('%d of %d splits ...' % (counter, num_splits))
 
             split_name = self.split_names_in_db[i]
             split_coverages[split_name] = {}

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1179,8 +1179,17 @@ class ProfileSuperclass(object):
         self.run = r
         self.progress = p
 
+        # this one is a large dictionary with coverage values for every nucletoide positon in every sample for
+        # every split and initialized by the member function `init_split_nucleotide_coverages_dict` --unless the
+        # member funciton `init_gene_coverages_and_detection_dicts` is not called first, in which case it is
+        # automatically initialized from within that function.
+        self.split_coverage_values_per_nt = None
+
+        # these are initialized by the member function `init_gene_coverages_and_detection_dicts`. but you knew
+        # that already becasue you are a smart ass.
         self.gene_coverages_dict = {}
         self.gene_detection_dict = {}
+
         self.split_coverage_values = None
 
         self.auxiliary_profile_data_available = None
@@ -1264,11 +1273,10 @@ class ProfileSuperclass(object):
         self.run.info('Profile DB', 'Initialized: %s (v. %s)' % (self.profile_db_path, anvio.__profile__version__))
 
 
-    def init_gene_coverages_and_detection_dicts(self, min_cov_for_detection=0):
-        """This function will fill process the auxiliary data and fill two dictionaries:
+    def init_split_nucleotide_coverages_dict(self):
+        """This function will fill process the auxiliary data and fill this dictionary:
 
-            - self.gene_detection_dict
-            - self.gene_coverages_dict
+            - self.split_coverage_values_per_nt
 
            If this is taking forever and you want to kill Meren, everyone will understand you.
         """
@@ -1291,6 +1299,16 @@ class ProfileSuperclass(object):
                               Good luck with your downstream endeavors.")
             return
 
+        self.split_coverage_values_per_nt = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.auxiliary_data_path, self.p_meta['contigs_db_hash']).get_all()
+
+
+    def init_gene_coverages_and_detection_dicts(self, min_cov_for_detection=0):
+        """This function will fill process the `self.split_coverage_values_per_nt` dict and fill two dictionaries:
+
+            - self.gene_detection_dict
+            - self.gene_coverages_dict
+        """
+
         run = terminal.Run(verbose=False)
         progress = terminal.Progress(verbose=False)
         contigs_db = ContigsSuperclass(self.args, r=run, p=progress)
@@ -1312,8 +1330,8 @@ class ProfileSuperclass(object):
 
         sample_names = self.p_meta['samples']
 
-        # recover all split coverage data at once:
-        split_coverages = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.auxiliary_data_path, self.p_meta['contigs_db_hash']).get_all()
+        if not self.split_coverage_values_per_nt:
+            self.init_split_nucleotide_coverages_dict()
 
         self.progress.new('Computing gene coverage and detection data')
         self.progress.update('...')
@@ -1325,7 +1343,7 @@ class ProfileSuperclass(object):
                 self.progress.update('%d of %d splits ...' % (counter, num_splits))
 
             # recover split coverage values from the auxiliary data file:
-            split_coverage = split_coverages[split_name]
+            split_coverage = self.split_coverage_values_per_nt[split_name]
 
             # identify entry ids for genes in `split_name`
             genes_in_splits_entries = contigs_db.split_name_to_genes_in_splits_entry_ids[split_name]

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1315,12 +1315,13 @@ class ProfileSuperclass(object):
         # recover all split coverage data at once:
         split_coverages = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.auxiliary_data_path, self.p_meta['contigs_db_hash']).get_all()
 
-        self.progress.new('Recovering gene coverage and detection data')
+        self.progress.new('Computing gene coverage and detection data')
+        self.progress.update('...')
 
         num_splits, counter = len(self.split_names), 1
         # go through all the split names
         for split_name in self.split_names:
-            if num_splits > 10 and counter % 10 == 0:
+            if num_splits > 100 and counter % 100 == 0:
                 self.progress.update('%d of %d splits ...' % (counter, num_splits))
 
             # recover split coverage values from the auxiliary data file:

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1311,7 +1311,9 @@ class ProfileSuperclass(object):
                               think about whether we can be less lazy about stuff, and do things better.")
 
         sample_names = self.p_meta['samples']
-        split_coverages = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.auxiliary_data_path, self.p_meta['contigs_db_hash'])
+
+        # recover all split coverage data at once:
+        split_coverages = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.auxiliary_data_path, self.p_meta['contigs_db_hash']).get_all()
 
         self.progress.new('Recovering gene coverage and detection data')
 
@@ -1322,7 +1324,7 @@ class ProfileSuperclass(object):
                 self.progress.update('%d of %d splits ...' % (counter, num_splits))
 
             # recover split coverage values from the auxiliary data file:
-            split_coverage = split_coverages.get(split_name)
+            split_coverage = split_coverages[split_name]
 
             # identify entry ids for genes in `split_name`
             genes_in_splits_entries = contigs_db.split_name_to_genes_in_splits_entry_ids[split_name]


### PR DESCRIPTION
Hi @ShaiberAlon,

The performance is about the same, but I improved the design a little bit. Now when you do this, it should give you access to a dictionary that keeps the coverage of each nt position across all samples for every split:

``` python
p = dbops.ProfileSuperclass(args)
p.init_split_coverage_values_per_nt_dict()

# do something with `p.split_coverage_values_per_nt_dict`
```

But only calling that function will not initialize gene coverages. The following are operationally the same, but they will also give access to `p.gene_detection_dict` and `p.gene_coverages_dict`, along with `p.split_coverage_values_per_nt_dict`:

``` python
p = dbops.ProfileSuperclass(args)
p.init_split_coverage_values_per_nt_dict()
p.init_gene_coverages_and_detection_dicts()
```
or

``` python
p = dbops.ProfileSuperclass(args)
p.init_gene_coverages_and_detection_dicts()
```

Use either, and enjoy the nucleotide-level coverage values :)

Please review the code, and merge it to the master if you are fine with these changes.


Best,