### PR TITLE
Fix underscores in group names bug (#1248)

### DIFF
--- a/sandbox/anvi-script-run-functional-enrichment-stats
+++ b/sandbox/anvi-script-run-functional-enrichment-stats
@@ -124,7 +124,7 @@ get_unadjusted_p_value <- function(anova_output) {
 # fit the GLMs in a nifty way using nest()
 w_models <- df_in %>%
   gather(key = "type", value = "value", -c(1:n_columns_before_data)) %>%
-  separate(type, into = c("type", "group"), sep = "_") %>%
+  separate(type, into = c("type", "group"), sep = "_", extra = "merge") %>%
   spread(type, value) %>%
   mutate(x = N * p) %>%
   select(-p) %>%


### PR DESCRIPTION
Proposed fix for the bug mentioned here: https://github.com/merenlab/anvio/issues/1248#issuecomment-542691491

The extra underscore in the group name was throwing things off.  This should correct that so that the `type` is everything up until the first underscore, and the `group` is everything after that.