### PR TITLE
Fix megahit rule

### DIFF
--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -461,9 +461,9 @@ if run_idba_ud == True:
         input:
             fasta = dirs_dict["QC_DIR"] + "/{group}-merged.fa"
         output:
-            temp_dir = temp(dirs_dict["FASTA_DIR"] + "/{group}_TEMP"),
             contigs = temp(dirs_dict["FASTA_DIR"] + "/{group}/final.contigs.fa")
         params:
+            temp_dir = temp(dirs_dict["FASTA_DIR"] + "/{group}_TEMP"),
             mink = M.get_rule_param("idba_ud", "--mink"),
             maxk = M.get_rule_param("idba_ud", "--maxk"),
             step = M.get_rule_param("idba_ud", "--step"),
@@ -485,7 +485,7 @@ if run_idba_ud == True:
         threads: M.T('idba_ud')
         resources: nodes = M.T('idba_ud')
         run:
-            cmd = "idba_ud -o {output.temp_dir} --read {input.fasta} --num_threads {threads} " + \
+            cmd = "idba_ud -o {params.temp_dir} --read {input.fasta} --num_threads {threads} " + \
                   "{params.mink} {params.maxk} {params.step} {params.inner_mink} " + \
                   "{params.inner_step} {params.prefix} {params.min_count} " + \
                   "{params.min_support} {params.seed_kmer} {params.min_contig} " + \
@@ -493,7 +493,8 @@ if run_idba_ud == True:
                   "{params.no_bubble} {params.no_local} {params.no_coverage} " + \
                   "{params.no_correct} {params.pre_correction} >> {log} 2>&1"
             shell(cmd)
-            shell("mv {output.temp_dir}/contig.fa {output.contigs} >> {log} 2>&1")
+            shell("mv {params.temp_dir}/contig.fa {output.contigs} >> {log} 2>&1")
+            shell("rm -rf {params.temp_dir}")
 
 
 def input_for_megahit(wildcards):

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -583,7 +583,7 @@ if M.get_param_value_from_config(['megahit', 'run']) == True:
                 "{params.tmp_dir} {params._continue} {params.verbose} >> {log} 2>&1"
             print("Running: %s" % cmd)
             shell(cmd)
-            shell("mv {output.temp_dir}/final.contigs.fa {output.contigs} >> {log} 2>&1")
+            shell("mv {params.temp_dir}/final.contigs.fa {output.contigs} >> {log} 2>&1")
             shell("rm -rf {params.temp_dir}")
 
 

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -529,6 +529,7 @@ if M.get_param_value_from_config(['megahit', 'run']) == True:
         log: dirs_dict["LOGS_DIR"] + "/{group}-megahit.log"
         input: unpack(input_for_megahit)
         params:
+            temp_dir = dirs_dict["FASTA_DIR"] + "/{group}_TEMP",
             # the minimum length for contigs (smaller contigs will be discarded)
             min_contig_len = M.get_rule_param("megahit", "--min-contig-len"),
             min_count = M.get_rule_param("megahit", "--min-count"),
@@ -561,8 +562,6 @@ if M.get_param_value_from_config(['megahit', 'run']) == True:
         # to the final location.
         output:
             contigs = temp(dirs_dict["FASTA_DIR"] + "/{group}/final.contigs.fa")
-        params:
-            temp_dir = temp(dirs_dict["FASTA_DIR"] + "/{group}_TEMP"),
         threads: M.T('megahit')
         resources: nodes = M.T('megahit'),
         # Making this rule a shadow rule so all extra files created by megahit

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -560,8 +560,9 @@ if M.get_param_value_from_config(['megahit', 'run']) == True:
         # once megahit is done running then the contigs database is moved
         # to the final location.
         output:
-            temp_dir = temp(dirs_dict["FASTA_DIR"] + "/{group}_TEMP"),
             contigs = temp(dirs_dict["FASTA_DIR"] + "/{group}/final.contigs.fa")
+        params:
+            temp_dir = temp(dirs_dict["FASTA_DIR"] + "/{group}_TEMP"),
         threads: M.T('megahit')
         resources: nodes = M.T('megahit'),
         # Making this rule a shadow rule so all extra files created by megahit
@@ -572,7 +573,7 @@ if M.get_param_value_from_config(['megahit', 'run']) == True:
             r2 = ','.join(input.r2)
 
             cmd = "megahit -1 %s -2 %s " % (r1, r2) + \
-                "-o {output.temp_dir} " + \
+                "-o {params.temp_dir} " + \
                 "-t {threads} " + \
                 "{params.min_contig_len} {params.min_count} {params.k_min} " + \
                 "{params.k_max} {params.k_step} {params.k_list} {params.no_mercy} " + \
@@ -584,6 +585,7 @@ if M.get_param_value_from_config(['megahit', 'run']) == True:
             print("Running: %s" % cmd)
             shell(cmd)
             shell("mv {output.temp_dir}/final.contigs.fa {output.contigs} >> {log} 2>&1")
+            shell("rm -rf {params.temp_dir}")
 
 
 

--- a/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -3,13 +3,6 @@
         "threads": 5,
         "run": false
     },
-    "krakenhll": {
-        "--gzip-compressed": true,
-        "additional_params": "--preload",
-        "run": true,
-        "--db": "/fake/db",
-        "threads": ""
-    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 20,


### PR DESCRIPTION
This pull request includes critical fixes to the metagenomics workflow.

As of snakemake v5.2, you can no longer use directories as outputs, unless you specifically mark these as directories (see https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#directories-as-outputs).

This issue affected both the `megahit` and `idba_ud` rules (but nothing else).

Thank you @jarrodscott for reporting this issue.