### PR TITLE
Exported gff3 files are now formatted correctly

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -790,8 +790,9 @@ class ContigsSuperclass(object):
             output.write('##gff-version 3\n')
             for gene_callers_id in gene_caller_ids_list:
                 entry = sequences_dict[gene_callers_id]
-                output.write('{id}\t{source}\t{contig}\t1\t{length}\t.\t.\t.\tID={id}'.format(
-                    id=gene_callers_id, source='IGS', contig=entry['contig'], length=entry['length']))
+                output.write('{contig}\t{source}\t{type}\t{start}\t{stop}\t.\t{strand}\t.\tID={id}'.format(
+                    contig=entry['contig'], source='.', type='CDS', start=entry['start']+1, stop=entry['stop'],
+                    strand=entry['direction'].replace('f','+').replace('r','-'), id=gene_callers_id))
                 output.write(name_template.format(entry))
                 output.write('\n')
 


### PR DESCRIPTION
The files exported by `anvi-get-sequences-for-gene-calls -c CONTIGS.db --export-gff3` were incorrectly formatted.
This change addreses issues #551 and #554. See gff3 format at: https://uswest.ensembl.org/info/website/upload/gff3.html
Within the lines modified by this commit, ideally the second column ("source") would be populated by the gene caller (e.g. "prodigal") but I don't know how to make that change.