### PR TITLE
Phylo workflow

### DIFF
--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -83,7 +83,8 @@ def get_raw_fasta(wildcards):
 rule generate_and_annotate_contigs_db:
     input: expand(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done", group=group_names)
 
-rule anvi_script_reformat_fasta:
+
+rule anvi_script_reformat_fasta_prefix_only:
     '''
         Reformating the headers of the contigs fasta files.
 
@@ -93,33 +94,61 @@ rule anvi_script_reformat_fasta:
         contigs would look like this:
         > MYSAMPLE01_000000000001
         > MYSAMPLE01_000000000002
+
+        We do it in two steps in this workflow with the rules:
+        anvi_script_reformat_fasta_prefix_only and anvi_script_reformat_fasta_min_length
+        The first rule anvi_script_reformat_fasta_prefix_only does all the formating
+        of headers without considering the min_len parameter. The second rule takes
+        the output of the first rule as input and considers the min_len param.
+        The reasoning is that this way we have a fasta file that includes all the contigs
+        from the raw fasta file, but with headers that match the fasta final fasta file.
+        Hence, if later we decide we want to include shorter contigs, we can do it using
+        the output of anvi_script_reformat_fasta_prefix_only and the headers would be consistant.
     '''
     version: 1.0
-    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_script_reformat_fasta.log"
+    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_script_reformat_fasta_prefix_only.log"
     input:
         contigs = get_raw_fasta
     output:
         # write protecting the contigs fasta file using protected() because
         # runnig the assembly is probably the most time consuming step and
         # we don't want anyone accidentaly deleting or changing this file.
-        contigs = protected(dirs_dict["FASTA_DIR"] + "/{group}/{group}-contigs.fa"),
+        contigs = protected(dirs_dict["FASTA_DIR"] + "/{group}/{group}-contigs-prefix-formatted-only.fa"),
         report = dirs_dict["FASTA_DIR"] + "/{group}/{group}-reformat-report.txt"
     params:
         prefix = "{group}",
         simplify_names = M.get_rule_param("anvi_script_reformat_fasta", "--simplify-names"),
         keep_ids = M.get_rule_param("anvi_script_reformat_fasta", "--keep-ids"),
         exclude_ids = M.get_rule_param("anvi_script_reformat_fasta", "--exclude-ids"),
-        min_len = M.get_rule_param("anvi_script_reformat_fasta", "--min-len"),
     threads: M.T('anvi_script_reformat_fasta')
     resources: nodes = M.T('anvi_script_reformat_fasta'),
     shell: w.r("""anvi-script-reformat-fasta {input} \
                                              -o {output.contigs} \
                                              -r {output.report} \
                                              --prefix {params.prefix} \
-                                             {params.min_len} \
                                              {params.exclude_ids} \
                                              {params.keep_ids} \
                                              {params.simplify_names} >> {log} 2>&1""")
+
+
+rule anvi_script_reformat_fasta:
+    '''
+        See docummentation for anvi_script_reformat_fasta_prefix_only
+    '''
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_script_reformat_fasta.log"
+    input:
+        contigs = dirs_dict["FASTA_DIR"] + "/{group}/{group}-contigs-prefix-formatted-only.fa"
+    output:
+        contigs = dirs_dict["FASTA_DIR"] + "/{group}/{group}-contigs.fa"
+    params:
+        prefix = "{group}",
+        min_len = M.get_rule_param("anvi_script_reformat_fasta", "--min-len"),
+    threads: M.T('anvi_script_reformat_fasta')
+    resources: nodes = M.T('anvi_script_reformat_fasta'),
+    shell: w.r("""anvi-script-reformat-fasta {input} \
+                                             -o {output.contigs} \
+                                             {params.min_len} >> {log} 2>&1""")
 
 
 def input_for_run_remove_human_dna_using_centrifuge(wildcards):

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -37,7 +37,7 @@ rule generate_phylogeny:
 rule anvi_get_sequences_for_hmm_hits:
     version: 1.0
     log: os.path.join(dirs_dict["LOGS_DIR"], "anvi_get_sequences_for_hmm_hits.log")
-    input: unpack(lambda wildcards M.input_for_anvi_get_sequences_for_hmm_hits) # The lambda function here is just a trick. from some reason without it, snakemake can't unpack the dict
+    input: unpack(lambda: wildcards M.input_for_anvi_get_sequences_for_hmm_hits) # The lambda function here is just a trick. from some reason without it, snakemake can't unpack the dict
     output: os.path.join(dirs_dict["PHYLO_DIR"], "proteins.fa")
     params:
         internal_genomes_argument = lambda wildcards: "--internal-genomes " + M.internal_genomes_file if M.internal_genomes_file else "",

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -37,7 +37,7 @@ rule generate_phylogeny:
 rule anvi_get_sequences_for_hmm_hits:
     version: 1.0
     log: os.path.join(dirs_dict["LOGS_DIR"], "anvi_get_sequences_for_hmm_hits.log")
-    input: unpack(M.input_for_anvi_get_sequences_for_hmm_hits)
+    input: unpack(lambda wildcards M.input_for_anvi_get_sequences_for_hmm_hits) # The lambda function here is just a trick. from some reason without it, snakemake can't unpack the dict
     output: os.path.join(dirs_dict["PHYLO_DIR"], "proteins.fa")
     params:
         internal_genomes_argument = lambda wildcards: "--internal-genomes " + M.internal_genomes_file if M.internal_genomes_file else "",

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -75,32 +75,32 @@ rule trimal:
     resources: nodes = M.T('trimal')
     shell:
         """
-        trimal -in {input} \
-               -out {output} \
-               {params.gt} \
-               {params.additional_params} >> {log} 2>&1
+            trimal -in {input} \
+                   -out {output} \
+                   {params.gt} \
+                   {params.additional_params} >> {log} 2>&1
         """
 
 
-rule iqtree_omp:
+rule iqtree:
     version: 1.0
-    log: os.path.join(dirs_dict["LOGS_DIR"], "iqtree_omp.log")
+    log: os.path.join(dirs_dict["LOGS_DIR"], "iqtree.log")
     input: os.path.join(dirs_dict["PHYLO_DIR"], "proteins_GAPS_REMOVED.fa")
     output: os.path.join(dirs_dict["PHYLO_DIR"], M.get_param_value_from_config('project_name'))
     params:
-        m = M.get_rule_param('iqtree_omp', '-m'),
-        bb = M.get_rule_param('iqtree_omp', '-bb'),
-        additional_params = M.get_rule_param('iqtree_omp', 'additional_params')
-    threads: M.T('iqtree_omp')
-    resources: nodes = M.T('iqtree_omp')
+        m = M.get_rule_param('iqtree', '-m'),
+        bb = M.get_rule_param('iqtree', '-bb'),
+        additional_params = M.get_rule_param('iqtree', 'additional_params')
+    threads: M.T('iqtree')
+    resources: nodes = M.T('iqtree')
     shell:
         """
-        iqtree-omp -s {input} \
-                   -nt {threads} \
-                   {params.m} \
-                   {params.bb} \
-                   {params.additional_params} \
-                   -o {output} >> {log} 2>&1
+            iqtree -s {input} \
+                       -nt {threads} \
+                       {params.m} \
+                       {params.bb} \
+                       {params.additional_params} \
+                       -o {output} >> {log} 2>&1
         """
 
 

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -9,7 +9,7 @@ import anvio.workflows as w
 import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
-from anvio.workflows.contigs import ContigsDBWorkflow
+from anvio.workflows.phylogenomics import PhylogenomicsWorkflow
 
 __author__ = "Alon Shaiber"
 __copyright__ = "Copyright 2017, The anvio Project"

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -1,5 +1,6 @@
 # -*- coding: utf-8
 
+import os
 import argparse
 import pandas as pd
 
@@ -41,6 +42,76 @@ if fasta_txt_file:
 
 rule generate_phylogeny:
     input: 
+
+rule anvi_get_sequences_for_hmm_hits:
+    version: 1.0
+    log: os.path.join(dirs_dict["LOGS_DIR"], "anvi_get_sequences_for_hmm_hits.log")
+    input: unpack(M.input_for_anvi_get_sequences_for_hmm_hits)
+    output: os.path.join(dirs_dict["PHYLO_DIR"], "proteins.fa")
+    params:
+        internal_genomes_argument = lambda wildcards: "--internal-genomes " + M.internal_genomes_file if M.internal_genomes_file else "",
+        external_genomes_argument = lambda wildcards: "--external-genomes " + M.external_genomes_file if M.external_genomes_file else "",
+        return_best_hit = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--return-best-hit')
+        separator = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--separator')
+        align_with = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--align-with')
+        min_num_bins_gene_occurs = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--min-num-bins-gene-occurs')
+        max_num_genes_missing_from_bin = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--max-num-genes-missing-from-bin')
+        concatenate_genes = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--concatenate-genes')
+        get_aa_sequences = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--get-aa-sequences')
+        gene_names = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--gene-names')
+        hmm_sources = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--hmm-sources')
+    threads: M.T('anvi_get_sequences_for_hmm_hits')
+    resources: nodes = M.T('anvi_get_sequences_for_hmm_hits')
+    shell:
+        """
+            anvi-get-sequences-for-hmm-hits {params.internal_genomes_argument} {params.external_genomes_argument} \
+                                            {params.return_best_hit} {params.separator} {params.align_with} \
+                                            {params.min_num_bins_gene_occurs} {params.max_num_genes_missing_from_bin} \
+                                            {params.concatenate_genes} {params.get_aa_sequences} {params.gene_names} \
+                                            {params.hmm_sources} >> {log} 2>&1
+        """
+
+
+rule trimal:
+    version: 1.0
+    log: os.path.join(dirs_dict["LOGS_DIR"], "trimal.log")
+    input: os.path.join(dirs_dict["PHYLO_DIR"], "proteins.fa")
+    output: os.path.join(dirs_dict["PHYLO_DIR"], "proteins_GAPS_REMOVED.fa")
+    params:
+        gt = M.get_rule_param('trimal', '-gt'),
+        additional_params = M.get_rule_param('trimal', 'additional_params')
+    threads: M.T('trimal')
+    resources: nodes = M.T('trimal')
+    shell:
+        """
+        trimal -in {input} \
+               -out {output} \
+               {params.gt} \
+               {params.additional_params} >> {log} 2>&1
+        """
+
+
+rule iqtree_omp:
+    version: 1.0
+    log: os.path.join(dirs_dict["LOGS_DIR"], "iqtree_omp.log")
+    input: os.path.join(dirs_dict["PHYLO_DIR"], "proteins_GAPS_REMOVED.fa")
+    output: os.path.join(dirs_dict["PHYLO_DIR"], M.get_param_value_from_config('project_name'))
+    params:
+        m = M.get_rule_param('iqtree_omp', '-m'),
+        bb = M.get_rule_param('iqtree_omp', '-bb')
+        additional_params = M.get_rule_param('iqtree_omp', 'additional_params')
+    threads: M.T('iqtree_omp')
+    resources: nodes = M.T('iqtree_omp')
+    shell:
+        """
+        iqtree-omp -s {input} \
+                   -nt {threads} \
+                   {params.m} \
+                   {params.bb} \
+                   {params.additional_params} \
+                   -o {output} >> {log} 2>&1
+        """
+
 
 if not slave_mode:
     # check if all program dependencies are met. for this line to be effective,

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8
+
+import argparse
+import pandas as pd
+
+import anvio
+import anvio.workflows as w
+import anvio.terminal as terminal
+import anvio.filesnpaths as filesnpaths
+
+from anvio.workflows.contigs import ContigsDBWorkflow
+
+__author__ = "Alon Shaiber"
+__copyright__ = "Copyright 2017, The anvio Project"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "Alon Shaiber"
+__email__ = "alon.shaiber@gmail.com"
+
+run = terminal.Run()
+
+slave_mode = False if 'workflows/phylogenomics' in workflow.included[0] else True
+if not slave_mode:
+    # don't be confused, child. when things come to this point, the variable `config`
+    # is already magically filled in by snakemake:
+    M = PhylogenomicsWorkflow(argparse.Namespace(config=config, slave_mode=slave_mode))
+    M.init()
+    dirs_dict = M.dirs_dict
+
+localrules: generate_phylogeny
+
+group_names = []
+fasta_txt_file = M.get_param_value_from_config('fasta_txt', repress_default=True)
+
+if fasta_txt_file:
+    filesnpaths.is_file_exists(fasta_txt_file)
+    fasta_information = u.get_TAB_delimited_file_as_dictionary(fasta_txt_file)
+    group_names = list(fasta_information.keys())
+    references_mode = True
+
+rule generate_phylogeny:
+    input: 
+
+if not slave_mode:
+    # check if all program dependencies are met. for this line to be effective,
+    # there should be an initial dry run step (which is the default behavior of
+    # the `WorkflowSuperClass`, so you are most likely covered).
+    M.check_workflow_program_dependencies(workflow)

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -31,17 +31,8 @@ if not slave_mode:
 
 localrules: generate_phylogeny
 
-group_names = []
-fasta_txt_file = M.get_param_value_from_config('fasta_txt', repress_default=True)
-
-if fasta_txt_file:
-    filesnpaths.is_file_exists(fasta_txt_file)
-    fasta_information = u.get_TAB_delimited_file_as_dictionary(fasta_txt_file)
-    group_names = list(fasta_information.keys())
-    references_mode = True
-
 rule generate_phylogeny:
-    input: 
+    input: os.path.join(dirs_dict["PHYLO_DIR"], M.get_param_value_from_config('project_name'))
 
 rule anvi_get_sequences_for_hmm_hits:
     version: 1.0
@@ -51,14 +42,14 @@ rule anvi_get_sequences_for_hmm_hits:
     params:
         internal_genomes_argument = lambda wildcards: "--internal-genomes " + M.internal_genomes_file if M.internal_genomes_file else "",
         external_genomes_argument = lambda wildcards: "--external-genomes " + M.external_genomes_file if M.external_genomes_file else "",
-        return_best_hit = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--return-best-hit')
-        separator = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--separator')
-        align_with = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--align-with')
-        min_num_bins_gene_occurs = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--min-num-bins-gene-occurs')
-        max_num_genes_missing_from_bin = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--max-num-genes-missing-from-bin')
-        concatenate_genes = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--concatenate-genes')
-        get_aa_sequences = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--get-aa-sequences')
-        gene_names = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--gene-names')
+        return_best_hit = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--return-best-hit'),
+        separator = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--separator'),
+        align_with = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--align-with'),
+        min_num_bins_gene_occurs = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--min-num-bins-gene-occurs'),
+        max_num_genes_missing_from_bin = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--max-num-genes-missing-from-bin'),
+        concatenate_genes = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--concatenate-genes'),
+        get_aa_sequences = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--get-aa-sequences'),
+        gene_names = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--gene-names'),
         hmm_sources = M.get_rule_param('anvi_get_sequences_for_hmm_hits', '--hmm-sources')
     threads: M.T('anvi_get_sequences_for_hmm_hits')
     resources: nodes = M.T('anvi_get_sequences_for_hmm_hits')
@@ -98,7 +89,7 @@ rule iqtree_omp:
     output: os.path.join(dirs_dict["PHYLO_DIR"], M.get_param_value_from_config('project_name'))
     params:
         m = M.get_rule_param('iqtree_omp', '-m'),
-        bb = M.get_rule_param('iqtree_omp', '-bb')
+        bb = M.get_rule_param('iqtree_omp', '-bb'),
         additional_params = M.get_rule_param('iqtree_omp', 'additional_params')
     threads: M.T('iqtree_omp')
     resources: nodes = M.T('iqtree_omp')

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -56,7 +56,7 @@ class PhylogenomicsWorkflow(WorkflowSuperClass):
         # initialize the base class
         WorkflowSuperClass.__init__(self)
 
-        self.rules.extend(['anvi_get_sequences_for_hmm_hits', 'trimal'])
+        self.rules.extend(['anvi_get_sequences_for_hmm_hits', 'trimal', 'iqtree_omp'])
 
         self.general_params.extend(['project_name'])
 

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -56,7 +56,7 @@ class PhylogenomicsWorkflow(WorkflowSuperClass):
         # initialize the base class
         WorkflowSuperClass.__init__(self)
 
-        self.rules.extend(['anvi_get_sequences_for_hmm_hits', 'trimal', 'iqtree_omp'])
+        self.rules.extend(['anvi_get_sequences_for_hmm_hits', 'trimal', 'iqtree'])
 
         self.general_params.extend(['project_name'])
 
@@ -68,7 +68,7 @@ class PhylogenomicsWorkflow(WorkflowSuperClass):
                                                                         '--get-aa-sequences': True,
                                                                         '--hmm-sources': 'Campbell_et_al'},
                                     'trimal': {'-gt': 0.5},
-                                    'iqtree_omp': {'threads': 8, '-m': 'WAG', '-bb': 1000}})
+                                    'iqtree': {'threads': 8, '-m': 'WAG', '-bb': 1000}})
 
         get_sequences_params = ['--external-genomes', '--internal-genomes', '--return-best-hit', \
                                 '--separator', '--align-with', '--min-num-bins-gene-occurs', \
@@ -76,7 +76,7 @@ class PhylogenomicsWorkflow(WorkflowSuperClass):
                                 '--get-aa-sequences', '--gene-names', '--hmm-sources']
         self.rule_acceptable_params_dict['anvi_get_sequences_for_hmm_hits'] = get_sequences_params
         self.rule_acceptable_params_dict['trimal'] = ['-gt', 'additional_params']
-        self.rule_acceptable_params_dict['iqtree_omp'] = ['-m', '-bb', 'additional_params']
+        self.rule_acceptable_params_dict['iqtree'] = ['-m', '-bb', 'additional_params']
 
 
     def init(self):

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -104,7 +104,7 @@ class PhylogenomicsWorkflow(WorkflowSuperClass):
             self.input_for_anvi_get_sequences_for_hmm_hits['external_genomes_file'] = external_genomes_file
             self.external_genomes_file = external_genomes_file
 
-        if self.get_rule_param('anvi_get_sequences_for_hmm_hits', '--return-best-hit') != True:
+        if not self.get_rule_param('anvi_get_sequences_for_hmm_hits', '--return-best-hit'):
             run.warning('You changed the value for --return-best-hit for the rule anvi_get_sequences_for_hmm_hits \
                          to something other than the default value, which is "true", while we allow you to do it \
                          this is likely to break things, we trust that you know what you are doing, but advise you \

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8
+# pylint: disable=line-too-long
+"""
+    Classes to define and work with anvi'o phylogenomics workflows.
+"""
+
+
+import anvio
+import anvio.terminal as terminal
+
+from anvio.workflows import WorkflowSuperClass
+from anvio.errors import ConfigError
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "Alon Shaiber"
+__email__ = "alon.shaiber@gmail.com"
+
+
+class PhylogenomicsWorkflow(WorkflowSuperClass):
+    def __init__(self, args=None, run=terminal.Run(), progress=terminal.Progress()):
+        # if a regular instance of `ContigsDBWorkflow` is being generated, we
+        # expect it to have a parameter `args`. if there is no `args` given, we
+        # assume the class is being inherited as a base class from within another
+        if args:
+            if len(self.__dict__):
+                raise ConfigError("Something is wrong. You are ineriting `PhylogenomicsWorkflow` from \
+                                   within another class, yet you are providing an `args` parameter.\
+                                   This is not alright.")
+            self.args = args
+            self.name = 'phylogenomics'
+        else:
+            if not len(self.__dict__):
+                raise ConfigError("When you are *not* inheriting `PhylogenomicsWorkflow` from within\
+                                   a super class, you must provide an `args` parameter.")
+
+            if 'name' not in self.__dict__:
+                raise ConfigError("The super class trying to inherit `PhylogenomicsWorkflow` does not\
+                                   have a set `self.name`. Which means there may be other things\
+                                   wrong with it, hence anvi'o refuses to continue.")
+
+        self.run = run
+        self.progress = progress
+
+        # initialize the base class
+        WorkflowSuperClass.__init__(self)
+
+        self.rules.extend([])
+
+        self.general_params.extend([])
+
+        self.dirs_dict.update({"FASTA_DIR": "01_FASTA",
+                               "CONTIGS_DIR": "02_CONTIGS"})
+
+        self.default_config.update({})
+
+        self.rule_acceptable_params_dict[''] = []

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -83,8 +83,8 @@ class PhylogenomicsWorkflow(WorkflowSuperClass):
         ''' backhand stuff (mostly sanity checks) specific for the phylogenomics workflow'''
         super().init()
 
-        internal_genomes_file = self.get_rule_param('anvi_get_sequences_for_hmm_hits', '--internal-genomes')
-        external_genomes_file = self.get_rule_param('anvi_get_sequences_for_hmm_hits', '--external-genomes')
+        internal_genomes_file = self.get_param_value_from_config(['anvi_get_sequences_for_hmm_hits', '--internal-genomes'])
+        external_genomes_file = self.get_param_value_from_config(['anvi_get_sequences_for_hmm_hits', '--external-genomes'])
 
         if not internal_genomes_file and not external_genomes_file:
             raise ConfigError('You must provide either an external genomes file or internal genomes file \

--- a/bin/anvi-run-workflow
+++ b/bin/anvi-run-workflow
@@ -10,6 +10,7 @@ from anvio.errors import ConfigError, FilesNPathsError
 from anvio.workflows.contigs import ContigsDBWorkflow
 from anvio.workflows.metagenomics import MetagenomicsWorkflow
 from anvio.workflows.pangenomics import PangenomicsWorkflow
+from anvio.workflows.phylogenomics import PhylogenomicsWorkflow
 
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
@@ -26,7 +27,8 @@ pp = terminal.pretty_print
 
 workflows_dict = {'contigs': ContigsDBWorkflow,
                   'metagenomics': MetagenomicsWorkflow,
-                  'pangenomics': PangenomicsWorkflow}
+                  'pangenomics': PangenomicsWorkflow,
+                  'phylogenomics': PhylogenomicsWorkflow}
 
 
 def main(args):


### PR DESCRIPTION
Added a phylogenomic workflow that accepts either internal genomes file or external genomes file or both and uses trimal, and iqtree.

In addition also addressed #926.

I left the default `min_len` for `anvi-script-reformat-fasta` to zero. The user can do what they want.