### PR TITLE
anvi-get-short-reads-from-bam gets beefed up

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -745,15 +745,12 @@ D = {
                       your short reads, as well as the length of the gene you are targeting.\
                       The default is %(default)d nts."}
                 ),
-    'split-by-forward-and-reverse': (
-            ['-Q', '--split-by-forward-and-reverse'],
+    'split-R1-and-R2': (
+            ['-Q', '--split-R1-and-R2'],
             {'default': False,
              'action': 'store_true',
-             'help': "When declared, this program outputs 3 FASTA files, one for forward reads,\
-                      one for reverse reads, and one for unpaired reads. This means you need to\
-                      provide 3 output files for the flag `-o` in this order: forward reads,\
-                      reverse reads, and unpaired reads, each separated by a comma (no spaces).\
-                      For example, `-o fwd.fa,rev.fa,unpaired.fa`."}
+             'help': "When declared, this program outputs 3 FASTA files for paired-end reads: one\
+                      for R1, one for R2, and one for unpaired reads."}
                 ),
     'gzip-output': (
             ['-X', '--gzip-output'],

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -745,6 +745,22 @@ D = {
                       your short reads, as well as the length of the gene you are targeting.\
                       The default is %(default)d nts."}
                 ),
+    'split-by-forward-and-reverse': (
+            ['-Q', '--split-by-forward-and-reverse'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "When declared, this program outputs 3 FASTA files, one for forward reads,\
+                      one for reverse reads, and one for unpaired reads. This means you need to\
+                      provide 3 output files for the flag `-o` in this order: forward reads,\
+                      reverse reads, and unpaired reads, each separated by a comma (no spaces).\
+                      For example, `-o fwd.fa,rev.fa,unpaired.fa`."}
+                ),
+    'gzip-output': (
+            ['-X', '--gzip-output'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "When declared, output file(s) will be gzip compressed and the extension `.gz` will be added."}
+                ),
     'list-contigs': (
             ['--list-contigs'],
             {'default': False,

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -382,7 +382,7 @@ class GetReadsFromBAM:
         self.bin_ids_file_path = A('bin_ids_file')
         self.output_file_path = A('output_file')
         self.gzip = A('gzip_output')
-        self.split_r1_r2 = A('split_by_forward_and_reverse')
+        self.split_R1_and_R2 = A('split_R1_and_R2')
 
         self.bins = set([])
         self.split_names_of_interest = set([])
@@ -406,7 +406,7 @@ class GetReadsFromBAM:
 
     def get_short_reads_for_splits_dict(self):
         short_reads_for_splits_dict = {}
-        if self.split_r1_r2:
+        if self.split_R1_and_R2:
             short_reads_for_splits_dict['R1'] = {}
             short_reads_for_splits_dict['R2'] = {}
             short_reads_for_splits_dict['unpaired'] = {}
@@ -465,7 +465,7 @@ class GetReadsFromBAM:
              'reference_start', 'rlen', 'rname', 'rnext', 'seq', 'setTag', 'set_tag', 'set_tags', 'tags', 
              'template_length', 'tid', 'tlen']'''
 
-            if self.split_r1_r2:
+            if self.split_R1_and_R2:
                 for contig_id, start, stop in contig_start_stops:
                     for entry in bam_file_object.fetch(contig_id, start, stop):
                         if entry.is_read1:

--- a/bin/anvi-get-short-reads-from-bam
+++ b/bin/anvi-get-short-reads-from-bam
@@ -30,12 +30,16 @@ if __name__ == '__main__':
     parser.add_argument('input_bams', metavar = 'BAM FILE[S]', nargs='+',
                         help = 'BAM file(s) to access to recover short reads')
 
+    output_file_kwargs = {'help': 'File path(s) to store results. Multiple files should be separated by commas (no spaces).'}
+
     parser.add_argument(*anvio.A('profile-db'), **anvio.K('profile-db'))
     parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
     parser.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
     parser.add_argument(*anvio.A('bin-id'), **anvio.K('bin-id'))
     parser.add_argument(*anvio.A('bin-ids-file'), **anvio.K('bin-ids-file'))
-    parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file'))
+    parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file', output_file_kwargs))
+    parser.add_argument(*anvio.A('gzip-output'), **anvio.K('gzip-output'))
+    parser.add_argument(*anvio.A('split-by-forward-and-reverse'), **anvio.K('split-by-forward-and-reverse'))
 
     args = anvio.get_args(parser)
 

--- a/bin/anvi-get-short-reads-from-bam
+++ b/bin/anvi-get-short-reads-from-bam
@@ -37,7 +37,8 @@ if __name__ == '__main__':
     parser.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
     parser.add_argument(*anvio.A('bin-id'), **anvio.K('bin-id'))
     parser.add_argument(*anvio.A('bin-ids-file'), **anvio.K('bin-ids-file'))
-    parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file', output_file_kwargs))
+    parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file'))
+    parser.add_argument(*anvio.A('output-file-prefix'), **anvio.K('output-file-prefix'))
     parser.add_argument(*anvio.A('gzip-output'), **anvio.K('gzip-output'))
     parser.add_argument(*anvio.A('split-R1-and-R2'), **anvio.K('split-R1-and-R2'))
 

--- a/bin/anvi-get-short-reads-from-bam
+++ b/bin/anvi-get-short-reads-from-bam
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     parser.add_argument(*anvio.A('bin-ids-file'), **anvio.K('bin-ids-file'))
     parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file', output_file_kwargs))
     parser.add_argument(*anvio.A('gzip-output'), **anvio.K('gzip-output'))
-    parser.add_argument(*anvio.A('split-by-forward-and-reverse'), **anvio.K('split-by-forward-and-reverse'))
+    parser.add_argument(*anvio.A('split-R1-and-R2'), **anvio.K('split-R1-and-R2'))
 
     args = anvio.get_args(parser)
 


### PR DESCRIPTION
Tested on unpaired and paired bam files, w/ all combinations of user input I could think of. 

Multiple files separated by `,` for `-o` is a little ugly, but documentation is good with an example. Also, code catches funny instances like `file1,file2,`, `,file1,file2,file3` and `file2,,file2,file2`