### PR TITLE
anvi-inspect should raise an error when wrong split name is provided

### DIFF
--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -693,10 +693,8 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.p_meta['available_item_orders'].append('alphabetical')
 
         if not self.inspect_split_name or self.inspect_split_name not in self.displayed_item_names_ordered:
-            self.inspect_split_name = alphabetical_order['data'][0]
-            self.run.warning("Either you forgot to provide split name to inspect or the split name\
-                             you have provided does not exist. So anvi'o decided to show you the split: \
-                             %s" % self.inspect_split_name)
+            raise ConfigError("Either you forgot to provide split name to inspect or the split name\
+                             you have provided does not exist.")
 
 
     def load_refine_mode(self):


### PR DESCRIPTION
The current behavior is to just print a warning and open the inspect page with an arbitrary split. Why did you choose to do that? I think it is a very confusing behavior and hence I suggest this change. If you agree, then please merge.