### PR TITLE
Unit testing visualize-split-coverages script functions

### DIFF
--- a/anvio/tests/sandbox/test_visualize_split_coverages/run_tests.R
+++ b/anvio/tests/sandbox/test_visualize_split_coverages/run_tests.R
@@ -1,0 +1,29 @@
+library(testthat)
+
+## First get the directory of this test runner file.
+opts <- commandArgs()
+file_opt_idx <- grep("--file=", opts, fixed = TRUE)
+file_opt <- opts[[file_opt_idx]]
+file_name <- sub("--file=", "", file_opt, fixed = TRUE)
+this_dir <- dirname(file_name)
+
+source_code <- file.path(
+    this_dir,
+    "..", "..", "..", "..",
+    "sandbox",
+    "anvi-script-visualize-split-coverages"
+)
+
+## If this line is changed in the source file, this hack won't work
+## anymore.
+function_end_marker <- "End of function definitions"
+source_code_lines <- readLines(source_code)
+function_end_line <- grep(function_end_marker, source_code_lines, fixed = TRUE)
+
+## Only source the part of the file with function definitions.
+tmp <- textConnection(source_code_lines[1:function_end_line])
+source(tmp)
+close(tmp)
+
+## Run the tests.
+test_dir(this_dir, reporter = SummaryReporter$new())

--- a/anvio/tests/sandbox/test_visualize_split_coverages/test_visualize_split_coverages.R
+++ b/anvio/tests/sandbox/test_visualize_split_coverages/test_visualize_split_coverages.R
@@ -1,0 +1,177 @@
+describe("sapply_by_group()", {
+    describe("with character groups", {
+        df <- data.frame(
+            count = c(1, 20, 3, 10, 2, 30),
+            group = rep(c("a", "b"), 3)
+        )
+
+        it("sapply a function by group", {
+            actual <- sapply_by_group(count ~ group, df, mean)
+            expect_equal(actual, c(2, 20))
+        })
+
+        it("follows sort order of the factors", {
+            ## Change sort order
+            df$group <- factor(df$group, levels = c("b", "a"))
+
+            actual <- sapply_by_group(count ~ group, df, mean)
+            expect_equal(actual, c(20, 2))
+        })
+    })
+
+    describe("with numeric groups", {
+        df <- data.frame(
+            count = c(1, 20, 3, 10, 2, 30),
+            group = rep(c(1, 2), 3)
+        )
+
+        it("sapply a function by group", {
+            actual <- sapply_by_group(count ~ group, df, mean)
+            expect_equal(actual, c(2, 20))
+        })
+    })
+})
+
+describe("get_points_per_sample()", {
+    total <- 10
+
+    df <- data.frame(
+        coverage = 1:10,
+        split_name = rep("contig", total),
+        sample_name = c(rep("sample_1", total / 2),
+                        rep("sample_2", total / 2))
+    )
+
+    it("calculates number of points per sample", {
+        actual <- get_points_per_sample(df)
+        expected <- rep(total / 2, 2)
+
+        expect_equal(actual, expected)
+    })
+})
+
+describe("smooth_coverage()", {
+    coverage <- c(1, 4, 3, 4)
+    smoothed_coverage <- c(1, 3, 4, 4)
+
+    df <- data.frame(
+        coverage = c(coverage,
+                     coverage * 10,
+                     coverage * 100,
+                     coverage * 1000),
+        split_name = c(rep("contig_1", 4),
+                       rep("contig_2", 4),
+                       rep("contig_1", 4),
+                       rep("contig_2", 4)),
+        ## sample_2 comes before sample_1 in the data frame!
+        sample_name = c(rep("sample_2", 8),
+                        rep("sample_1", 8))
+    )
+
+    it("smooths coverage with running medians", {
+        actual <- smooth_coverage(df, window_size = 3)
+
+        ## sample_1 values come first in the output however as they
+        ## are grouped by sample, and that is sorted by factor level!
+        expected <- c(
+            smoothed_coverage * 100,
+            smoothed_coverage * 1000,
+            smoothed_coverage,
+            smoothed_coverage * 10
+        )
+
+        expect_equal(actual, expected)
+    })
+})
+
+describe("shrink_data()", {
+    df <- data.frame(
+        sample_name = c(rep("s1", 8),
+                        rep("s2", 8)),
+        x_values = rep(0:7, 2),
+        split_name = c(rep("c1", 4),
+                       rep("c2", 4),
+                       rep("c1", 4),
+                       rep("c2", 4)),
+        coverage = rep(10, 16)
+    )
+
+    it("reduces the size of the data frame", {
+        ## For each sample, keeps first and last rows plus any that
+        ## divide the window size.
+        actual <- shrink_data(df, window_size = 3)
+        expected <- df[c(1, 4, 7, 8, 9, 12, 15, 16), ]
+        expected$x_values.max <- rep(7, 8)
+
+        expect_equal(actual, expected)
+    })
+})
+
+describe("is_hex_color()", {
+    it("hex codes must start with '#' char", {
+        expect_false(is_hex_color("123fff"))
+    })
+
+    it("is false for 'short' hex codes", {
+        expect_false(is_hex_color("#333"))
+    })
+
+    it("is true for valid hex code", {
+        expect_true(is_hex_color("#123fFf"))
+        expect_true(is_hex_color("#000000"))
+        expect_true(is_hex_color("#fFfFfF"))
+    })
+
+    it("is false for invalid hex code", {
+        expect_false(is_hex_color("#123qqq"))
+        expect_false(is_hex_color("black"))
+        expect_false(is_hex_color("#123q"))
+    })
+})
+
+
+describe("fix_colors()", {
+    df <- data.frame(
+        sample_color = c(
+            "arst",
+            "blue",
+            "#123FFF",
+            "123FFF"
+        )
+    )
+
+    it("returns vec with invalid colors as #333333", {
+        actual <- fix_colors(df)
+        expected <- c("#333333", "blue", "#123FFF", "#333333")
+
+        expect_equal(actual, expected)
+    })
+})
+
+describe("sort_split_coverages()", {
+    sample_sort_order <- c("s_2", "s_1")
+
+    split_coverages <- data.frame(
+        unique_entry_id = 0:9,
+        nt_position = rep(0:4, 2),
+        split_name = rep("contig_1", 10),
+        sample_name = c(rep("s_1", 5), rep("s_2", 5)),
+        coverage = 1:10,
+        x_values = rep(0:4, 2)
+    )
+
+    sample_data <- data.frame(
+        sample_name = sample_sort_order,
+        sample_color = c("blue", "green")
+    )
+
+    it("sorts split_coverages df based on sample ordering in sample_data", {
+        actual <- sort_split_coverages(split_coverages, sample_data)
+        expected <- rbind(
+            split_coverages[6:10, ],
+            split_coverages[1:5, ]
+        )
+
+        expect_equivalent(actual, expected)
+    })
+})

--- a/sandbox/anvi-script-visualize-split-coverages
+++ b/sandbox/anvi-script-visualize-split-coverages
@@ -2,6 +2,14 @@
 
 ## Last update: 2019-06-20 (mooreryan)
 
+## To run unit tests:
+##
+## - Install the `testthat` package.
+##
+## - The test runner is located ${anvio_source_dir}/anvio/tests/sandbox/test_visualize_split_coverages/test_visualize_split_coverages.R
+##
+## - Run the test runner with Rscript at the terminal.
+
 ## To add a new chart type:
 ##
 ## - Pick a name for your new chart type, e.g., 'box', then add that
@@ -70,14 +78,21 @@ get_points_per_sample <- function(split_coverages) {
 }
 
 get_window_size <- function(sample_size) {
+    ## This size was chosen because it reduces the size, but still
+    ## looks nice over a large range of values.
     window_size <- floor(sample_size / 1000 * 3)
 
+    ## Window size must be odd.
     ifelse(window_size %% 2 == 0,
            window_size + 1,
            window_size)
 }
 
-## Smooths the coverage using running medians of size `window_size`, group-by-group.
+## Smooths the coverage using running medians of size `window_size`,
+## group-by-group.  Output is sorted by sample_name (according to
+## their factor levels), so the result may NOT be in the same order as
+## the input data frame if the input data frame is NOT sorted by
+## sample_name first.
 smooth_coverage <- function(split_coverages, window_size) {
     sapply_by_group(
         coverage ~ sample_name,
@@ -123,6 +138,7 @@ cap_coverage <- function(coverage, max_coverage) {
 ## Opposite of %in%
 "%nin%" <- Negate("%in%")
 
+#### End utility functions ####
 
 #### Functions to handle user input ####
 
@@ -249,6 +265,10 @@ check_opts <- function(opts) {
     check_chart_type(opts)
 }
 
+#### End user input checking functions ####
+
+#### Parsing functions
+
 ## Parse the split coverages file.
 parse_split_coverages <- function(opts) {
     ## Sanity check: split coverages should always be given.
@@ -273,15 +293,17 @@ parse_split_coverages <- function(opts) {
         abort("bad header row in split coverages file")
     }
 
+    ## Lots of steps expected nicely sorted data frame, so sort it by
+    ## sample_name, then split_name, then nt_position.
+    split_coverages <- split_coverages[order(split_coverages$sample_name,
+                                             split_coverages$split_name,
+                                             split_coverages$nt_position), ]
+
     ## If there are multiple split_names in the split coverages file,
     ## we need to make sure they are all sorted properly, then we need
     ## to treat all split_names within a single contig as one big
     ## super-contig.
     if (length(unique(split_coverages$split_name)) > 1) {
-        ## Sort the data based on sample name, then by split name.
-        split_coverages <- split_coverages[order(split_coverages$sample_name,
-                                                 split_coverages$split_name), ]
-
         ## Get number of positions (rows) for all splits per sample.
         sample_counts <- table(split_coverages$sample_name)
 
@@ -414,7 +436,10 @@ sort_split_coverages <- function(split_coverages, sample_data) {
     split_coverages$sample_name <- factor(split_coverages$sample_name,
                                           levels = sample_data$sample_name)
 
-    ## First order by sample name, then by nt pos.
+    ## First order by sample name, then by x_values.  Sort by x_values
+    ## rather than first by split_name as the x_values will have
+    ## already been set up to be in the correct order regardless of
+    ## whether there are multiple split names in the file.
     split_coverages[order(split_coverages$sample_name,
                           split_coverages$x_values), ]
 }
@@ -451,6 +476,8 @@ parse_input_data <- function(opts) {
          ## above.
          sample_names = split_coverages$sample_name)
 }
+
+#### End parsing functions and helpers ####
 
 
 #### Plotting functions ####
@@ -618,7 +645,8 @@ Description:
     opts
 }
 
-#### Actual program starts here ####
+## Do not edit the comment on the next line, or you will break the unit tests!!
+#### End of function definitions ####
 
 opts <- set_up_opts()
 


### PR DESCRIPTION
Added some unit tests for some of the non-trivial functions in the `visualize-split-coverages` R script.

It uses the `testthat` package.

To run tests, first ensure `testthat` is installed.  Then (from the `anvio` source directory) run 

```
Rscript anvio/tests/sandbox/test_visualize_split_coverages/run_tests.R
```

Not 100% sure if `anvio/tests/sandbox/test_visualize_split_coverages` is the best directory for unit tests for the script however....