### PR TITLE
anvi-export-locus with flanking genes

### DIFF
--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -736,8 +736,8 @@ class LocusSplitter:
         if len(self.num_genes_list) == 1:
             self.num_genes_list = [0, self.num_genes_list[0]]
 
-            # # add sanity check for flanking genes 
-            # if self.flanking_genes 
+            # # add sanity check for flanking genes
+            # if self.flanking_genes
 
 
         self.run.warning(None, header="Input / Output", lc="cyan")
@@ -893,73 +893,69 @@ class LocusSplitter:
         locus_start = self.contigs_db.genes_in_contigs_dict[first_gene_of_the_block]['start']
         locus_stop = self.contigs_db.genes_in_contigs_dict[last_gene_of_the_block]['stop']
 
-        # being a performance nerd here yes
-        contig_sequence = db.DB(self.input_contigs_db_path, None, ignore_version=True) \
-                            .get_some_rows_from_table(t.contig_sequences_table_name,
-                                                      where_clause="contig='%s'" % contig_name)[0][1]
-
         ################################
         # Flanking gene locus extraction
         ################################
 
         # Parse flanking genes argument
+        if self.flanking_genes:
 
-        flanking_genes_list = self.flanking_genes.split(',')
+            flanking_genes_list = self.flanking_genes.split(',')
 
-        flank_1 = flanking_genes_list[0]
-        flank_2 = flanking_genes_list[1]
+            flank_1 = flanking_genes_list[0]
+            flank_2 = flanking_genes_list[1]
 
-        # Get the contigs_db ready
-        self.run.info('Mode', 'Function search')
-        contigs_db = dbops.ContigsSuperclass(self.args, r=self.run_object) # This somehow gives us the original contigs_db
+            # Get the contigs_db ready
+            self.run.info('Mode', 'Function search')
+            contigs_db = dbops.ContigsSuperclass(self.args, r=self.run_object) # This somehow gives us the original contigs_db
 
-        # Retrieve gene_caller_IDs for both flanking genes
+            # Retrieve gene_caller_IDs for both flanking genes
 
-        ## flank_1
-        contigs_db.init_functions() # This somehow allows us to search the function in the contigs_db
-        self.run.info('Flank_1', flank_1, mc='green')
-        self.run.info('Function calls being used', ', '.join(contigs_db.gene_function_call_sources))
+            ## flank_1
+            contigs_db.init_functions() # This somehow allows us to search the function in the contigs_db
+            self.run.info('Flank_1', flank_1, mc='green')
+            self.run.info('Function calls being used', ', '.join(contigs_db.gene_function_call_sources))
 
-        foo, search_report_flank_1 = contigs_db.search_for_gene_functions([flank_1], requested_sources=self.annotation_sources, verbose=True)
+            foo, search_report_flank_1 = contigs_db.search_for_gene_functions([flank_1], requested_sources=self.annotation_sources, verbose=True)
 
-        first_gene_of_the_block = search_report_flank_1[0][0]
+            first_gene_of_the_block = search_report_flank_1[0][0]
 
-        ## flank_2
-        self.run.info('Flank_2', flank_2, mc='green')
-        self.run.info('Function calls being used', ', '.join(contigs_db.gene_function_call_sources))
+            ## flank_2
+            self.run.info('Flank_2', flank_2, mc='green')
+            self.run.info('Function calls being used', ', '.join(contigs_db.gene_function_call_sources))
 
-        foo, search_report_flank_2 = contigs_db.search_for_gene_functions([flank_2], requested_sources=self.annotation_sources, verbose=True)
+            foo, search_report_flank_2 = contigs_db.search_for_gene_functions([flank_2], requested_sources=self.annotation_sources, verbose=True)
 
-        last_gene_of_the_block = search_report_flank_2[0][0]
+            last_gene_of_the_block = search_report_flank_2[0][0]
 
         # Use flanking gene gene_caller_IDs to cut out locus
 
-        # Get positions to cut at
+        # Get positions to cut at for either flanking or search_term
         locus_start = self.contigs_db.genes_in_contigs_dict[first_gene_of_the_block]['start']
         locus_stop = self.contigs_db.genes_in_contigs_dict[last_gene_of_the_block]['stop']
-    
+
         # Get original contig sequence (probably the entire genome)
         # being a performance nerd here yes
         contig_sequence = db.DB(self.input_contigs_db_path, None, ignore_version=True) \
                             .get_some_rows_from_table(t.contig_sequences_table_name,
                                                       where_clause="contig='%s'" % contig_name)[0][1]
-        
+
         #... and cut (for both search_term and flanking_genes)!
         locus_sequence = contig_sequence[locus_start:locus_stop]
-        
+
 
         # here we will create a gene calls dict for genes that are specific to our locus. since we trimmed
         # the contig sequence to the locus of interest, we will have to adjust start and stop positions of
         # genes in teh gene calls dict.
         # New with flanking
-        
+
         locus_gene_calls_dict = {}
         for g in range(first_gene_of_the_block, last_gene_of_the_block + 1):
             locus_gene_calls_dict[g] = copy.deepcopy(self.contigs_db.genes_in_contigs_dict[g])
             excess = self.contigs_db.genes_in_contigs_dict[first_gene_of_the_block]['start']
             locus_gene_calls_dict[g]['start'] -= excess
             locus_gene_calls_dict[g]['stop'] -= excess
-        
+
         self.run.info("Locus gene call start/stops excess (nts)", excess)
 
         if D() != 1 and self.reverse_complement_if_necessary:

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -684,8 +684,6 @@ class LocusSplitter:
         self.input_contigs_db_path = A('contigs_db')
         self.num_genes = A('num_genes')
         self.search_term = A('search_term')
-        self.flank_gene_downstream = A('flank_gene_downstream')
-        self.flank_gene_upstream = A('flank_gene_upstream')
         self.gene_caller_ids = A('gene_caller_ids')
         self.delimiter = A('delimiter')
         self.output_dir = A('output_dir') or os.path.abspath(os.path.curdir)

--- a/bin/anvi-export-locus
+++ b/bin/anvi-export-locus
@@ -14,6 +14,8 @@
 
   Then I run the program `anvi-export-gene-block` in the anvi'o master this way:
 
+  * need to migrate the `CONTIGS.db` to the new anvio version
+
     anvi-export-locus -c CONTIGS.db \
                       -O OUTPUT \
                       --use-hmm \
@@ -73,8 +75,14 @@ if __name__ == '__main__':
                             To get only genes preceeding the match use \"-n 5,0\". \
                             If the number of genes requested exceeds the length of the contig, then the output \
                             will include the sequence until the end of the contig.', required=True)
+    
     groupB =  parser.add_argument_group('Additional essential INPUT - OPTION 1', "Search according to either HMM or functional annotations")
     groupB.add_argument('-s', '--search-term', help='Search term.')
+    
+    # Adding new argument for cutting out locus with flanking genes
+    groupF =  parser.add_argument_group('Additional essential INPUT - OPTION 3', "Search terms for flanking genes.")
+    groupF.add_argument('-f', '--flanking-genes', help='Locus will be extracted based on search terms from two flanking genes. For example \"-f ABC_transporter,RecA \"')
+
     groupC =  parser.add_argument_group('Additional essential INPUT - OPTION 2', "Search specific gene id's")
     groupC.add_argument(*anvio.A('gene-caller-ids'), **anvio.K('gene-caller-ids'))
     groupC.add_argument(*anvio.A('delimiter'), **anvio.K('delimiter'))


### PR DESCRIPTION
This PR will add additional functionality to `anvi-export-locus`.  With the `--flanking-genes` the function should now be able to cut out a locus based on 2 flanking genes one provides. 