### PR TITLE
fixed help message for fasta-text-file header

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -165,7 +165,7 @@ D = {
             'help': "A two-column TAB-delimited file that lists multiple FASTA files to import\
                      for analysis. If using for `anvi-dereplicate-genomes` or `anvi-compute-distance`,\
                      each FASTA is assumed to be a genome. The first item in the header line\
-                     should read 'name', and the second item should read 'fasta_path'. Each line\
+                     should read 'name', and the second item should read 'path'. Each line\
                      in the field should describe a single entry, where the first column is\
                      the name of the FASTA file or corresponding sequence, and the second column\
                      is the path to the FASTA file itself."}


### PR DESCRIPTION
While using anvi-compute-genome-similarity I noticed the help message says the FASTA_TEXT_FILE second column name should be "fasta_path" when program expects just "path". So I just changed the help message to prompt "path" for future reference. 

Unless anvi-compute-genome-similarity is the odd one out and it should be accepting "fasta_path" in which case I did it backwards?