### PR TITLE
added default output file to new gen-vignette script

### DIFF
--- a/sandbox/anvi-script-gen-vignette
+++ b/sandbox/anvi-script-gen-vignette
@@ -232,7 +232,7 @@ if __name__ == '__main__':
 
     parser.add_argument('-p', '--program-names-to-focus', default=None, help="Comma-spearated list of program names to focus\
                          Mostly for debugging purposes.")
-    parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file'))
+    parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file', {'default': 'vignette-out.md'}))
 
     args = anvio.get_args(parser)
 


### PR DESCRIPTION
it was crashing with no user-friendly error message when none was provided