### PR TITLE
change scikit-learn requirment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 cython
 bottle==0.12.13
-pysam==0.14.1
+pysam>=0.14.1
 ete3==3.1.1
 scipy>=0.13.3
 scikit-learn>=0.19.1
@@ -16,4 +16,4 @@ pandas>=0.20.1
 matplotlib>=2.2.0
 pyani==0.2.7
 statsmodels==0.9.0
-snakemake==4.7.0
+snakemake>=4.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ requests>=2.10.0
 psutil>=5.0.1
 mistune==0.7.4
 six==1.11.0
-pandas==0.20.1
+pandas>=0.20.1
 matplotlib>=2.2.0
 pyani==0.2.7
 statsmodels==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bottle==0.12.13
 pysam==0.14.1
 ete3==3.1.1
 scipy>=0.13.3
-scikit-learn==0.19.1
+scikit-learn>=0.19.1
 django==2.0.2
 h5py>=2.8.0rc1
 cherrypy==8.9.1


### PR DESCRIPTION
With the new brew and new python versions pip install
scikit-learn==0.19.1 fails, but `pip install scikit-learn` works (which
is version `0.19.2`)

Homebrew 1.7.1
Python 3.7.0

@ozcan, @meren, do you have an objection to this change?