### PR TITLE
Restructure target rules

### DIFF
--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -54,6 +54,7 @@ class WorkflowSuperClass:
         self.list_dependencies = A('list_dependencies')
         self.dry_run_only = A('dry_run')
         self.additional_params = A('additional_params')
+        self.target_files = None
 
         if self.additional_params:
             run.warning("OK, SO THIS IS SERIOUS, AND WHEN THINGS ARE SERIOUS THEN WE USE CAPS. \
@@ -122,6 +123,10 @@ class WorkflowSuperClass:
         if not self.slave_mode:
             self.check_config()
             self.check_rule_params()
+
+
+    def init_target_files(self):
+        self.target_files = []
 
 
     def sanity_checks(self):

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -54,7 +54,6 @@ class WorkflowSuperClass:
         self.list_dependencies = A('list_dependencies')
         self.dry_run_only = A('dry_run')
         self.additional_params = A('additional_params')
-        self.target_files = None
 
         if self.additional_params:
             run.warning("OK, SO THIS IS SERIOUS, AND WHEN THINGS ARE SERIOUS THEN WE USE CAPS. \
@@ -123,10 +122,6 @@ class WorkflowSuperClass:
         if not self.slave_mode:
             self.check_config()
             self.check_rule_params()
-
-
-    def init_target_files(self):
-        self.target_files = []
 
 
     def sanity_checks(self):
@@ -595,7 +590,7 @@ def get_workflow_snake_file_path(workflow):
     return snakefile_path
 
 
-def warning_for_param(config, rule, param, wildcard, our_default=None):
+def check_for_risky_param_change(config, rule, param, wildcard, our_default=None):
     value = A([rule, param], config)
     if value:
         warning_message = 'You chose to define %s for the rule %s in the config file as %s.\

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -30,31 +30,21 @@ if not slave_mode:
 
 localrules: annotate_contigs_database
 
-# default is NOT running taxonomy with centrifuge
-run_taxonomy_with_centrifuge = M.get_param_value_from_config(["centrifuge", "run"]) == True
 
-# default is running anvi_run_hmms
-run_anvi_run_hmms = M.get_param_value_from_config(["anvi_run_hmms", "run"]) == True
-
-# default is running anvi_run_ncbi_cogs
-run_anvi_run_ncbi_cogs = M.get_param_value_from_config(["anvi_run_ncbi_cogs", "run"]) == True
-#
-# default is running anvi_run_scg_taxonomy
-run_anvi_run_scg_taxonomy = M.get_param_value_from_config(["anvi_run_scg_taxonomy", "run"]) == True
-
-# default is NOT running anvi-script-run-eggnog-mapper
-run_anvi_script_run_eggnog_mapper = M.get_param_value_from_config(["anvi_script_run_eggnog_mapper", "run"]) == True
-
-# sanity check for centrifuge db
-if run_taxonomy_with_centrifuge:
-    if not M.get_param_value_from_config(["centrifuge", "db"]):
-        raise ConfigError("If you plan to run centrifuge, then you must "\
-                          "provide a path for the centrifuge db in the "\
-                          "config file. See documentation for more details.")
-
-
-rule generate_and_annotate_contigs_db:
+rule contigs_target_rule:
     input: expand(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done", group=M.group_names)
+
+
+rule annotate_contigs_database:
+    '''This is a dummy rule to mark that annotation was completed for each database
+
+    This allows workflows that inherit the contigs workflow to just track the output
+    of this rule, instead of tracking the individual
+    '''
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-annotate_contigs_database.log"
+    input: lambda wildcards: M.get_contigs_target_files()
+    output: touch(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done")
 
 
 rule gunzip_fasta:
@@ -263,87 +253,83 @@ rule import_external_functions:
     shell: "anvi-import-functions -c {input.contigs} -i {input.gene_functional_annotation} >> {log} 2>&1"
 
 
-if run_taxonomy_with_centrifuge:
-    # If the user wants taxonomy to be assigned with centrifuge
-    # then these following rules would run.
-    rule export_gene_calls_for_centrifuge:
-        ''' Export gene calls and use for centrifuge'''
-        version: 1.0
-        log: dirs_dict["LOGS_DIR"] + "/{group}-export_gene_calls_for_centrifuge.log"
-        # marking the input as ancient in order to ignore timestamps.
-        input: ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
-        # output is temporary. No need to keep this file.
-        output: temp(dirs_dict["CONTIGS_DIR"] + "/{group}-gene-calls.fa")
-        threads: M.T('export_gene_calls_for_centrifuge')
-        resources: nodes = M.T('export_gene_calls_for_centrifuge'),
-        shell: "anvi-get-sequences-for-gene-calls -c {input} -o {output} >> {log} 2>&1"
+rule export_gene_calls_for_centrifuge:
+    ''' Export gene calls and use for centrifuge'''
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-export_gene_calls_for_centrifuge.log"
+    # marking the input as ancient in order to ignore timestamps.
+    input: ancient(M.get_contigs_db_path())
+    # output is temporary. No need to keep this file.
+    output: temp(dirs_dict["CONTIGS_DIR"] + "/{group}-gene-calls.fa")
+    threads: M.T('export_gene_calls_for_centrifuge')
+    resources: nodes = M.T('export_gene_calls_for_centrifuge'),
+    shell: "anvi-get-sequences-for-gene-calls -c {input} -o {output} >> {log} 2>&1"
 
 
-    rule centrifuge:
-        ''' Run centrifuge on the exported gene calls of the contigs.db'''
-        version: 1.0
-        log: dirs_dict["LOGS_DIR"] + "/{group}-centrifuge.log"
-        input: rules.export_gene_calls_for_centrifuge.output
-        output:
-            hits = dirs_dict["CONTIGS_DIR"] + "/{group}-centrifuge_hits.tsv",
-            report = dirs_dict["CONTIGS_DIR"] + "/{group}-centrifuge_report.tsv"
-        params: db=config["centrifuge"]['db']
-        threads: M.T('centrifuge')
-        resources: nodes = M.T('centrifuge'),
-        shell: w.r("centrifuge -f \
-                               -x {params.db} \
-                               {input} \
-                               -S {output.hits} \
-                               --report-file {output.report} \
-                               --threads {threads} >> {log} 2>&1")
+rule centrifuge:
+    ''' Run centrifuge on the exported gene calls of the contigs.db'''
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-centrifuge.log"
+    input: rules.export_gene_calls_for_centrifuge.output
+    output:
+        hits = dirs_dict["CONTIGS_DIR"] + "/{group}-centrifuge_hits.tsv",
+        report = dirs_dict["CONTIGS_DIR"] + "/{group}-centrifuge_report.tsv"
+    params: db=M.get_param_value_from_config(["centrifuge", "db"])
+    threads: M.T('centrifuge')
+    resources: nodes = M.T('centrifuge'),
+    shell: w.r("centrifuge -f \
+                           -x {params.db} \
+                           {input} \
+                           -S {output.hits} \
+                           --report-file {output.report} \
+                           --threads {threads} >> {log} 2>&1")
 
 
-    rule anvi_import_taxonomy_for_genes:
-        ''' Run anvi-import-taxonomy-for-genes'''
-        version: 1.0
-        log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_import_taxonomy_for_genes.log"
-        input:
-            hits = rules.centrifuge.output.hits,
-            report = rules.centrifuge.output.report,
-            # marking the contigs.db as ancient in order to ignore timestamps.
-            contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
-        # using a flag file because no file is created by this rule.
-        # for more information see:
-        # http://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#flag-files
-        output: touch(dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_anvi_import_taxonomy_for_genes.done")
-        params: parser = "centrifuge"
-        threads: M.T('anvi_import_taxonomy_for_genes')
-        resources: nodes = M.T('anvi_import_taxonomy_for_genes'),
-        shell: w.r("anvi-import-taxonomy-for-genes -c {input.contigs} \
-                                                   -i {input.report} {input.hits} \
-                                                   -p {params.parser} >> {log} 2>&1")
+rule anvi_import_taxonomy_for_genes:
+    ''' Run anvi-import-taxonomy-for-genes'''
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_import_taxonomy_for_genes.log"
+    input:
+        hits = rules.centrifuge.output.hits,
+        report = rules.centrifuge.output.report,
+        # marking the contigs.db as ancient in order to ignore timestamps.
+        contigs = ancient(M.get_contigs_db_path())
+    # using a flag file because no file is created by this rule.
+    # for more information see:
+    # http://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#flag-files
+    output: touch(dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_anvi_import_taxonomy_for_genes.done")
+    params: parser = "centrifuge"
+    threads: M.T('anvi_import_taxonomy_for_genes')
+    resources: nodes = M.T('anvi_import_taxonomy_for_genes'),
+    shell: w.r("anvi-import-taxonomy-for-genes -c {input.contigs} \
+                                               -i {input.report} {input.hits} \
+                                               -p {params.parser} >> {log} 2>&1")
 
 
-if run_anvi_run_hmms:
-    rule anvi_run_hmms:
-        """ Run anvi-run-hmms"""
-        version: 1.0
-        log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_hmms.log"
-        # marking the input as ancient in order to ignore timestamps.
-        input: ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
-        # using a snakemake flag file as an output since no file is generated
-        # by the rule.
-        output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done")
-        params:
-            installed_hmm_profile = M.get_rule_param("anvi_run_hmms", "--installed-hmm-profile"),
-            hmm_profile_dir = M.get_rule_param("anvi_run_hmms", "--hmm-profile-dir"),
-        threads: M.T('anvi_run_hmms')
-        resources: nodes = M.T('anvi_run_hmms'),
-        shell: w.r("anvi-run-hmms -c {input} \
-                                  -T {threads} \
-                                  {params.hmm_profile_dir} \
-                                  {params.installed_hmm_profile} >> {log} 2>&1")
+rule anvi_run_hmms:
+    """ Run anvi-run-hmms"""
+    version: 1.0
+    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_hmms.log"
+    # marking the input as ancient in order to ignore timestamps.
+    input: ancient(M.get_contigs_db_path())
+    # using a snakemake flag file as an output since no file is generated
+    # by the rule.
+    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done")
+    params:
+        installed_hmm_profile = M.get_rule_param("anvi_run_hmms", "--installed-hmm-profile"),
+        hmm_profile_dir = M.get_rule_param("anvi_run_hmms", "--hmm-profile-dir"),
+    threads: M.T('anvi_run_hmms')
+    resources: nodes = M.T('anvi_run_hmms'),
+    shell: w.r("anvi-run-hmms -c {input} \
+                              -T {threads} \
+                              {params.hmm_profile_dir} \
+                              {params.installed_hmm_profile} >> {log} 2>&1")
 
 
 rule anvi_run_pfams:
     version: 1.0
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-anvi_run_pfams.log")
-    input: ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
+    input: ancient(M.get_contigs_db_path())
     output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "anvi_run_pfams-{group}.done"))
     params:
         pfam_data_dir = M.get_rule_param('anvi_run_pfams', '--pfam-data-dir')
@@ -356,7 +342,7 @@ rule anvi_run_ncbi_cogs:
     version: anvio.__contigs__version__
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_ncbi_cogs.log"
     input:
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
+        contigs = ancient(M.get_contigs_db_path())
     output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_ncbi_cogs-{group}.done")
     params:
         # anvi-run-ncbi-cogs params. See anvi-run-ncbi-cogs help menu for more info.
@@ -374,28 +360,27 @@ rule anvi_run_ncbi_cogs:
                                      {params.search_with} >> {log} 2>&1""")
 
 
-if run_anvi_run_hmms and run_anvi_run_scg_taxonomy:
-    rule anvi_run_scg_taxonomy:
-        version: anvio.__contigs__version__
-        log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_scg_taxonomy.log"
-        input:
-            # make sure HMMs were done before running this rule
-            hmms_done = ancient(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done"),
-            contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
-        output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_scg_taxonomy-{group}.done")
-        params:
-            scg_taxonomy_data_dir = M.get_rule_param('anvi_run_scg_taxonomy', '--scgs-taxonomy-data-dir'),
-        threads: M.T('anvi_run_scg_taxonomy')
-        resources: nodes = M.T('anvi_run_scg_taxonomy'),
-        shell: w.r("""anvi-run-scg-taxonomy -c {input.contigs} \
-                                            -T {threads} \
-                                            {params.scg_taxonomy_data_dir} >> {log} 2>&1""")
+rule anvi_run_scg_taxonomy:
+    version: anvio.__contigs__version__
+    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_scg_taxonomy.log"
+    input:
+        # make sure HMMs were done before running this rule
+        hmms_done = ancient(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done"),
+        contigs = ancient(M.get_contigs_db_path())
+    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_scg_taxonomy-{group}.done")
+    params:
+        scg_taxonomy_data_dir = M.get_rule_param('anvi_run_scg_taxonomy', '--scgs-taxonomy-data-dir'),
+    threads: M.T('anvi_run_scg_taxonomy')
+    resources: nodes = M.T('anvi_run_scg_taxonomy'),
+    shell: w.r("""anvi-run-scg-taxonomy -c {input.contigs} \
+                                        -T {threads} \
+                                        {params.scg_taxonomy_data_dir} >> {log} 2>&1""")
 
 
 rule anvi_get_sequences_for_gene_calls:
     version: 1.0
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_get_sequences_for_gene_calls.log"
-    input: ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
+    input: ancient(M.get_contigs_db_path())
     output: temp(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs-aa-sequences.fa")
     threads: M.T('anvi_get_sequences_for_gene_calls')
     resources: nodes = M.T('anvi_get_sequences_for_gene_calls')
@@ -441,41 +426,6 @@ rule anvi_script_run_eggnog_mapper:
         shell("anvi-script-run-eggnog-mapper -c {input.contigs} --annotation {input.eggnog_output}.temp {params.use_version}  >> {log} 2>&1")
 
         shell("rm {input.eggnog_output}.temp 2>{log}")
-
-
-rule annotate_contigs_database:
-    '''
-        This is a dummy rule and it is here just to guarantee that all
-        the contigs annotations will run (according to what was requested
-        in the config file). The main use is to use --until annotate_contigs_database
-        if you just want a contigs databases with all the annotations.
-    '''
-    version: 1.0
-    log: dirs_dict["LOGS_DIR"] + "/{group}-annotate_contigs_database.log"
-    input:
-        # this is here just so snakemake would run the taxonomy before running this rule
-        taxonomy = rules.anvi_import_taxonomy_for_genes.output if run_taxonomy_with_centrifuge else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
-
-        # this is here just so snakemake would run the hmms before running this rule
-        hmms = rules.anvi_run_hmms.output if run_anvi_run_hmms else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
-
-        # this is here just so snakemake would run the ncbi cogs before running this rule
-        cogs = rules.anvi_run_ncbi_cogs.output if run_anvi_run_ncbi_cogs else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
-
-        # this is here because Meren finally understood why it is here thanks to a short-lived wisdom during which
-        # he could see everything. it is gone now. SO GOOD LUCK TO YOU.
-        scg_taxonomy = rules.anvi_run_scg_taxonomy.output if (run_anvi_run_hmms and run_anvi_run_scg_taxonomy) else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
-
-        # I hope that by now, you understand why this is here (hint: it is in order to prevent global warming)
-        eggnog_mapper = rules.anvi_script_run_eggnog_mapper.output if run_anvi_script_run_eggnog_mapper else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
-
-        # import external functions
-        import_external_functions = M.import_external_functions_flags if M.import_external_functions_flags else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
-
-        # annotate pfams
-        pfams =  rules.anvi_run_pfams.output if M.run_pfams else ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
-    output: touch(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done")
-    shell: "touch {output} >> {log} 2>&1"
 
 
 # generate external genomes storage

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -352,8 +352,6 @@ rule anvi_run_pfams:
     shell: " anvi-run-pfams -c {input} {params.pfam_data_dir} -T {threads} >> {log} 2>&1"
 
 
-
-w.warning_for_param(config, 'anvi_run_ncbi_cogs', '--temporary-dir-path', '{group}')
 rule anvi_run_ncbi_cogs:
     version: anvio.__contigs__version__
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_ncbi_cogs.log"

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -106,18 +106,66 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
         self.sanity_check_contigs_project_name()
 
-        self.import_external_functions_flags = [os.path.join(self.dirs_dict["CONTIGS_DIR"],
-                                                group + "-external-functions-imported.done")\
-                                                for group in self.contigs_information \
-                                                if self.contigs_information[group].get('gene_functional_annotation')]
+        # check and warn user regarding risky change of temp dir name
+        w.check_for_risky_param_change(self.config, 'anvi_run_ncbi_cogs', '--temporary-dir-path', '{group}')
 
-        self.run_pfams = self.get_param_value_from_config(['anvi_run_pfams', 'run'])
 
-        # warn user regarding risky change of temp dir name
-        w.warning_for_param(self.config, 'anvi_run_ncbi_cogs', '--temporary-dir-path', '{group}')
+    def get_contigs_target_files(self):
+        # Add the contigs database as a target file.
+        # This is the only mandatory target file for this workflow.
+        target_files = []
+        target_files.append(self.get_contigs_db_path())
 
-    def init_target_files(self):
-        super().init_target_files()
+        # Add the optional target files according to user configurations
+        target_files.extend(self.get_contigs_workflow_optional_targets())
+
+        return target_files
+
+
+    def get_contigs_workflow_optional_targets(self):
+        optional_targets = []
+
+        run_taxonomy_with_centrifuge = self.get_param_value_from_config(["centrifuge", "run"]) == True
+        # sanity check for centrifuge db
+        if run_taxonomy_with_centrifuge:
+            if not self.get_param_value_from_config(["centrifuge", "db"]):
+                raise ConfigError("If you plan to run centrifuge, then you must "\
+                                  "provide a path for the centrifuge db in the "\
+                                  "config file. See documentation for more details.")
+
+        if run_taxonomy_with_centrifuge:
+            optional_targets.append(self.dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_anvi_import_taxonomy_for_genes.done")
+
+        run_anvi_run_hmms = self.get_param_value_from_config(["anvi_run_hmms", "run"]) == True
+        if run_anvi_run_hmms:
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_hmms-{group}.done"))
+
+        if self.get_param_value_from_config(["anvi_run_ncbi_cogs", "run"]) == True:
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_ncbi_cogs-{group}.done"))
+
+        run_anvi_run_scg_taxonomy = self.get_param_value_from_config(["anvi_run_scg_taxonomy", "run"]) == True
+        if run_anvi_run_scg_taxonomy:
+            if not run_anvi_run_hmms:
+                self.run.warning('You chose to run anvi_run_scg_taxonomy, but you didn\'t choose to run\
+                                  anvi_run_hmms. Continue at your own risk. If your contigs databases\
+                                  don\'t have HMM hits stored already then anvi_run_scg_taxonomy will fail.')
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_scg_taxonomy-{group}.done"))
+
+        if self.get_param_value_from_config(["anvi_script_run_eggnog_mapper", "run"]) == True:
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-anvi_script_run_eggnog_mapper.done"))
+
+        # import external functions if provided
+        import_external_functions_flags = [os.path.join(self.dirs_dict["CONTIGS_DIR"],
+                                           group + "-external-functions-imported.done")\
+                                           for group in self.contigs_information \
+                                           if self.contigs_information[group].get('gene_functional_annotation')]
+        if import_external_functions_flags:
+            optional_targets.extend(import_external_functions_flags)
+
+        if self.get_param_value_from_config(['anvi_run_pfams', 'run']):
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_pfams-{group}.done"))
+
+        return optional_targets
 
 
     def sanity_check_contigs_project_name(self):
@@ -132,6 +180,10 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                          the same name, unless you incloded "{group}" in the name you provided\
                          but even then, we did not test that option and we are not sure it would\
                          work...' % contigs_project_name)
+
+
+    def get_contigs_db_path(self):
+        return os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-contigs.db")
 
 
     def get_raw_fasta(self, wildcards, remove_gz_suffix=True):

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -113,6 +113,8 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
         self.run_pfams = self.get_param_value_from_config(['anvi_run_pfams', 'run'])
 
+        # warn user regarding risky change of temp dir name
+        w.warning_for_param(self.config, 'anvi_run_ncbi_cogs', '--temporary-dir-path', '{group}')
 
     def init_target_files(self):
         super().init_target_files()

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -114,6 +114,10 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         self.run_pfams = self.get_param_value_from_config(['anvi_run_pfams', 'run'])
 
 
+    def init_target_files(self):
+        super().init_target_files()
+
+
     def sanity_check_contigs_project_name(self):
         contigs_project_name = self.get_param_value_from_config(['anvi_gen_contigs_database', '--project-name'], repress_default=True)
         if contigs_project_name != self.default_config['anvi_gen_contigs_database']['--project-name'] and contigs_project_name is not None:

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -130,7 +130,7 @@ rule metagenomics_workflow_target_rule:
         The final product of the workflow is an anvi'o merged profile directory
         for each group
     '''
-    input: M.target_files
+    input: M.get_metagenomics_target_files()
 
 
 rule iu_gen_configs:
@@ -769,7 +769,7 @@ rule anvi_profile:
     input:
         bam = dirs_dict["MAPPING_DIR"] + "/{group}/{sample}.bam",
         # marking the contigs.db as ancient in order to ignore timestamps.
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db")
+        contigs = ancient(M.get_contigs_db_path())
     output:
         profile = dirs_dict["PROFILE_DIR"] + "/{group}/{sample}/PROFILE.db",
         AUXILIARY_DATA = dirs_dict["PROFILE_DIR"] + "/{group}/{sample}/AUXILIARY-DATA.db",
@@ -893,7 +893,7 @@ rule gen_readme_file_for_unmerged_groups:
     version: 1.0
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-gen_readme_file_for_unmerged_groups.log")
     input:
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
         profiles = input_for_anvi_merge,
         percent_of_reads_mapped_imported_flag = lambda wildcards: configure_flag_files_for_anvi_merge_optional_inputs(wildcards, 'import_percent_of_reads_mapped.done', run_import_percent_of_reads_mapped),
         kraken_flag = lambda wildcards: configure_flag_files_for_anvi_merge_optional_inputs(wildcards, "import_krakenuniq_taxonomy.done", M.run_krakenuniq)
@@ -925,7 +925,7 @@ rule anvi_merge:
     # The input are all profile databases that belong to the same group
     input:
         # marking the contigs.db as ancient in order to ignore timestamps.
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
         profiles = input_for_anvi_merge,
         percent_of_reads_mapped_imported_flag = lambda wildcards: configure_flag_files_for_anvi_merge_optional_inputs(wildcards, 'import_percent_of_reads_mapped.done', run_import_percent_of_reads_mapped),
         kraken_flag = lambda wildcards: configure_flag_files_for_anvi_merge_optional_inputs(wildcards, "import_krakenuniq_taxonomy.done", M.run_krakenuniq)
@@ -1014,7 +1014,7 @@ rule anvi_import_collection:
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_import_collection.log"
     input:
         profile = lambda wildcards: M.profile_databases[wildcards.group],
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
         collection_file = lambda wildcards: M.collections[wildcards.group]['collection_file']
     output:
         imported_collection_flag = touch(os.path.join(dirs_dict["MERGE_DIR"], \
@@ -1042,7 +1042,7 @@ rule anvi_import_default_collection:
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_import_default_collection.log"
     input:
         profile = lambda wildcards: M.profile_databases[wildcards.group],
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
     output:
         imported_collection_flag = touch(os.path.join(dirs_dict["MERGE_DIR"], \
                                               '{group}', \
@@ -1062,7 +1062,7 @@ rule anvi_summarize:
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-anvi_summarize.log")
     input:
         profile = lambda wildcards: M.profile_databases[wildcards.group],
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
         imported_collection_flag = lambda wildcards: M.get_collection_import_flag(str(wildcards.group))
     output:
         summary_done = temp(touch(os.path.join(dirs_dict["SUMMARY_DIR"], "{group}-summary.touch")))
@@ -1087,7 +1087,7 @@ rule anvi_split:
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-anvi_split.log")
     input:
         profile = lambda wildcards: M.profile_databases[wildcards.group],
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
         imported_collection_flag = os.path.join(dirs_dict["MERGE_DIR"], \
                                                 '{group}', \
                                                 'collection-import.done')
@@ -1279,7 +1279,7 @@ rule anvi_cluster_contigs:
     threads: M.T("anvi_cluster_contigs")
     resources: nodes = M.T("anvi_cluster_contigs")
     input:
-        contigs = ancient(dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"),
+        contigs = ancient(M.get_contigs_db_path()),
         profile = lambda wildcards: M.profile_databases[wildcards.group]
     params:
         driver = '{driver}',

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -36,7 +36,6 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
     def __init__(self, args=None, run=terminal.Run(), progress=terminal.Progress()):
         self.init_workflow_super_class(args, workflow_name='metagenomics')
 
-        self.target_files = [] # TODO: Once we update all other workflows then this will be initiated in WorkflowSuperClass
         self.samples_information = {}
         self.kraken_annotation_dict = {}
         self.run_krakenuniq = None
@@ -197,7 +196,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
 
 
     def init_target_files(self):
-        target_files = []
+        super().init_target_files()
 
         # let's also set the PROFILE databases paths variable here:
         for group in self.group_names:

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -192,13 +192,8 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         self.init_samples_txt()
         self.init_kraken()
         self.init_refereces_txt()
-        self.init_target_files()
 
-
-    def init_target_files(self):
-        super().init_target_files()
-
-        # let's also set the PROFILE databases paths variable here:
+        # Set the PROFILE databases paths variable:
         for group in self.group_names:
             # we need to use the single profile if the group is of size 1.
             self.profile_databases[group] = os.path.join(self.dirs_dict["MERGE_DIR"], group, "PROFILE.db") if self.group_sizes[group] > 1 else \
@@ -206,6 +201,11 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                                                             group,
                                                             self.samples_information.loc[self.samples_information['group']==group,'sample'].values[0],
                                                             "PROFILE.db")
+
+
+    def get_metagenomics_target_files(self):
+
+        target_files = []
 
         target_files.extend(list(self.profile_databases.values()))
 
@@ -241,9 +241,11 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                                   for g in self.collections.keys() if not self.collections[g]['default_collection']]
             target_files.extend(split)
 
-        self.configure_anvi_cluster_contigs()
+        targets_files_for_binning = self.get_target_files_for_anvi_cluster_contigs()
+        if targets_files_for_binning:
+            target_files.extend(targets_files_for_binning)
 
-        self.target_files.extend(target_files)
+        return target_files
 
 
     def get_collection_import_flag(self, group):
@@ -541,7 +543,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         return contigs
 
 
-    def configure_anvi_cluster_contigs(self):
+    def get_target_files_for_anvi_cluster_contigs(self):
         import anvio.workflows as w
         w.D(self.get_param_value_from_config(['anvi_cluster_contigs', 'run']))
         if self.get_param_value_from_config(['anvi_cluster_contigs', 'run']) is not True:
@@ -589,7 +591,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
             # if the key word '{driver}' is not in the collection name then it is a static collection name
             example_collection_name = collection_name
         else:
-            # if the key word '{driver}' IS in the collection name, then let's take one 
+            # if the key word '{driver}' IS in the collection name, then let's take one
             # driver as example when we check if the collection name is valid.
             example_collection_name = collection_name.format(driver=requested_drivers[0])
         try:
@@ -600,13 +602,13 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                    error we got: %s' % (collection_name, e))
 
         groups_of_size_one = []
+        target_files = []
         for d in requested_drivers:
             for g in self.group_names:
                 if self.group_sizes[g] > 1:
                     # add flag files of binning to the target files
                     # only if the group is larger than 1 (because otherwise, there is no merged profile)
-                    target_file = self.get_flag_file_for_binning_driver(g, d)
-                    self.target_files.append(target_file)
+                    target_files.append(self.get_flag_file_for_binning_driver(g, d))
                 else:
                     groups_of_size_one.append(g)
         if groups_of_size_one:
@@ -614,8 +616,12 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                          %s, since there is only one sample in this group, and hence there\
                          will be no merged profile, which is required for anvi-cluster-contigs.' % ', '.join(groups_of_size_one))
 
+        return target_files
+
+
     def get_flag_file_for_binning_driver(self, group, driver):
         return os.path.join(self.dirs_dict['MERGE_DIR'], group + '-' + driver + '.done')
+
 
     def get_param_name_for_binning_driver(self, driver):
         return '--additional-params' + '-' + driver

--- a/anvio/workflows/pangenomics/Snakefile
+++ b/anvio/workflows/pangenomics/Snakefile
@@ -32,7 +32,7 @@ if not slave_mode:
     include: w.get_workflow_snake_file_path('phylogenomics')
 
 rule pangenomics_target_rule:
-    input: M.target_files
+    input: M.get_pangenomics_target_files()
 
 
 # run pangenome
@@ -148,7 +148,7 @@ rule import_phylogenetic_tree_to_pangenome:
         newick = os.path.join(M.dirs_dict["PHYLO_DIR"], M.project_name + "-proteins_GAPS_REMOVED.fa" + ".contree")
     output:
         layers_orders_file = temp(os.path.join(M.dirs_dict["PAN_DIR"], M.project_name + "-layers-orders.txt")),
-        phylogeny_imported = touch(M.phylogeny_imported_flag)
+        phylogeny_imported = touch(M.get_phylogeny_imported_flag())
     params:
         tree_name = M.tree_name,
         just_do_it = M.get_rule_param('import_phylogenetic_tree_to_pangenome', '--just-do-it')

--- a/anvio/workflows/pangenomics/__init__.py
+++ b/anvio/workflows/pangenomics/__init__.py
@@ -32,7 +32,6 @@ class PangenomicsWorkflow(PhylogenomicsWorkflow, ContigsDBWorkflow, WorkflowSupe
     def __init__(self, args=None, run=terminal.Run(), progress=terminal.Progress()):
         self.init_workflow_super_class(args, workflow_name='pangenomics')
 
-        self.target_files = [] # TODO: Once we update all other workflows then this will be initiated in WorkflowSuperClass
         self.pan_project_name = None
         self.valid_sequence_sources_for_phylogeny = ['gene_clusters', 'hmm']
         self.sequence_source_for_phylogeny = None
@@ -115,8 +114,9 @@ class PangenomicsWorkflow(PhylogenomicsWorkflow, ContigsDBWorkflow, WorkflowSupe
 
         self.init_target_files()
 
+
     def init_target_files(self):
-        target_files = []
+        super().init_target_files()
         target_files.append(os.path.join(self.dirs_dict["PAN_DIR"], self.pan_project_name + "-PAN.db"))
 
         if self.sequence_source_for_phylogeny:

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -33,8 +33,8 @@ if not slave_mode:
 localrules: generate_phylogeny
 
 
-rule generate_phylogeny:
-    input: os.path.join(dirs_dict["PHYLO_DIR"], M.project_name + "-proteins_GAPS_REMOVED.fa" + ".contree")
+rule phylogenomics_target_rule:
+    input: M.get_phylogenomics_target_files()
 
 rule anvi_get_sequences_for_hmm_hits:
     version: 1.0

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -79,9 +79,8 @@ class PhylogenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
             self.phylogenomics_sequence_file = os.path.join(self.dirs_dict["PHYLO_DIR"], self.project_name + "-proteins.fa")
 
 
-    def init_target_files(self):
-        super().init_target_files()
-        self.target_files.append(self.get_phylogenetic_tree_output_file_name())
+    def get_phylogenomics_target_files(self):
+        return self.get_phylogenetic_tree_output_file_name()
 
 
     def sanity_checks(self):

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -81,6 +81,7 @@ class PhylogenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
 
     def init_target_files(self):
         super().init_target_files()
+        self.target_files.append(self.get_phylogenetic_tree_output_file_name())
 
 
     def sanity_checks(self):
@@ -97,3 +98,7 @@ class PhylogenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
 
         if not self.project_name:
             raise ConfigError("You must provide a project_name in your config file.")
+
+
+    def get_phylogenetic_tree_output_file_name(self):
+        return os.path.join(self.dirs_dict["PHYLO_DIR"], self.project_name + "-proteins_GAPS_REMOVED.fa" + ".contree")

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -79,6 +79,10 @@ class PhylogenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
             self.phylogenomics_sequence_file = os.path.join(self.dirs_dict["PHYLO_DIR"], self.project_name + "-proteins.fa")
 
 
+    def init_target_files(self):
+        super().init_target_files()
+
+
     def sanity_checks(self):
         if not self.get_rule_param('anvi_get_sequences_for_hmm_hits', '--gene-names'):
             run.warning('You did not provide a list of genes to use for phylogenomics. This is ok and things might work \

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -52,7 +52,7 @@ class PhylogenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                                                                         '--align-with': 'famsa',
                                                                         '--concatenate-genes': True,
                                                                         '--get-aa-sequences': True,
-                                                                        '--hmm-sources': 'Campbell_et_al'},
+                                                                        '--hmm-sources': 'Bacteria_71'},
                                     'trimal': {'-gt': 0.5},
                                     'iqtree': {'threads': 8, '-m': 'WAG', '-bb': 1000}})
 


### PR DESCRIPTION
Changing the way we work with target files so that it is the same standard for all workflows.

The purpose of this was to make it easier for someone who is extending these workflows to understand what is going on. It also allows us to recommend people who are extending the workflows to follow the same standard.

Each workflow has a function `get_workflow_name_target_files()` (e.g. `get_contigs_target_rules()`), which returns a list of the target files.

This is mostly cosmetic and should have no affect on the way workflows work.