### PR TITLE
user-server-shutdown by user in anvi-display-pan

### DIFF
--- a/bin/anvi-display-pan
+++ b/bin/anvi-display-pan
@@ -66,6 +66,7 @@ if __name__ == '__main__':
     groupF.add_argument(*anvio.A('read-only'), **anvio.K('read-only'))
     groupF.add_argument(*anvio.A('server-only'), **anvio.K('server-only'))
     groupF.add_argument(*anvio.A('password-protected'), **anvio.K('password-protected'))
+    groupF.add_argument(*anvio.A('user-server-shutdown'), **anvio.K('user-server-shutdown'))
 
     args = anvio.get_args(parser)
 


### PR DESCRIPTION
This adds the `--user-server-shutdown` option to `anvi-display-pan` like #1115 does for `anvi-interactive`