### PR TITLE
minor changes to anvi-script-FASTA-to-contigs-db

### DIFF
--- a/sandbox/anvi-script-FASTA-to-contigs-db
+++ b/sandbox/anvi-script-FASTA-to-contigs-db
@@ -25,9 +25,11 @@ if [ "$#" -ne 1  ]; then
     exit -1
 fi
 
-EXT=$(basename $1 | cut -f 2 -d '.')
-if [ "$EXT" != "fa" ]; then
-    echo "Error: File name has to have an extension of '.fa'"
+BASE_EXT=$(basename $1)
+EXT="${BASE_EXT##*.}"
+
+if [ "$EXT" != "fa" ] && [ "$EXT" != "fasta" ]; then
+    echo "Error: File name has to have an extension of '.fa' or '.fasta'"
     exit -1
 fi
 

--- a/sandbox/anvi-script-FASTA-to-contigs-db
+++ b/sandbox/anvi-script-FASTA-to-contigs-db
@@ -25,9 +25,7 @@ if [ "$#" -ne 1  ]; then
     exit -1
 fi
 
-BASE_EXT=$(basename $1)
-EXT="${BASE_EXT##*.}"
-
+EXT="${1##*.}"
 if [ "$EXT" != "fa" ] && [ "$EXT" != "fasta" ]; then
     echo "Error: File name has to have an extension of '.fa' or '.fasta'"
     exit -1


### PR DESCRIPTION
Two small changes:
* allow `.fa` or `.fasta` as extensions without errors.
* retrieval of the file extension form the to avoid errors with NCBI-like files e.g. "GCA_000472665.1.fa"
