### PR TITLE
Temporary workaround for 'sad tables'

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -17,6 +17,7 @@ anvio_codename = 'esther'
 
 DEBUG = '--debug' in sys.argv
 FORCE = '--force' in sys.argv
+FIX_SAD_TABLES = '--fix-sad-tables' in sys.argv
 
 def P(d, dont_exit=False):
     """Poor man's debug output printer during debugging."""
@@ -46,7 +47,7 @@ def get_args(parser):
        to see can still be sorted out.
     """
 
-    allowed_ad_hoc_flags = ['--version', '--debug', '--force']
+    allowed_ad_hoc_flags = ['--version', '--debug', '--force', '--fix-sad-tables']
 
     args, unknown = parser.parse_known_args()
 

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -29,6 +29,13 @@ __status__ = "Development"
 
 run = terminal.Run()
 
+
+def get_list_in_chunks(input_list, num_items_in_each_chunk=1000):
+    """Yield smaller bits of a list"""
+    for index in range(0, len(input_list), num_items_in_each_chunk):
+        yield input_list[index:index + num_items_in_each_chunk]
+
+
 class DB:
     def __init__(self, db_path, client_version, new_database=False, ignore_version=False):
         self.db_path = db_path

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -423,10 +423,7 @@ class DB:
         return results_dict
 
 
-    def get_table_as_dataframe(self, table_name,
-                               table_structure  = None, columns_of_interest = None,
-                               keys_of_interest = None, omit_parent_column  = False,
-                               error_if_no_data = True, where_clause        = None):
+    def get_table_as_dataframe(self, table_name, table_structure  = None, columns_of_interest = None, keys_of_interest = None, omit_parent_column  = False, error_if_no_data = True, where_clause = None):
         """get_table_as_dict() uses the first column as the key in the resulting
            dictionary. For pandas DataFrames there are two reasonable design
            approaches. The first mimics this approach and uses the first column as

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -216,7 +216,10 @@ class DB:
 
 
     def _exec_many(self, sql_query, values):
-        return self.cursor.executemany(sql_query, values)
+        for chunk in get_list_in_chunks(values):
+            self.cursor.executemany(sql_query, chunk)
+
+        return True
 
 
     def insert(self, table_name, values=()):

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -216,8 +216,6 @@ genome_gene_function_calls_table_name      = 'gene_function_calls'
 genome_gene_function_calls_table_structure = ['genome_name', ] + gene_function_calls_table_structure[:]
 genome_gene_function_calls_table_types     = [    'str'    , ] + gene_function_calls_table_types[:]
 
-tables_without_unique_entry_ids = [genome_gene_function_calls_table_name]
-
 ####################################################################################################
 #
 #     TABLE DESCRIPTIONS FOR THE STRUCTURE DB
@@ -245,3 +243,11 @@ structure_residue_info_table_types      = ['integer',         'integer'        ,
 residue_info_sources = {"DSSP":        {"structure": ['codon_order_in_gene' , 'aa'   , 'sec_struct' , 'rel_solvent_acc' , 'phi'  , 'psi'  , 'NH_O_1_index' , 'NH_O_1_energy' , 'O_NH_1_index' , 'O_NH_1_energy' , 'NH_O_2_index' , 'NH_O_2_energy' , 'O_NH_2_index' , 'O_NH_2_energy'],
                                         "types":     ['integer'             , 'text' , 'text'       , 'real'            , 'real' , 'real' , 'integer'      , 'real'          , 'integer'      , 'real'          , 'integer'      , 'real'          , 'integer'      , 'real']},
                        }
+
+####################################################################################################
+#
+#     META META META
+#
+####################################################################################################
+
+tables_without_unique_entry_ids = [genome_gene_function_calls_table_name]

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -35,7 +35,7 @@ pp = terminal.pretty_print
 
 
 class TablesForHMMHits(Table):
-    def __init__(self, db_path, num_threads_to_use=1, run=run, progress=progress):
+    def __init__(self, db_path, num_threads_to_use=1, run=run, progress=progress, initializing_for_deletion=False):
         self.num_threads_to_use = num_threads_to_use
         self.db_path = db_path
 
@@ -62,8 +62,9 @@ class TablesForHMMHits(Table):
                                   sources only operate on DNA sequences, and at this point it doesn't know which HMMs you wish to run.\
                                   If the lack of genes causes a problem, you will get another error message later probably :/")
 
-        self.set_next_available_id(t.hmm_hits_table_name)
-        self.set_next_available_id(t.hmm_hits_splits_table_name)
+        if not initializing_for_deletion:
+            self.set_next_available_id(t.hmm_hits_table_name)
+            self.set_next_available_id(t.hmm_hits_splits_table_name)
 
 
     def populate_search_tables(self, sources={}):

--- a/anvio/tables/views.py
+++ b/anvio/tables/views.py
@@ -78,10 +78,7 @@ class TablesForViews(Table):
         db_entries = [tuple([item] + [data_dict[item][h] for h in table_structure[1:]]) for item in data_dict]
 
         try:
-            # be gentle, and split large number of db_entries into smaller pieces
-            # before inserting them into the database
-            for chunk in utils.get_list_in_chunks(db_entries):
-                anvio_db.db._exec_many('''INSERT INTO %s VALUES (%s)''' % (table_name, ','.join(['?'] * len(table_structure))), chunk)
+            anvio_db.db._exec_many('''INSERT INTO %s VALUES (%s)''' % (table_name, ','.join(['?'] * len(table_structure))), db_entries)
         except Exception as e:
             num_columns = set([len(x) for x in db_entries])
             if len(num_columns) == 1:

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -631,12 +631,6 @@ def transpose_tab_delimited_file(input_file_path, output_file_path):
     return output_file_path
 
 
-def get_list_in_chunks(input_list, num_items_in_each_chunk=1000):
-    """Yield smaller bits of a list"""
-    for index in range(0, len(input_list), num_items_in_each_chunk):
-        yield input_list[index:index + num_items_in_each_chunk]
-
-
 def split_fasta(input_file_path, parts=1, prefix=None):
     if not prefix:
         prefix = os.path.abspath(input_file_path)
@@ -646,7 +640,7 @@ def split_fasta(input_file_path, parts=1, prefix=None):
 
     source = u.ReadFasta(input_file_path, quiet=True)
     length = len(source.ids)
-    
+
     if length < parts:
         parts = length
 
@@ -656,7 +650,7 @@ def split_fasta(input_file_path, parts=1, prefix=None):
 
     for part_no in range(parts):
         output_file = prefix + '.' + str(part_no)
-        
+
         output_fasta = u.FastaOutput(output_file)
 
         chunk_start = chunk_size * part_no

--- a/bin/anvi-delete-hmms
+++ b/bin/anvi-delete-hmms
@@ -47,12 +47,12 @@ def main(args):
                            do anything at all (anvi'o the pacifist). Choose either, and let's pretend this never\
                            happened.")
 
-    hmm_tables = TablesForHMMHits(args.contigs_db)
+    hmm_tables = TablesForHMMHits(args.contigs_db, initializing_for_deletion=True)
     if args.hmm_source:
         if args.hmm_source not in info_table:
             run.warning("Nice try, and anvi'o is proud of you. But it doesn't change the fact that the HMM source\
                          '%s' was not in your contigs database. That's OK. Now anvi'o will pretend as if nothing\
-                         happened, and quite without a fuss (but you shall remember this)." % args.hmm_source)
+                         happened, and quit without a fuss." % args.hmm_source)
             sys.exit(0)
 
         hmm_tables.remove_source(args.hmm_source)


### PR DESCRIPTION
This PR implements a lengthy workaround to one of the most critical design mistakes that remain in anvi'o.

Briefly, we set `entry_id` values in table classes depending on the data that will be entered into the database, and this is how it goes roughly: anvi'o learns the highest entry id in a table (to which it is about to enter some data), then for each db entry assigns a new `entry_id`, and finally enters the data. 

it is all good when there is a single process doing it. but when there are multiple processes running in parallel (not multiple threads, but multiple runs), sometimes race conditions occur: two processes learn the max entry id about the same time, and when they finally enter the data to the db, some entries end up not being unique.

this is a toughie because sometimes entry ids are used to connect distinct information from different tables, so they must be known before the data goes into the database, etc. when these race conditions occur, anvi'o gives an error telling the user kindly that they are fucked. The solution implemented in this PR tries to solve it whenever it is applicable, but this is a solution FAR FROM BEING PERFECT.

The perfect solution would remove the need for unique entry ids for table entries. Which is easy to do, but will require updates to all databases and lots of testing to make sure it is good to roll out.