### PR TITLE
Pandas variabilityops

### DIFF
--- a/anvio/db.py
+++ b/anvio/db.py
@@ -6,6 +6,7 @@
 
 import os
 import sqlite3
+import pandas as pd
 
 import anvio
 import anvio.filesnpaths as filesnpaths
@@ -255,6 +256,50 @@ class DB:
                 results_dict[row[0]] = entry
 
         return results_dict
+
+
+    def get_table_as_dataframe(self, table, table_structure=None, columns_of_interest=None, keys_of_interest=None, omit_parent_column=False, error_if_no_data=True):
+        """
+        get_table_as_dict() uses the first column as the key in the resulting
+        dictionary. For pandas DataFrames there are two reasonable design
+        approaches. The first mimics this approach and uses the first column as
+        the index of the DataFrame. The approach I take instead is to keep the
+        first column as a column in the DataFrame (it is afterall, a column)
+        and use numerical indices for the DataFrame.
+        """
+        if not table_structure:
+            table_structure = self.get_table_structure(table)
+
+        columns_to_return = table_structure
+
+        if omit_parent_column:
+            if '__parent__' in table_structure:
+                columns_to_return.remove('__parent__')
+                table_structure.remove('__parent__')
+
+        if columns_of_interest:
+            for col in table_structure[1:]:
+                if col not in columns_of_interest:
+                    columns_to_return.remove(col)
+
+        if len(columns_to_return) == 1:
+            if error_if_no_data:
+                raise ConfigError("get_table_as_dataframe :: after removing an column that was not mentioned in the columns\
+                                    of interest by the client, nothing was left to return...")
+            else:
+                return {}
+
+        if keys_of_interest:
+            keys_of_interest = set(keys_of_interest)
+
+        rows = self.get_all_rows_from_table(table)
+        results_df = pd.DataFrame(rows, columns=table_structure)
+
+        if keys_of_interest:
+            results_df = results_df.loc[results_df.index.isin(keys_of_interest)]
+        results_df = results_df.loc[:, columns_to_return]
+
+        return results_df
 
 
     def get_some_rows_from_table_as_dict(self, table, where_clause, error_if_no_data=True, string_the_key=False):

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -17,6 +17,9 @@ import configparser
 import multiprocessing
 import urllib.request, urllib.error, urllib.parse
 
+import numpy as np
+import pandas as pd
+
 from email.mime.text import MIMEText
 from collections import Counter
 
@@ -394,6 +397,44 @@ def store_array_as_TAB_delimited_file(a, output_path, header, exclude_columns=[]
         f.write('\t'.join([str(row[i]) for i in range(0, num_fields) if i not in exclude_indices]) + '\n')
 
     f.close()
+    return output_path
+
+
+def store_dataframe_as_TAB_delimited_file(d, output_path, columns=None, include_index=False, index_label="index", naughty_characters=[-np.inf, np.inf], rep_str=""):
+    """
+    Stores a pandas DataFrame as a tab-delimited file.
+
+    PARAMS
+    ======
+    d: pandas DataFrame
+        DataFrame you want to save.
+    output_path: string
+        Output_path for the file. Checks if file is writable.
+    columns: list, pandas.Index, tuple (default = d.columns)
+        Columns in DataFrame to write. Default is all, in the order they appear.
+    include_index: Boolean (default = False)
+        Should the index be included as the first column? Default is no.
+    index_label: String (default = "index")
+        If include_index is True, this is the header for the index.
+    naughty_characters: list (default = [np.inf, -np.inf])
+        A list of elements that are replaced with rep_str. Note that all np.nan's (aka NaN's) are also replaced with
+        rep_str.
+    rep_str: String (default = "")
+        The string that elements belonging to naughty_characters are replaced by.
+
+    RETURNS
+    =======
+    output_path
+    """
+
+    filesnpaths.is_output_file_writable(output_path)
+
+    if not columns:
+        columns = d.columns
+
+    d.replace(naughty_characters, np.nan, inplace=True)
+
+    d.to_csv(output_path, sep="\t", columns=columns, index=include_index, index_label=index_label, na_rep=rep_str)
     return output_path
 
 
@@ -966,11 +1007,9 @@ def convert_sequence_indexing(index, source="anvio", destination="not anvio"):
 
 def convert_SSM_to_single_accession(matrix_data):
     """
-    The substitution scores from the SSM dictionaries created in
-    anvio.data.SSMs are accessed via a dictionary of dictionaries, e.g.
-    data["Ala"]["Trp"]. This returns a new dictionary accessed via the
-    concatenated sequence element pair, e.g. data["AlaTrp"] or data["AT"],
-    where they are ordered alphabetically.
+    The substitution scores from the SSM dictionaries created in anvio.data.SSMs are accessed via a dictionary of
+    dictionaries, e.g.  data["Ala"]["Trp"]. This returns a new dictionary accessed via the concatenated sequence element
+    pair, e.g. data["AlaTrp"], data["AT"], etc.  where they are ordered alphabetically.
     """
     items = matrix_data.keys()
     new_data = {}

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -936,6 +936,54 @@ def get_codon_order_to_nt_positions_dict(gene_call):
     return codon_order_to_nt_positions
 
 
+def convert_sequence_indexing(index, source="anvio", destination="not anvio"):
+    """
+    Anvi'o zero-indexes sequences. For example, the methionine that every
+    ORF starts with has the index 0. This is in contrast to the rest of the
+    world, in which the methionine is indexed by 1. This function converts
+    between the two. 
+    
+    index : integer
+        The sequence index you are converting. 
+    source : string
+        The convention you are converting from. Must be either "anvio" or "not
+        anvio"
+    destination : string
+        The convention you are converting to. Must be either "anvio" or "not
+        anvio"
+    """
+
+    if source not in ["anvio", "not anvio"] or destination not in ["anvio", "not anvio"]:
+        raise ValueError("Must be 'anvio' or 'not anvio'.")
+
+    if source == "anvio" and destination == "not anvio":
+        return index + 1
+
+    if source == "not anvio" and destination == "anvio":
+        return index - 1
+
+    return index
+
+def convert_SSM_to_single_accession(matrix_data):
+    """
+    The substitution scores from the SSM dictionaries created in
+    anvio.data.SSMs are accessed via a dictionary of dictionaries, e.g.
+    data["Ala"]["Trp"]. This returns a new dictionary accessed via the
+    concatenated sequence element pair, e.g. data["AlaTrp"] or data["AT"],
+    where they are ordered alphabetically.
+    """
+    items = matrix_data.keys()
+    new_data = {}
+
+    for row in items:
+        for column in items:
+
+            if row > column:
+                continue
+            new_data[''.join([row, column])] = matrix_data[row][column]
+    return new_data
+
+
 def get_DNA_sequence_translated(sequence, gene_callers_id, return_with_stops=False):
     sequence = sequence.upper()
 

--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -92,7 +92,7 @@ def get_competing_items(reference, items_frequency_tuples_list=[]):
         # the contig for this particular `pos`) may not be one of these. but here,
         # we don't care about that.
 
-        # FIXME: CONGRATULATIONS. YOU DID FIND THE SHITTIEST PIECE OF CODE IN THIS
+        # FIXME: CONGRATULATIONS. YOU DID FIND THE NTH SHITTIEST PIECE OF CODE IN THIS
         #        REPOSITORY. IF YOU SEND US AN E-MAIL, SOMEONE WILL RESPOND WITH A
         #        FORMAL APOLOGY FOR THIS MONSTROSITY.
         if num_items > 2 and items_frequency_tuples_list[1][1] == items_frequency_tuples_list[2][1]:

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -552,9 +552,9 @@ class VariabilitySuper(object):
         changed = "removed" if not added else "added"
 
         self.run.info('Entries after "%s"' % (reason),
-                      '%s (%s were %s)' % (pp(num_after),
-                                           pp(abs(num_before - num_after)),
-                                           changed),
+                         '%s (%s were %s)' % (pp(num_after),
+                                              pp(abs(num_before - num_after)),
+                                              changed),
                       mc='green')
 
         self.check_if_data_is_empty()

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -4,7 +4,6 @@
 """Classes to make sense of single nucleotide variation"""
 
 
-from collections import Counter
 
 import os
 import sys
@@ -21,7 +20,6 @@ import anvio.dbops as dbops
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.constants as constants
-import anvio.variability as variability
 import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
 import anvio.auxiliarydataops as auxiliarydataops
@@ -400,8 +398,6 @@ class VariabilitySuper(object):
 
         if not len(entry_ids):
             entry_ids = list(self.data.index)
-
-        items = constants.amino_acids if self.engine == "AA" else list(constants.nucleotides)
 
         # index those with and without non-zero coverage
         coverage_zero = self.data.index.isin(entry_ids) & (self.data["coverage"] == 0)
@@ -843,13 +839,17 @@ class VariabilitySuper(object):
         if self.include_split_names_in_output:
             new_structure.append('split_name')
 
-        self.progress.update('exporting variable positions table as a TAB-delimited file ...')
+        # Update entry_id with sequential numbers based on the final ordering of the data:
+        self.data = self.data.reset_index()
+        self.data.entry_id = self.data.index
 
+        self.progress.update('exporting variable positions table as a TAB-delimited file ...')
         utils.store_dataframe_as_TAB_delimited_file(self.data, self.args.output_file, columns=new_structure)
+        self.progress.end()
+
         self.run.info('Num entries reported', pp(len(self.data.index)))
         self.run.info('Output File', self.output_file_path)
         self.run.info('Num %s positions reported' % self.engine, self.data["unique_pos_identifier"].nunique())
-        self.progress.end()
 
 
 class VariableNtPositionsEngine(dbops.ContigsSuperclass, VariabilitySuper):

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -262,11 +262,21 @@ class VariabilitySuper(object):
     def apply_advanced_filters(self):
         if self.min_departure_from_consensus:
             self.run.info('Min departure from consensus', self.min_departure_from_consensus)
+            self.progress.new('Filtering based on min departure from consensus')
+            entries_before = len(self.data.index)
             self.data = self.data[self.data['departure_from_consensus'] >= self.min_departure_from_consensus]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="min departure from consensus")
+            self.progress.end()
 
         if self.max_departure_from_consensus < 1:
             self.run.info('Max departure from consensus', self.max_departure_from_consensus)
+            self.progress.new('Filtering based on max departure from consensus')
+            entries_before = len(self.data.index)
             self.data = self.data[self.data['departure_from_consensus'] <= self.max_departure_from_consensus]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="max departure from consensus")
+            self.progress.end()
 
         self.check_if_data_is_empty()
 
@@ -588,9 +598,13 @@ class VariabilitySuper(object):
         subsample_func = lambda x: pd.Series(x.unique()) if len(x.unique()) <= self.num_positions_from_each_split else\
                                    pd.Series(np.random.choice(x.unique(), size=self.num_positions_from_each_split, replace=False))
         unique_positions_to_keep = self.data.groupby('split_name')['unique_pos_identifier'].apply(subsample_func)
+
+        entries_before = len(self.data.index)
         self.data = self.data[self.data['unique_pos_identifier'].isin(unique_positions_to_keep)]
+        entries_after = len(self.data.index)
 
         self.progress.end()
+        self.report_removed_entries_from_data(entries_before, entries_after, reason="num positions each split")
 
 
     def compute_comprehensive_variability_scores(self):

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -287,19 +287,28 @@ class VariabilitySuper(object):
             self.run.info('Samples of interest', ', '.join(sorted(list(self.samples_of_interest))))
             self.sample_ids = sorted(list(self.samples_of_interest))
             self.progress.new('Filtering based on samples of interest')
+            entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["sample_id"].isin(self.samples_of_interest)]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="samples of interest")
             self.progress.end()
 
         if self.genes_of_interest:
             self.run.info('Num genes of interest', pp(len(self.genes_of_interest)))
             self.progress.new('Filtering based on genes of interest')
+            entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["corresponding_gene_call"].isin(self.genes_of_interest)]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="genes of interest")
             self.progress.end()
 
         if self.splits_of_interest:
             self.run.info('Num splits of interest', pp(len(self.splits_of_interest)))
             self.progress.new('Filtering based on splits of interest')
+            entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["split_name"].isin(self.splits_of_interest)]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="splits of interest")
             self.progress.end()
 
         # let's report the number of positions reported in each sample before filtering any further:
@@ -309,13 +318,19 @@ class VariabilitySuper(object):
         if self.min_departure_from_reference:
             self.run.info('Min departure from reference', self.min_departure_from_reference)
             self.progress.new('Filtering based on min departure from reference')
+            entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["departure_from_reference"] >= self.min_departure_from_reference]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="min departure from reference")
             self.progress.end()
 
         if self.max_departure_from_reference < 1:
             self.run.info('Max departure from reference', self.max_departure_from_reference)
             self.progress.new('Filtering based on max departure from reference')
+            entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["departure_from_reference"] <= self.max_departure_from_reference]
+            entries_after = len(self.data.index)
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="max departure from reference")
             self.progress.end()
 
         if self.engine == 'NT':
@@ -336,8 +351,11 @@ class VariabilitySuper(object):
 
         self.progress.update('counting occurrences of each position across samples ...')
 
-        occurrences = self.data.unique_pos_identifier_str.value_counts()
-        self.data = self.data[self.data.unique_pos_identifier_str.isin(occurrences[occurrences >= self.min_occurrence].index)]
+        occurrences = self.data["unique_pos_identifier_str"].value_counts()
+        entries_before = len(self.data.index)
+        self.data = self.data[self.data["unique_pos_identifier_str"].isin(occurrences[occurrences >= self.min_occurrence].index)]
+        entries_after = len(self.data.index)
+        self.report_removed_entries_from_data(entries_before, entries_after, reason="min occurrence")
         self.progress.end()
 
 

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -266,8 +266,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data[self.data['departure_from_consensus'] >= self.min_departure_from_consensus]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="min departure from consensus")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="min departure from consensus")
 
         if self.max_departure_from_consensus < 1:
             self.run.info('Max departure from consensus', self.max_departure_from_consensus)
@@ -275,8 +275,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data[self.data['departure_from_consensus'] <= self.max_departure_from_consensus]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="max departure from consensus")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="max departure from consensus")
 
         self.check_if_data_is_empty()
 
@@ -300,8 +300,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["sample_id"].isin(self.samples_of_interest)]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="samples of interest")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="samples of interest")
 
         if self.genes_of_interest:
             self.run.info('Num genes of interest', pp(len(self.genes_of_interest)))
@@ -309,8 +309,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["corresponding_gene_call"].isin(self.genes_of_interest)]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="genes of interest")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="genes of interest")
 
         if self.splits_of_interest:
             self.run.info('Num splits of interest', pp(len(self.splits_of_interest)))
@@ -318,8 +318,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["split_name"].isin(self.splits_of_interest)]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="splits of interest")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="splits of interest")
 
         # let's report the number of positions reported in each sample before filtering any further:
         num_positions_each_sample = dict(self.data.sample_id.value_counts())
@@ -331,8 +331,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["departure_from_reference"] >= self.min_departure_from_reference]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="min departure from reference")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="min departure from reference")
 
         if self.max_departure_from_reference < 1:
             self.run.info('Max departure from reference', self.max_departure_from_reference)
@@ -340,8 +340,8 @@ class VariabilitySuper(object):
             entries_before = len(self.data.index)
             self.data = self.data.loc[self.data["departure_from_reference"] <= self.max_departure_from_reference]
             entries_after = len(self.data.index)
-            self.report_removed_entries_from_data(entries_before, entries_after, reason="max departure from reference")
             self.progress.end()
+            self.report_removed_entries_from_data(entries_before, entries_after, reason="max departure from reference")
 
         if self.engine == 'NT':
             self.data['unique_pos_identifier_str'] = self.data['split_name'] + "_" + self.data['pos'].astype(str)
@@ -365,8 +365,8 @@ class VariabilitySuper(object):
         entries_before = len(self.data.index)
         self.data = self.data[self.data["unique_pos_identifier_str"].isin(occurrences[occurrences >= self.min_occurrence].index)]
         entries_after = len(self.data.index)
-        self.report_removed_entries_from_data(entries_before, entries_after, reason="min occurrence")
         self.progress.end()
+        self.report_removed_entries_from_data(entries_before, entries_after, reason="min occurrence")
 
 
     def set_unique_pos_identification_numbers(self):
@@ -548,7 +548,7 @@ class VariabilitySuper(object):
         """Just tells people how many were there before and after a filtering step"""
 
         self.run.info('Remaining entries after "%s"' % (reason),
-                      '%s (%s was removed)' % (pp(num_after),
+                      '%s (%s were removed)' % (pp(num_after),
                                                pp(num_before - num_after)),
                       mc='green')
         self.check_if_data_is_empty()

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -4,7 +4,6 @@
 """Classes to make sense of single nucleotide variation"""
 
 
-
 import os
 import sys
 import copy
@@ -154,7 +153,7 @@ class VariabilitySuper(object):
             raise ConfigError("Anvi'o doesn't know what to do with a engine on '%s' yet :/" % self.engine)
 
         # set items of interest while you are at it.
-        self.items = constants.amino_acids if self.engine == 'AA' else sorted(list(constants.nucleotides))
+        self.items = constants.amino_acids if self.engine == 'AA' else list(constants.nucleotides)
 
         self.progress.update('Making sure our databases are here ..')
         if not self.profile_db_path:
@@ -233,7 +232,7 @@ class VariabilitySuper(object):
         # data is one of them, since they will be read from different tables.
         # another one is the substitution scoring matrices.
         if self.engine == 'NT':
-            self.data = profile_db.db.get_table_as_dataframe(t.variable_nts_table_name)
+            self.data = profile_db.db.get_table_as_dataframe(t.variable_nts_table_name, table_structure=t.variable_nts_table_structure)
             self.progress.end()
 
         elif self.engine == 'AA':

--- a/bin/anvi-gen-variability-profile
+++ b/bin/anvi-gen-variability-profile
@@ -53,7 +53,6 @@ if __name__ == '__main__':
     groupE.add_argument(*anvio.A('max-departure-from-consensus'), **anvio.K('max-departure-from-consensus'))
     groupE.add_argument(*anvio.A('min-occurrence-of-variable-positions'), **anvio.K('min-occurrence-of-variable-positions'))
     groupE.add_argument(*anvio.A('genes-of-interest'), **anvio.K('genes-of-interest'))
-    groupE.add_argument("--pandas", required=True, type=int)
 
     args = parser.parse_args()
     

--- a/bin/anvi-gen-variability-profile
+++ b/bin/anvi-gen-variability-profile
@@ -53,6 +53,7 @@ if __name__ == '__main__':
     groupE.add_argument(*anvio.A('max-departure-from-consensus'), **anvio.K('max-departure-from-consensus'))
     groupE.add_argument(*anvio.A('min-occurrence-of-variable-positions'), **anvio.K('min-occurrence-of-variable-positions'))
     groupE.add_argument(*anvio.A('genes-of-interest'), **anvio.K('genes-of-interest'))
+    groupE.add_argument("--pandas", required=True, type=int)
 
     args = parser.parse_args()
     


### PR DESCRIPTION
In comparison to master, here are the differences I have documented:

1. Entries are ordered by unique_pos_identifier. For a given unique_pos_identifier, entries are ordered alphabetically by sample_id.

2. Ties from consensus values are now resolved alphabetically.

3. Competing item logic is now logical. There are three rules that are always upheld.
     - In the case of ties for the most common, or second most common item, they are always resolved alphabetically. E.g. a tie between Ala and Trp for the second most common item goes to Ala. 
     - The competing items are always arranged alphabetically, regardless of which is most common. In the previous example Ala was second most common, and if Ser was the most common, competing_aas will still be AlaSer
     - If the coverage of the most common item is equal to the total coverage, the item is paired with itself, e.g CysCys.

4. To get a first glance at variation, we display competing_nts during inspect mode in the interactive interface, which means they are stored. I don't know how the competing_nts are computed during this process, but after looking at 3 datasets (Infant Gut, E. Faecalis; TARA Oceans, HIMB083; and Mushroom Spring, Synechococcus), there were no "N" counts (--engine NT), which makes me think that consensus and competing_nts are calculated without consideration of "N" values. In contrast, the variability table is not prejudiced to N, and treats it like any other item in self.items. This means it can be the consensus value, or be one of the items in competing_nts, etc.

5. `STP` from --engine AA and `N` from `--engine NT` can be competing items or consensus values. This may or may not be different behavior.

6. For kullback_leibler_divergence_normalized, it used to be the case that if one or more of the samples for a given unique_pos_identifier had 0 coverage, the value was infinite. I now do something that is mathematically equivalent to simply discarding that sample for that unique_pos_identifier, i.e. I give it zero weight and calculate what the entropy is without that sample.

7. In my last update weighted SSM scores were not identical between master and pandas_variability. This is just due to small numerical error, when rounding the results to within 3 decimal places everything is identical. So this is equally as correct as master.

8. Any `--quince-mode` and `--min-coverage-in-each-sample 0` can produce entries with 0 coverage. In these cases `n2n1ratio` and `departure_from_consensus` used to be `-1.0`. Now, they resolve to `0.0`.

9. All `np.nan`s `-np.inf`s and `np.inf`s are set to the empty string `""` when exporting to tab-delimited file. This choice was to increase compatibility between how other programs handle things like "NaN", "inf", "-inf", etc.

10. `recover_base_frequencies_for_all_samples` may be partially vectorizable, but for now is definitely the slowest part of the code.

11. `compute_comprehensive_variability_scores` is now split into metrics that require `--quince-mode`, and those that don't. Before, some metrics didn't actually require `--quince-mode`, but were wrapped in  `compute_comprehensive_variability_scores` which did require `--quince-mode`.

12. It was discovered in the master version that `filter_based_on_scattering_factor` didn't have its intended behaviour. It still doesn't, but now a `ConfigError` is invoked if the function is called. I will fix this.

Aside from the above differences, the identicalness of the table between pandas_variability and master has been verified on the INFANT GUT for the following tables:

```
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine AA -o VARIABILITY_TESTS/PANDAS_AA --quince
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine AA -o VARIABILITY_TESTS/PANDAS_AA_DFR --quince -r 0.1 -z 0.9
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine AA -o VARIABILITY_TESTS/PANDAS_AA_DFC --quince -j 0.1 -a 0.9
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine AA -o VARIABILITY_TESTS/PANDAS_AA_MINCOV --quince --min-coverage-in-each-sample 20
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine AA -o VARIABILITY_TESTS/PANDAS_AA_X --quince -x 2
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine AA -o VARIABILITY_TESTS/PANDAS_AA_HEAVYPARAMS --quince --min-coverage-in-each-sample 1 -r 0.05 -z 0.95 -j 0.05 -a 0.95 -x 2

anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine NT -o VARIABILITY_TESTS/PANDAS_NT --quince
anvi-gen-variability-profile -p DATA/PROFILE21.db  -c DATA/CONTIGS.db -C merens -b E_facealis --engine NT -o VARIABILITY_TESTS/PANDAS_NT_HEAVYPARAMS --quince --min-coverage-in-each-sample 1 -r 0.05 -z 0.95 -j 0.05 -a 0.95 -x 2
```