### PR TITLE
fix strip acting on tabs (our separator string)

### DIFF
--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -708,7 +708,7 @@ def get_vectors_from_TAB_delim_matrix(file_path, cols_to_return=None, rows_to_re
     sample_to_id_dict = {}
 
     input_matrix = open(file_path, 'rU')
-    columns = input_matrix.readline().strip().split('\t')[1:]
+    columns = input_matrix.readline().strip('\n').split('\t')[1:]
 
     fields_of_interest = []
     if cols_to_return:


### PR DESCRIPTION
Sometimes valid tab delimited files begin their first non-commented line with the tab character. `strip()` removes this tab character and messes up the number of columns. This was brought to my attention when getting different results from `anvi-matrix-to-newick` for the following data files:

![image](https://user-images.githubusercontent.com/8688665/59536399-3cb37a80-8eb9-11e9-9198-23cff28b69ff.png)

![image](https://user-images.githubusercontent.com/8688665/59536422-49d06980-8eb9-11e9-8411-658b3cdc7c81.png)

anvi-matrix-to-newick produces the wrong tree file for the first case, and this pull request fixes that issue.