### PR TITLE
Fix typo in help message

### DIFF
--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -13,7 +13,7 @@
 
     https://ndownloader.figshare.com/files/8252861
 
-  Uunpack it and went into it:
+  Unpack it and went into it:
 
     tar -zxvf INFANTGUTTUTORIAL.tar.gz && cd INFANT-GUT-TUTORIAL
 


### PR DESCRIPTION
Found a typo when going through one of the anvi scripts.