### PR TITLE
summarize every profile for which a collection was provided

### DIFF
--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -144,7 +144,11 @@ rule metagenomics_workflow_target_rule:
                                               '{group}', \
                                               'collection-import.done'), group=list(M.collections.keys())) \
                                      if M.collections \
-                                     else expand(dirs_dict["CONTIGS_DIR"] + "/{group}-annotate_contigs_database.done", group=M.group_names)
+                                     else expand(dirs_dict["CONTIGS_DIR"] + "/{group}-annotate_contigs_database.done", group=M.group_names),
+           summary = expand(os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-SUMMARY"), \
+                            group=list(M.collections.keys())) \
+                      if M.collections \
+                      else expand(dirs_dict["CONTIGS_DIR"] + "/{group}-annotate_contigs_database.done", group=M.group_names),
 
 
 rule iu_gen_configs:
@@ -1023,6 +1027,45 @@ rule anvi_import_collection:
                                   {params.contigs_mode} \
                                   {input.collection_file} >> {log} 2>&1
         """
+
+
+rule anvi_summarize:
+    version: 1.0
+    log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-anvi_summarize.log")
+    input:
+        profile = dirs_dict["MERGE_DIR"] + "/{group}/PROFILE.db",
+        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        imported_collection_flag = os.path.join(dirs_dict["MERGE_DIR"], \
+                                                '{group}', \
+                                                'collection-import.done')
+    output:
+        summary_done = temp(touch(os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-summary.touch")))
+    params:
+        collection_name = lambda wildcards: M.collections[wildcards.group]['collection_name'],
+        summary_temp_dir = os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-TEMP")
+    threads: M.T('anvi_summarize')
+    resources: nodes = M.T('anvi_summarize')
+    shell:
+        """
+            anvi-summarize -p {input.profile} \
+                           -c {input.contigs} \
+                           -C {params.collection_name} \
+                           -o {params.summary_temp_dir} >> {log} 2>&1
+        """
+
+
+rule dummy_rule_for_anvi_summarize:
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-dummy_rule_for_anvi_summarize.log"
+    input:
+        summary_done = os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-summary.touch")
+    output:
+        directory(os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-SUMMARY"))
+    params:
+        summary_temp_dir = os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-TEMP")
+    threads: 1
+    resources: nodes = 1
+    shell: "mv {params.summary_temp_dir} {output} >> {log} 2>&1"
 
 
 rule krakenhll:

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -60,7 +60,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                      'bowtie_build', 'bowtie', 'samtools_view', 'anvi_init_bam', 'idba_ud',\
                      'anvi_profile', 'annotate_contigs_database', 'anvi_merge', 'import_percent_of_reads_mapped',\
                      'krakenhll', 'krakenhll_mpa_report', 'import_kraken_hll_taxonomy', 'metaspades',\
-                     'remove_short_reads_based_on_references'])
+                     'remove_short_reads_based_on_references', 'anvi_summarize'])
 
         self.general_params.extend(['samples_txt', "references_mode", "all_against_all",\
                                     "kraken_txt", "collections_txt"])
@@ -120,7 +120,8 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                                "MAPPING_DIR": "04_MAPPING",
                                "PROFILE_DIR": "05_ANVIO_PROFILE",
                                "MERGE_DIR": "06_MERGED",
-                               "TAXONOMY_DIR": "07_TAXONOMY"})
+                               "TAXONOMY_DIR": "07_TAXONOMY",
+                               "SUMMARY_DIR": "08_SUMMARY"})
 
         self.default_config.update({'samples_txt': "samples.txt",
                                     'metaspades': {"additional_params": "--only-assembler", "threads": 7},


### PR DESCRIPTION
later on we can decide if we want to make this optional. But for now if a collection was provided then we run summary.

We still need to add all the configurable parameters for anvi-summarize.