### PR TITLE
HMMops filter for missing genes

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -432,6 +432,15 @@ D = {
                       the gene names that appear multiple times, and remove all but the one with the lowest e-value. Good\
                       for whenever you really need to get only a single copy of single-copy core genes from a genome bin."}
                 ),
+    'max-num-genes-missing-from-bin': (
+            ['--max-num-genes-missing-from-bin'],
+            {'default': None,
+             'help': "If you have a list of gene names, you can use this parameter to omit any bin (or external genome) that\
+                      is missing more than a number of genes you desire. For instance, if you have 100 genome bins, and\
+                      you are interested in working with 5 ribosomal proteins, you can use '--max-num-genes-missing-from-bin 4'\
+                      to remove remove the bins that are missing more than 4 of those 5 genes. This is especially useful for\
+                      phylogenomic analyses. Parameter 0 will remove any bin that is missing any of the genes."}
+                ),
     'concatenate-genes': (
             ['--concatenate-genes'],
             {'default': False,

--- a/anvio/hmmops.py
+++ b/anvio/hmmops.py
@@ -230,8 +230,51 @@ class SequencesForHMMHits:
         for hit_unique_id in hit_unique_ids_to_remove:
             hmm_sequences_dict_for_splits.pop(hit_unique_id)
 
-
         return hmm_sequences_dict_for_splits
+
+
+    def get_num_genes_missing_per_bin_dict(self, hmm_sequences_dict_for_splits, gene_names):
+        """Get a dictionary of how many genes each bin is missing from a list of `gene_names`"""
+
+        all_bins = set([])
+
+        for entry in hmm_sequences_dict_for_splits.values():
+            all_bins.add(entry['bin_id'])
+
+        genes_in_bins_dict = dict([(bin_name, set([])) for bin_name in all_bins])
+        num_genes_missing_per_bin = dict([(bin_name, 0) for bin_name in all_bins])
+
+        for entry in hmm_sequences_dict_for_splits.values():
+            genes_in_bins_dict[entry['bin_id']].add(entry['gene_name'])
+
+        for bin_name in all_bins:
+            for gene_name in gene_names:
+                if gene_name not in genes_in_bins_dict[bin_name]:
+                    num_genes_missing_per_bin[bin_name] += 1
+
+        return num_genes_missing_per_bin
+
+
+    def filter_hmm_sequences_dict_for_bins_that_lack_more_than_N_genes(self, hmm_sequences_dict_for_splits, gene_names, max_num_genes_missing=0):
+        """This takes the output of `get_sequences_dict_for_hmm_hits_in_splits`, and goes through every bin\
+           to identify bins or genomes that have lack more than `max_num_genes_missing` from a list of genes.
+
+           Note that it returns a filtered dictionary, AND the bins that are removed."""
+
+        num_genes_missing_per_bin = self.get_num_genes_missing_per_bin_dict(hmm_sequences_dict_for_splits, gene_names)
+
+        bins_to_remove = set([])
+        all_bins = set(list(num_genes_missing_per_bin.keys()))
+        for bin_name in num_genes_missing_per_bin:
+            if num_genes_missing_per_bin[bin_name] > max_num_genes_missing:
+                bins_to_remove.add(bin_name)
+
+        bins_to_keep = all_bins.difference(bins_to_remove)
+
+        if len(bins_to_remove):
+            return (utils.get_filtered_dict(hmm_sequences_dict_for_splits, 'bin_id', bins_to_keep), bins_to_remove)
+        else:
+            return (hmm_sequences_dict_for_splits, set([]))
 
 
     def get_FASTA_header_and_sequence_for_gene_unique_id(self, hmm_sequences_dict_for_splits, gene_unique_id):

--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -79,14 +79,27 @@ def main(args):
                                hit for a gene in a given genome. Anvi'o could have set this flag on your behalf, but it just\
                                is not that kind of a platform :/")
 
+    if args.max_num_genes_missing_from_bin and not args.gene_names:
+        raise ConfigError("You can only use --max-num-genes-missing-from-bin flag if you already know what gene names you are\
+                           interested in (just to make sure you know what you are doing).")
+
+    if args.max_num_genes_missing_from_bin is not None:
+        try:
+            args.max_num_genes_missing_from_bin = int(args.max_num_genes_missing_from_bin)
+            assert(args.max_num_genes_missing_from_bin >= 0)
+        except:
+            raise ConfigError("For obvious reasons, anvi'o expects the parameter --max-num-genes-missing-from-bin to be a\
+                               non-negative integer.")
+
+
     hmm_sources = set([s.strip() for s in args.hmm_sources.split(',')]) if args.hmm_sources else set([])
 
-    # the following if/else block either uses SequencesForHMMHits or the wrapper class 
+    # the following if/else block either uses SequencesForHMMHits or the wrapper class
     # SequencesForHMMHitsWrapperForMultipleContigs (if there are multiple contigs files)
     # to get sequences, and construct `splits_dict` depending on the input files. it is
     # shitty code, and can be improved.
     if args.external_genomes:
-        s = hmmopswrapper.SequencesForHMMHitsWrapperForMultipleContigs(args, hmm_sources) 
+        s = hmmopswrapper.SequencesForHMMHitsWrapperForMultipleContigs(args, hmm_sources)
         splits_dict = s.splits_dict
     else:
         if args.list_hmm_sources:
@@ -130,6 +143,16 @@ def main(args):
     if len(gene_names):
         hmm_sequences_dict = utils.get_filtered_dict(hmm_sequences_dict, 'gene_name', set(gene_names))
         run.info('Filtered hits', '%d hits remain after filtering for %d gene(s)' % (len(hmm_sequences_dict), len(gene_names)))
+
+    if args.max_num_genes_missing_from_bin is not None:
+        hmm_sequences_dict, bins_removed = s.filter_hmm_sequences_dict_for_bins_that_lack_more_than_N_genes(hmm_sequences_dict, gene_names, args.max_num_genes_missing_from_bin)
+
+        if len(bins_removed):
+            run.info('Filtered hits', '%d hits remain after filtering for `--max-num-genes-missing-from-bin` flag' % (len(hmm_sequences_dict)))
+
+            run.warning('The `--max-num-genes-missing-from-bin` flag caused the removal of %d bins (or genomes, whatever)\
+                         from your analysis. This is the list of bins that will live in our memories: %s' % \
+                                                (len(bins_removed), ', '.join(bins_removed)))
 
     if not hmm_sequences_dict:
         raise ConfigError("Your selections resulted in 0 hits. There is nothing to report. Are you\
@@ -216,6 +239,7 @@ if __name__ == '__main__':
                                        using the `gene-names` argument. Each concatenated sequence will be separated from the other\
                                        ones by the `separator`.")
     groupG.add_argument(*anvio.A('concatenate-genes'), **anvio.K('concatenate-genes'))
+    groupG.add_argument(*anvio.A('max-num-genes-missing-from-bin'), **anvio.K('max-num-genes-missing-from-bin'))
     groupG.add_argument(*anvio.A('align-with'), **anvio.K('align-with'))
     groupG.add_argument(*anvio.A('separator'), **anvio.K('separator', {'help': 'A word that will be used to\
                                   sepaate concatenated gene sequences from each other (IF you are using this\


### PR DESCRIPTION
For instance you have 100 genomes, and you want to focus on 5 HMMs to do a phylogenomic analyses. But some of these genomes have only 1 of those 5, some others have none. How to subset a list of genomes that would be sufficiently rich with respect to how many of those 5 they have so the phylogenomic analysis is not utterly noisy?

One way to do it is to eliminate genomes based on their level of completion. But that doesn't really work this information does not guarantee that the genes you are interested will be present in genomes you pass. 

This new parameter, `--max-num-genes-missing-from-bin` solves that issue, by letting the user be able to say "Report only from genomes that contains at least X of my Y genes".
 