### PR TITLE
Explicitly define default for --hmm-source.

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -487,6 +487,7 @@ D = {
     'hmm-source': (
             ['--hmm-source'],
             {'metavar': 'SOURCE NAME',
+             'default': None,
              'help': "Use a specific HMM source. You can use '--list-hmm-sources' flag to see\
                       a list of available resources. The default is '%(default)s'."}
                 ),


### PR DESCRIPTION
Should have no functional impact. 

However, it blew up my Galaxy Tool generator when building help text. 

I can apply an easy one-line fix to my tool generator to default to `None` for any non-defineds, but this is the only instance of a value being referenced in the help but not explicitly declared.