### PR TITLE
Homogeneity Indices Filtering

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -303,7 +303,7 @@ class BottleApplication(Bottle):
                 functions_sources = list(self.interactive.gene_clusters_function_sources)
 
             inspection_available = self.interactive.auxiliary_profile_data_available
-            if self.interactive.p_meta['blank']:
+            if 'blank' in self.interactive.p_meta and self.interactive.p_meta['blank']:
                 inspection_available = False
 
             return json.dumps( { "title":                              self.interactive.title,

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -303,11 +303,8 @@ class BottleApplication(Bottle):
                 functions_sources = list(self.interactive.gene_clusters_function_sources)
 
             inspection_available = self.interactive.auxiliary_profile_data_available
-<<<<<<< HEAD
-            if 'blank' in self.interactive.p_meta and self.interactive.p_meta['blank']:
-=======
+            
             if not self.interactive.mode == 'pan' and self.interactive.p_meta['blank']:
->>>>>>> 20dc429d82c21dcef7fb11a3eb9f53eb13ab07e0
                 inspection_available = False
 
             return json.dumps( { "title":                              self.interactive.title,

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -136,6 +136,7 @@ class BottleApplication(Bottle):
         self.route('/data/filter_gene_clusters',               callback=self.filter_gene_clusters, method='POST')
         self.route('/data/reroot_tree',                        callback=self.reroot_tree, method='POST')
         self.route('/data/save_tree',                          callback=self.save_tree, method='POST')
+        self.route('/data/check_homogeneity_info',             callback=self.check_homogeneity_info, method='POST')
 
 
     def run_application(self, ip, port):
@@ -1157,6 +1158,13 @@ class BottleApplication(Bottle):
         except Exception as e:
             message = str(e.clear_text()) if hasattr(e, 'clear_text') else str(e)
             return json.dumps({'status': 1, 'message': message})
+
+    def check_homogeneity_info(self):
+        try:
+            func, geo = self.interactive.check_if_homogeneity_information_is_available()
+            return json.dumps({'status': 0, 'func_info': 1 if func else 0, 'geo_info': 1 if geo else 0})
+        except:
+            return json.dumps({'status': 1})
 
 
     def reroot_tree(self):

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -634,22 +634,22 @@
                                             <td><input class="form-control input-xs" size="6" parameter="max_num_genes_from_each_genome" type="text" value="0" disabled /></td>
                                         </tr>
                                         <tr>
-                                            <td><input class="form-control input-xs" type="checkbox" disabled /></td>
+                                            <td><input class="form-control input-xs" type="checkbox" disabled id="min_func"/></td>
                                             <td>Min functional homogeneity index</td>
                                             <td><input class="form-control input-xs" size="6" parameter="min_functional_homogeneity_index" type="text" value="-1" disabled /></td>
                                         </tr>
                                         <tr>
-                                            <td><input class="form-control input-xs" type="checkbox" disabled /></td>
+                                            <td><input class="form-control input-xs" type="checkbox" disabled id="max_func"/></td>
                                             <td>Max functional homogeneity index</td>
                                             <td><input class="form-control input-xs" size="6" parameter="max_functional_homogeneity_index" type="text" value="1" disabled /></td>
                                         </tr>
                                         <tr>
-                                            <td><input class="form-control input-xs" type="checkbox" disabled /></td>
+                                            <td><input class="form-control input-xs" type="checkbox" disabled id="min_geo"/></td>
                                             <td>Min geometric homogeneity index</td>
                                             <td><input class="form-control input-xs" size="6" parameter="min_geometric_homogeneity_index" type="text" value="-1" disabled /></td>
                                         </tr>
                                         <tr>
-                                            <td><input class="form-control input-xs" type="checkbox" disabled /></td>
+                                            <td><input class="form-control input-xs" type="checkbox" disabled id="max_geo"/></td>
                                             <td>Max geometric homogeneity index</td>
                                             <td><input class="form-control input-xs" size="6" parameter="max_geometric_homogeneity_index" type="text" value="1" disabled /></td>
                                         </tr>

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -324,6 +324,28 @@ function switchUserInterfaceMode(project, title) {
         $('#len_title').hide();
         $('.gene-filters-not-available-message').hide();
         $('.pan-filters button,input:checkbox').removeAttr('disabled')
+        $.ajax({
+            type: 'POST',
+            cache: false,
+            url: '/data/check_homogeneity_info',
+            success: function(data){
+                if (data['status'] == 1){
+                    $('#min_func').attr("disabled", 'disabled');
+                    $('#max_func').attr("disabled", 'disabled');
+                    $('#min_geo').attr("disabled", 'disabled');
+                    $('#max_geo').attr("disabled", 'disabled');
+                } else {
+                    if (data['func_info'] == 0){
+                        $('#min_func').attr("disabled", 'disabled');
+                        $('#max_func').attr("disabled", 'disabled');
+                    }
+                    if (data['geo_info'] == 0){
+                        $('#min_geo').attr("disabled", 'disabled');
+                        $('#max_geo').attr("disabled", 'disabled');
+                    }
+                }
+            }
+        })
     }
 
     if (server_mode) {

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1469,6 +1469,13 @@ class PanSuperclass(object):
         return num_gene_clusters_missing_per_genome
 
 
+    def check_if_homogeneity_information_is_available(self):
+        available_additional_data_keys = TableForItemAdditionalData(self.args).get_available_data_keys()
+        functional_homogeneity_info_is_available = 'functional_homogeneity_index' in available_additional_data_keys
+        geometric_homogeneity_info_is_available = 'geometric_homogeneity_index' in available_additional_data_keys
+        return functional_homogeneity_info_is_available, geometric_homogeneity_info_is_available
+
+
     def filter_gene_clusters_from_gene_clusters_dict(self, gene_clusters_dict, min_num_genomes_gene_cluster_occurs=0,
              max_num_genomes_gene_cluster_occurs=sys.maxsize, min_num_genes_from_each_genome=0, max_num_genes_from_each_genome=sys.maxsize,
              min_functional_homogeneity_index=-1, max_functional_homogeneity_index=1, min_geometric_homogeneity_index=-1,
@@ -1500,9 +1507,24 @@ class PanSuperclass(object):
         max_num_genes_from_each_genome = check(max_num_genes_from_each_genome, '--max-num-genes-from-each-genome')
 
         # check whether homogeneity data is available in the database:
-        available_additional_data_keys = TableForItemAdditionalData(self.args).get_available_data_keys()
-        functional_homogeneity_info_is_available = 'functional_homogeneity_index' in available_additional_data_keys
-        geometric_homogeneity_info_is_available = 'geometric_homogeneity_index' in available_additional_data_keys
+        functional_homogeneity_info_is_available, geometric_homogeneity_info_is_available = self.check_if_homogeneity_information_is_available()
+        if not functional_homogeneity_info_is_available:
+            if min_functional_homogeneity_index != -1 or max_functional_homogeneity_index != 1:
+                self.run.warning("You are trying to filter your gene clusters by functional homogeneity, when your pan database does not\
+                                  include information about functional homogeneity. You can always compute this index for all of your \
+                                  gene clusters using 'anvi-compute-gene-cluster-homogeneity', but anvi'o will override your decision for now.\
+                                  You will not be able to filter your gene clusters by functional homogeneity at this time.")
+                min_functional_homogeneity_index = -1
+                max_functional_homogeneity_index = 1
+        if not geometric_homogeneity_info_is_available:
+            if min_geometric_homogeneity_index != -1 or max_geometric_homogeneity_index != 1:
+                self.run.warning("You are trying to filter your gene clusters by geometric homogeneity, when your pan database does not\
+                                  include information about geometric homogeneity. You can always compute this index for all of your \
+                                  gene clusters using 'anvi-compute-gene-cluster-homogeneity', but anvi'o will override your decision for now.\
+                                  You will not be able to filter your gene clusters by geometric homogeneity at this time.")
+                min_geometric_homogeneity_index = -1
+                max_geometric_homogeneity_index = 1
+        #If the information is not available, we force the parameters to become their default values and inform users of what they've done to themselves
 
         if min_num_genomes_gene_cluster_occurs < 0 or max_num_genomes_gene_cluster_occurs < 0:
             raise ConfigError("When you ask for a negative value for the the minimum or maximum number of genomes a gene cluster is expected\
@@ -1520,16 +1542,17 @@ class PanSuperclass(object):
             raise ConfigError("Min number of genes for each gene cluster can't be larger than the .. pfft. Anvi'o refuses to continue with this\
                                error message. Check your parameters :(")
 
-        if (min_functional_homogeneity_index < 0 and min_functional_homogeneity_index != -1) or (min_geometric_homogeneity_index < 0 and min_geometric_homogeneity_index != -1):
-            raise ConfigError("Geometric and Functional homogeneity indices have a mininum value of 0, along with an error value of -1. You can either ask for\
-                               values of 0 or greater, or put in '-1'. These are hard limits.")
+        if functional_homogeneity_info_is_available and geometric_homogeneity_info_is_available:
+            if (min_functional_homogeneity_index < 0 and min_functional_homogeneity_index != -1) or (min_geometric_homogeneity_index < 0 and min_geometric_homogeneity_index != -1):
+                raise ConfigError("Geometric and Functional homogeneity indices have a mininum value of 0, along with an error value of -1. You can either ask for\
+                                   values of 0 or greater, or put in '-1'. These are hard limits.")
 
-        if max_functional_homogeneity_index > 1 or max_geometric_homogeneity_index > 1:
-            raise ConfigError("Geometric and Functional homogeneity indices have a maximum possible value of 1. Your parameters exceed this hard upper limit.\
-                               Please check your parameters.")
+            if max_functional_homogeneity_index > 1 or max_geometric_homogeneity_index > 1:
+                raise ConfigError("Geometric and Functional homogeneity indices have a maximum possible value of 1. Your parameters exceed this hard upper limit.\
+                                   Please check your parameters.")
 
-        if max_functional_homogeneity_index < min_functional_homogeneity_index or max_geometric_homogeneity_index < min_geometric_homogeneity_index:
-            raise ConfigError("Please. Check your parameters. Make sure that minimum values are less than (or equal to) maximum values. We beg you")
+            if max_functional_homogeneity_index < min_functional_homogeneity_index or max_geometric_homogeneity_index < min_geometric_homogeneity_index:
+                raise ConfigError("Please. Check your parameters. Make sure that minimum values are less than (or equal to) maximum values. We beg you")
 
         all_genomes = self.get_all_genome_names_in_gene_clusters_dict(gene_clusters_dict)
 
@@ -1545,7 +1568,8 @@ class PanSuperclass(object):
                                that is not what you're doing." % (len(all_genomes), min_num_genomes_gene_cluster_occurs))
 
         gene_cluster_occurrences_accross_genomes, num_genes_contributed_per_genome = self.get_basic_gene_clusters_stats(gene_clusters_dict)
-        homogeneity_keys, homogeneity_dict = TableForItemAdditionalData(self.args).get(['functional_homogeneity_index', 'geometric_homogeneity_index'])
+        if functional_homogeneity_info_is_available and geometric_homogeneity_info_is_available:
+            homogeneity_keys, homogeneity_dict = TableForItemAdditionalData(self.args).get(['functional_homogeneity_index', 'geometric_homogeneity_index'])
 
         gene_clusters_to_remove = set([])
         all_gene_clusters = set(list(gene_cluster_occurrences_accross_genomes.keys()))


### PR DESCRIPTION
- Fixed a bug where filtering by homogeneity indices would crash if they were not computed in the pan database earlier
- Updated the pan user interface - users will not be able to filter by homogeneity if the server cannot retrieve data on homogeneity indices