### PR TITLE
should count number of genomes and not number of profile databases

### DIFF
--- a/anvio/hmmopswrapper.py
+++ b/anvio/hmmopswrapper.py
@@ -38,7 +38,7 @@ class SequencesForHMMHitsWrapperForMultipleContigs(SequencesForHMMHits, GenomeDe
         self.load_genomes_descriptions(skip_functions=True, init=False)
         hmm_sources_in_all_genomes = self.get_HMM_sources_common_to_all_genomes()
 
-        num_internal_genomes = len(set([g['profile_db_path'] for g in self.genomes.values() if 'profile_db_path' in g]))
+        num_internal_genomes = len(set([g for g in self.genomes.values() if 'profile_db_path' in g]))
         collection_names = set([g['collection_id'] for g in self.genomes.values() if 'collection_id' in g])
 
         self.run.warning("SequencesForHMMHitsWrapperForMultipleContigs class is speaking (yes, the class is\


### PR DESCRIPTION
@meren, this is no big deal, but I noticed this so why not fix.


right now this is counting the number of unique profile databases within the internal genomes file. But the message (three lines of code below) is talking about how many genomes are coming fro internal genomes. right?