### PR TITLE
Workflow config v1

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2070,7 +2070,7 @@ D = {
     'config-file': (
             ['-c', '--config-file'],
             {'required': False,
-             'help': "TBD"}
+             'help': "A JSON-formatted configuration file."}
                 ),
     'additional-params': (
             ['-A', '--additional-params'],

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -42,6 +42,16 @@ def migrate(config_path):
     new_config.update(workflow_object.config)
     new_config['config_version'] = '1'
 
+    ## Deal with special cases
+    special_params = ['fasta_txt', 'references_for_removal', 'references_mode']
+    for param in special_params:
+        if not workflow_object.get_param_value_from_config(special_params):
+            # this are parameters for which the default values
+            # used to be repressed using "repress_default"
+            # if the user deleted these from their config
+            # then we must delete them here as well.
+            del new_config[param]
+
     filesnpaths.is_output_file_writable(config_path)
     open(config_path, 'w').write(json.dumps(new_config, indent=4))
 

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -40,7 +40,7 @@ def migrate(config_path):
     config = workflow_object.config
 
     default_config = workflow_object.default_config
-    new_config = config
+    new_config = config.copy()
     new_config['config_version'] = '1'
 
     ## Deal with special cases
@@ -51,13 +51,9 @@ def migrate(config_path):
         # if the param belongs to special params then we skip it
             continue
         elif type(default_config[param]) == dict:
-            if 'run' in default_config[param].keys() and not w.A(['param', 'run'], config):
-            # if this is a rule that has a 'run' parameter then
-            # if run is not set to true in the config then skip this rule
-                continue
-            else:
             # otherwise update config rule parameters
-                new_config[param] = default_config[param].update(config.get(param,''))
+                new_config[param] = default_config[param]
+                new_config[param].update(config.get(param,''))
         else:
             # if it's not a dict then it's a general parameter
             # update the general parameter

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+import json
+import argparse
+
+import anvio.workflows as w
+import anvio.terminal as terminal
+import anvio.filesnpaths as filesnpaths
+
+from anvio.errors import ConfigError
+
+current_version, next_version = [x[1:] for x in __name__.split('_to_')]
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+def migrate(config_path):
+    if config_path is None:
+        raise ConfigError("No config path is given.")
+
+    workflow_name, version = w.get_workflow_name_and_version_from_config(config_path, dont_raise=True)
+
+    if not workflow_name:
+        raise ConfigError('Your config must include a workflow_name. For example\
+                           if this config file is used for the metagenomics workflow\
+                           then add \'"workflow_name": "metagenomics"\' to your config.')
+
+    if version != current_version:
+        raise ConfigError("Version of this config file is not %s (hence, this script cannot really do anything)." % current_version)
+
+    progress.new("Upgrading your config")
+    progress.update("...")
+
+    args = argparse.Namespace(workflow=workflow_name, config_file=config_path)
+
+    workflow_module_dict = w.get_workflow_module_dict()
+    workflow_object = workflow_module_dict[workflow_name](args)
+
+    user_config_v1 = workflow_object.default_config
+    user_config_v1.update(workflow_object.config)
+
+    filesnpaths.is_output_file_writable(config_path)
+    open(config_path, 'w').write(json.dumps(user_config_v1, indent=4))
+
+
+    progress.end()
+    run.info_single("The config file is now %s. This upgrade brought back any default value that was\
+                     previously removed from your config file. It will not change anything about the\
+                     configuration of the resulting workflow and you can just carry on your work.\
+                     " % (next_version), nl_after=1, nl_before=1, mc='green')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='A simple script to upgrade a workflow config from version %s to version %s' % (current_version, next_version))
+    parser.add_argument('config', metavar = 'CONFIG', help = 'Config at version %s' % current_version)
+    parser.add_argument(*anvio.A("workflow"), **anvio.K("workflow"))
+    args, unknown = parser.parse_known_args()
+
+    try:
+        migrate(args.config)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -40,6 +40,7 @@ def migrate(config_path):
 
     user_config_v1 = workflow_object.default_config
     user_config_v1.update(workflow_object.config)
+    user_config_v1['config_version'] = '1'
 
     filesnpaths.is_output_file_writable(config_path)
     open(config_path, 'w').write(json.dumps(user_config_v1, indent=4))

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -38,12 +38,12 @@ def migrate(config_path):
     workflow_module_dict = w.get_workflow_module_dict()
     workflow_object = workflow_module_dict[workflow_name](args)
 
-    user_config_v1 = workflow_object.default_config
-    user_config_v1.update(workflow_object.config)
-    user_config_v1['config_version'] = '1'
+    new_config = workflow_object.default_config
+    new_config.update(workflow_object.config)
+    new_config['config_version'] = '1'
 
     filesnpaths.is_output_file_writable(config_path)
-    open(config_path, 'w').write(json.dumps(user_config_v1, indent=4))
+    open(config_path, 'w').write(json.dumps(new_config, indent=4))
 
 
     progress.end()

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -46,7 +46,7 @@ def migrate(config_path):
 
 
     progress.end()
-    run.info_single("The config file is now %s. This upgrade brought back any default value that was\
+    run.info_single("The config file version is now %s. This upgrade brought back any default value that was\
                      previously removed from your config file. It will not change anything about the\
                      configuration of the resulting workflow and you can just carry on your work.\
                      " % (next_version), nl_after=1, nl_before=1, mc='green')

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -57,7 +57,7 @@ def migrate(config_path):
                 continue
             else:
             # otherwise update config rule parameters
-                new_config[param] = default_config[param].update(config[param])
+                new_config[param] = default_config[param].update(config.get(param,''))
         else:
             # if it's not a dict then it's a general parameter
             # update the general parameter

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -20,6 +20,7 @@ pan_db_version = "13"
 auxiliary_data_version = "2"
 structure_db_version = "1"
 genomes_storage_vesion = "6"
+workflow_config_version = "1"
 
 versions_for_db_types = {'contigs': contigs_db_version,
                          'profile': profile_db_version,
@@ -27,7 +28,8 @@ versions_for_db_types = {'contigs': contigs_db_version,
                          'structure': structure_db_version,
                          'pan': pan_db_version,
                          'genomestorage': genomes_storage_vesion,
-                         'auxiliary data for coverages': auxiliary_data_version}
+                         'auxiliary data for coverages': auxiliary_data_version,
+                         'config': workflow_config_version}
 
 ####################################################################################################
 #

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
@@ -1,9 +1,43 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " ",
-        "dont_remove_just_map": true,
-        "references_for_removal_txt": "mock_ref_for_removal.txt"
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
     },
     "idba_ud": {
         "--min_contig": 1000,
@@ -30,6 +64,42 @@
     "iu_filter_quality_minoche": {
         "run": false
     },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " ",
+        "dont_remove_just_map": true,
+        "references_for_removal_txt": "mock_ref_for_removal.txt"
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud_no_qc",
         "CONTIGS_DIR": "03_CONTIGS_idba_ud_no_qc",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
@@ -1,43 +1,9 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " ",
+        "dont_remove_just_map": true,
+        "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
     "idba_ud": {
         "--min_contig": 1000,
@@ -64,41 +30,6 @@
     "iu_filter_quality_minoche": {
         "run": false
     },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " ",
-        "dont_remove_just_map": true,
-        "references_for_removal_txt": "mock_ref_for_removal.txt"
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
     "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud_no_qc",
@@ -109,6 +40,5 @@
         "MERGE_DIR": "06_MERGED_idba_ud_no_qc",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_idba_ud_no_qc",
         "LOGS_DIR": "00_LOGS_idba_ud_no_qc"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
@@ -1,9 +1,43 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " ",
-        "dont_remove_just_map": true,
-        "references_for_removal_txt": "mock_ref_for_removal.txt"
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
     },
     "idba_ud": {
         "--min_contig": 1000,
@@ -30,6 +64,42 @@
     "iu_filter_quality_minoche": {
         "run": false
     },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " ",
+        "dont_remove_just_map": true,
+        "references_for_removal_txt": "mock_ref_for_removal.txt"
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud_no_qc",
         "CONTIGS_DIR": "03_CONTIGS_idba_ud_no_qc",
@@ -39,5 +109,6 @@
         "MERGE_DIR": "06_MERGED_idba_ud_no_qc",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_idba_ud_no_qc",
         "LOGS_DIR": "00_LOGS_idba_ud_no_qc"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
@@ -109,5 +109,6 @@
         "MERGE_DIR": "06_MERGED_idba_ud_no_qc",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_idba_ud_no_qc",
         "LOGS_DIR": "00_LOGS_idba_ud_no_qc"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
@@ -28,7 +28,8 @@
         "--pre_correction": ""
     },
     "iu_filter_quality_minoche": {
-        "run": false
+        "run": false,
+        "--ignore-deflines": true
     },
     "workflow_name": "metagenomics",
     "output_dirs": {
@@ -40,5 +41,74 @@
         "MERGE_DIR": "06_MERGED_idba_ud_no_qc",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_idba_ud_no_qc",
         "LOGS_DIR": "00_LOGS_idba_ud_no_qc"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud-no-qc.json
@@ -1,43 +1,9 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " ",
+        "dont_remove_just_map": true,
+        "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
     "idba_ud": {
         "--min_contig": 1000,
@@ -64,42 +30,6 @@
     "iu_filter_quality_minoche": {
         "run": false
     },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " ",
-        "dont_remove_just_map": true,
-        "references_for_removal_txt": "mock_ref_for_removal.txt"
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud_no_qc",
         "CONTIGS_DIR": "03_CONTIGS_idba_ud_no_qc",
@@ -109,6 +39,5 @@
         "MERGE_DIR": "06_MERGED_idba_ud_no_qc",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_idba_ud_no_qc",
         "LOGS_DIR": "00_LOGS_idba_ud_no_qc"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -15,5 +15,81 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_idba_ud",
         "MERGE_DIR": "06_MERGED_idba_ud",
         "LOGS_DIR": "00_LOGS_idba_ud"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -91,5 +91,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_idba_ud",
         "MERGE_DIR": "06_MERGED_idba_ud",
         "LOGS_DIR": "00_LOGS_idba_ud"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -1,85 +1,9 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
     "idba_ud": {
         "--min_contig": 1000,
         "threads": 11,
         "run": true
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
     },
     "workflow_name": "metagenomics",
     "kraken_txt": "kraken.txt",
@@ -91,6 +15,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_idba_ud",
         "MERGE_DIR": "06_MERGED_idba_ud",
         "LOGS_DIR": "00_LOGS_idba_ud"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -1,10 +1,87 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
     "idba_ud": {
         "--min_contig": 1000,
         "threads": 11,
         "run": true
     },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "kraken_txt": "kraken.txt",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -1,87 +1,10 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
     "idba_ud": {
         "--min_contig": 1000,
         "threads": 11,
         "run": true
     },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "kraken_txt": "kraken.txt",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud",
@@ -91,6 +14,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_idba_ud",
         "MERGE_DIR": "06_MERGED_idba_ud",
         "LOGS_DIR": "00_LOGS_idba_ud"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -1,10 +1,87 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
     "idba_ud": {
         "--min_contig": 1000,
         "threads": 11,
         "run": true
     },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "kraken_txt": "kraken.txt",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_idba_ud",
@@ -14,5 +91,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_idba_ud",
         "MERGE_DIR": "06_MERGED_idba_ud",
         "LOGS_DIR": "00_LOGS_idba_ud"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
@@ -1,12 +1,37 @@
 {
     "fasta_txt": "",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -35,9 +60,47 @@
         "--continue": "",
         "--verbose": ""
     },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
     "iu_filter_quality_minoche": {
         "run": false
     },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "all_against_all": true,
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit_no_qc",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
@@ -1,12 +1,37 @@
 {
     "fasta_txt": "",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -35,9 +60,47 @@
         "--continue": "",
         "--verbose": ""
     },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
     "iu_filter_quality_minoche": {
         "run": false
     },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "all_against_all": true,
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit_no_qc",
@@ -47,5 +110,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit_no_qc",
         "MERGE_DIR": "06_MERGED_megahit_no_qc",
         "LOGS_DIR": "00_LOGS_megahit_no_qc"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
@@ -1,37 +1,12 @@
 {
     "fasta_txt": "",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -60,45 +35,8 @@
         "--continue": "",
         "--verbose": ""
     },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
     "iu_filter_quality_minoche": {
         "run": false
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
     },
     "workflow_name": "metagenomics",
     "all_against_all": true,
@@ -110,6 +48,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit_no_qc",
         "MERGE_DIR": "06_MERGED_megahit_no_qc",
         "LOGS_DIR": "00_LOGS_megahit_no_qc"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
@@ -1,10 +1,12 @@
 {
     "fasta_txt": "",
     "anvi_run_hmms": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "anvi_run_ncbi_cogs": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "samples_txt": "samples.txt",
     "megahit": {
@@ -36,7 +38,8 @@
         "--verbose": ""
     },
     "iu_filter_quality_minoche": {
-        "run": false
+        "run": false,
+        "--ignore-deflines": true
     },
     "workflow_name": "metagenomics",
     "all_against_all": true,
@@ -48,5 +51,68 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit_no_qc",
         "MERGE_DIR": "06_MERGED_megahit_no_qc",
         "LOGS_DIR": "00_LOGS_megahit_no_qc"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
@@ -1,37 +1,12 @@
 {
     "fasta_txt": "",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -60,47 +35,9 @@
         "--continue": "",
         "--verbose": ""
     },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
     "iu_filter_quality_minoche": {
         "run": false
     },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "all_against_all": true,
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit_no_qc",
@@ -110,6 +47,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit_no_qc",
         "MERGE_DIR": "06_MERGED_megahit_no_qc",
         "LOGS_DIR": "00_LOGS_megahit_no_qc"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit-no-qc-all-against-all.json
@@ -110,5 +110,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit_no_qc",
         "MERGE_DIR": "06_MERGED_megahit_no_qc",
         "LOGS_DIR": "00_LOGS_megahit_no_qc"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -55,5 +55,69 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit",
         "MERGE_DIR": "06_MERGED_megahit",
         "LOGS_DIR": "00_LOGS_megahit"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -1,8 +1,4 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
     "centrifuge": {
         "threads": 5,
         "run": false
@@ -21,26 +17,7 @@
         "--temporary-dir-path": "",
         "--search-with": ""
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -69,48 +46,6 @@
         "--continue": "",
         "--verbose": ""
     },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit",
         "CONTIGS_DIR": "03_CONTIGS_megahit",
@@ -119,6 +54,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit",
         "MERGE_DIR": "06_MERGED_megahit",
         "LOGS_DIR": "00_LOGS_megahit"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -1,4 +1,8 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
     "centrifuge": {
         "threads": 5,
         "run": false
@@ -17,7 +21,26 @@
         "--temporary-dir-path": "",
         "--search-with": ""
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -46,6 +69,48 @@
         "--continue": "",
         "--verbose": ""
     },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit",
         "CONTIGS_DIR": "03_CONTIGS_megahit",
@@ -54,5 +119,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit",
         "MERGE_DIR": "06_MERGED_megahit",
         "LOGS_DIR": "00_LOGS_megahit"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -1,4 +1,8 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
     "centrifuge": {
         "threads": 5,
         "run": false
@@ -17,7 +21,26 @@
         "--temporary-dir-path": "",
         "--search-with": ""
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -46,6 +69,48 @@
         "--continue": "",
         "--verbose": ""
     },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit",
         "CONTIGS_DIR": "03_CONTIGS_megahit",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -1,8 +1,4 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
     "centrifuge": {
         "threads": 5,
         "run": false
@@ -21,26 +17,7 @@
         "--temporary-dir-path": "",
         "--search-with": ""
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
     "megahit": {
         "--min-contig-len": 1000,
         "--memory": 0.4,
@@ -69,47 +46,6 @@
         "--continue": "",
         "--verbose": ""
     },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
     "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_megahit",
@@ -119,6 +55,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit",
         "MERGE_DIR": "06_MERGED_megahit",
         "LOGS_DIR": "00_LOGS_megahit"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -119,5 +119,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_megahit",
         "MERGE_DIR": "06_MERGED_megahit",
         "LOGS_DIR": "00_LOGS_megahit"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
@@ -1,4 +1,34 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -6,9 +36,52 @@
         "run": true,
         "use_scaffolds": true
     },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
     "iu_filter_quality_minoche": {
         "run": false
     },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_metaspades_no_qc",
         "CONTIGS_DIR": "03_CONTIGS_metaspades_no_qc",
@@ -18,5 +91,6 @@
         "MERGE_DIR": "06_MERGED_metaspades_no_qc",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades_no_qc",
         "LOGS_DIR": "00_LOGS_metaspades_no_qc"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
@@ -1,4 +1,34 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -6,9 +36,52 @@
         "run": true,
         "use_scaffolds": true
     },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
     "iu_filter_quality_minoche": {
         "run": false
     },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_metaspades_no_qc",
         "CONTIGS_DIR": "03_CONTIGS_metaspades_no_qc",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
@@ -1,34 +1,4 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -36,52 +6,9 @@
         "run": true,
         "use_scaffolds": true
     },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
     "iu_filter_quality_minoche": {
         "run": false
     },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_metaspades_no_qc",
         "CONTIGS_DIR": "03_CONTIGS_metaspades_no_qc",
@@ -91,6 +18,5 @@
         "MERGE_DIR": "06_MERGED_metaspades_no_qc",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades_no_qc",
         "LOGS_DIR": "00_LOGS_metaspades_no_qc"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
@@ -1,34 +1,4 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -36,50 +6,8 @@
         "run": true,
         "use_scaffolds": true
     },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
     "iu_filter_quality_minoche": {
         "run": false
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
     },
     "workflow_name": "metagenomics",
     "output_dirs": {
@@ -91,6 +19,5 @@
         "MERGE_DIR": "06_MERGED_metaspades_no_qc",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades_no_qc",
         "LOGS_DIR": "00_LOGS_metaspades_no_qc"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
@@ -7,7 +7,8 @@
         "use_scaffolds": true
     },
     "iu_filter_quality_minoche": {
-        "run": false
+        "run": false,
+        "--ignore-deflines": true
     },
     "workflow_name": "metagenomics",
     "output_dirs": {
@@ -19,5 +20,77 @@
         "MERGE_DIR": "06_MERGED_metaspades_no_qc",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades_no_qc",
         "LOGS_DIR": "00_LOGS_metaspades_no_qc"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades-no-qc-use-scaffolds.json
@@ -91,5 +91,6 @@
         "MERGE_DIR": "06_MERGED_metaspades_no_qc",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades_no_qc",
         "LOGS_DIR": "00_LOGS_metaspades_no_qc"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -1,34 +1,4 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -36,52 +6,9 @@
         "run": true,
         "use_scaffolds": ""
     },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
     },
     "workflow_name": "metagenomics",
     "output_dirs": {
@@ -93,6 +20,5 @@
         "MERGE_DIR": "06_MERGED_metaspades",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades",
         "LOGS_DIR": "00_LOGS_metaspades"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -1,4 +1,34 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -6,10 +36,54 @@
         "run": true,
         "use_scaffolds": ""
     },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_metaspades",
         "CONTIGS_DIR": "03_CONTIGS_metaspades",
@@ -19,5 +93,6 @@
         "MERGE_DIR": "06_MERGED_metaspades",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades",
         "LOGS_DIR": "00_LOGS_metaspades"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -1,34 +1,4 @@
 {
-    "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -36,54 +6,10 @@
         "run": true,
         "use_scaffolds": ""
     },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_metaspades",
         "CONTIGS_DIR": "03_CONTIGS_metaspades",
@@ -93,6 +19,5 @@
         "MERGE_DIR": "06_MERGED_metaspades",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades",
         "LOGS_DIR": "00_LOGS_metaspades"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -1,4 +1,34 @@
 {
+    "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples.txt",
     "metaspades": {
         "additional_params": "--only-assembler",
@@ -6,10 +36,54 @@
         "run": true,
         "use_scaffolds": ""
     },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_metaspades",
         "CONTIGS_DIR": "03_CONTIGS_metaspades",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -93,5 +93,6 @@
         "MERGE_DIR": "06_MERGED_metaspades",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades",
         "LOGS_DIR": "00_LOGS_metaspades"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -20,5 +20,78 @@
         "MERGE_DIR": "06_MERGED_metaspades",
         "TAXONOMY_DIR": "07_TAXONOMY_metaspades",
         "LOGS_DIR": "00_LOGS_metaspades"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
@@ -1,85 +1,12 @@
 {
     "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples-no-groups.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
     "iu_filter_quality_minoche": {
         "run": false
     },
     "gzip_fastqs": {
         "run": false
     },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "references_mode": true,
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_references_mode_no_qc_no_gzip",
@@ -89,6 +16,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_references_mode_no_qc_no_gzip",
         "MERGE_DIR": "06_MERGED_references_mode_no_qc_no_gzip",
         "LOGS_DIR": "00_LOGS_references_mode_no_qc_no_gzip"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
@@ -1,83 +1,11 @@
 {
     "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "samples_txt": "samples-no-groups.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
     "iu_filter_quality_minoche": {
         "run": false
     },
     "gzip_fastqs": {
         "run": false
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
-    "remove_short_reads_based_on_references": {
-        "delimiter-for-iu-remove-ids-from-fastq": " "
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
     },
     "workflow_name": "metagenomics",
     "references_mode": true,
@@ -89,6 +17,5 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_references_mode_no_qc_no_gzip",
         "MERGE_DIR": "06_MERGED_references_mode_no_qc_no_gzip",
         "LOGS_DIR": "00_LOGS_references_mode_no_qc_no_gzip"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
@@ -2,7 +2,8 @@
     "fasta_txt": "fasta.txt",
     "samples_txt": "samples-no-groups.txt",
     "iu_filter_quality_minoche": {
-        "run": false
+        "run": false,
+        "--ignore-deflines": true
     },
     "gzip_fastqs": {
         "run": false
@@ -17,5 +18,78 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_references_mode_no_qc_no_gzip",
         "MERGE_DIR": "06_MERGED_references_mode_no_qc_no_gzip",
         "LOGS_DIR": "00_LOGS_references_mode_no_qc_no_gzip"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
     }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
@@ -1,12 +1,85 @@
 {
     "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples-no-groups.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
     "iu_filter_quality_minoche": {
         "run": false
     },
     "gzip_fastqs": {
         "run": false
     },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "references_mode": true,
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_references_mode_no_qc_no_gzip",
@@ -16,5 +89,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_references_mode_no_qc_no_gzip",
         "MERGE_DIR": "06_MERGED_references_mode_no_qc_no_gzip",
         "LOGS_DIR": "00_LOGS_references_mode_no_qc_no_gzip"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
@@ -1,12 +1,85 @@
 {
     "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "samples_txt": "samples-no-groups.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
     "iu_filter_quality_minoche": {
         "run": false
     },
     "gzip_fastqs": {
         "run": false
     },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
+    "remove_short_reads_based_on_references": {
+        "delimiter-for-iu-remove-ids-from-fastq": " "
+    },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "references_mode": true,
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_references_mode_no_qc_no_gzip",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-no-qc-no-gzip-no-groups.json
@@ -89,5 +89,6 @@
         "PROFILE_DIR": "05_ANVIO_PROFILE_references_mode_no_qc_no_gzip",
         "MERGE_DIR": "06_MERGED_references_mode_no_qc_no_gzip",
         "LOGS_DIR": "00_LOGS_references_mode_no_qc_no_gzip"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -78,6 +78,9 @@
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
     "workflow_name": "metagenomics",
     "references_mode": true,
     "collections_txt": "collections.txt",
@@ -86,14 +89,6 @@
     },
     "anvi_split": {
         "run": true
-    },
-    "anvi_cluster_contigs": {
-        "run": true,
-        "--collection-name": "{driver}",
-        "--driver": [ "maxbin2", "concoct" ],
-        "--just-do-it": true,
-        "--additional-params-maxbin2": "--max-iteration 20",
-        "--additional-params-concoct": "--seed 1"
     },
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_references_mode",

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -1,87 +1,9 @@
 {
     "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
-    "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
-    },
-    "workflow_name": "metagenomics",
     "references_mode": true,
     "collections_txt": "collections.txt",
     "anvi_summarize": {
@@ -99,6 +21,5 @@
         "MERGE_DIR": "06_MERGED_references_mode",
         "LOGS_DIR": "00_LOGS_references_mode",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_references_mode"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -1,9 +1,87 @@
 {
     "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
+    "anvi_cluster_contigs": {
+        "--collection-name": "{driver}"
+    },
+    "workflow_name": "metagenomics",
     "references_mode": true,
     "collections_txt": "collections.txt",
     "anvi_summarize": {
@@ -21,5 +99,6 @@
         "MERGE_DIR": "06_MERGED_references_mode",
         "LOGS_DIR": "00_LOGS_references_mode",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_references_mode"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -104,5 +104,6 @@
         "MERGE_DIR": "06_MERGED_references_mode",
         "LOGS_DIR": "00_LOGS_references_mode",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_references_mode"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -1,9 +1,84 @@
 {
     "fasta_txt": "fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
+    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
     },
+    "workflow_name": "metagenomics",
     "references_mode": true,
     "collections_txt": "collections.txt",
     "anvi_summarize": {

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -1,85 +1,8 @@
 {
     "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
-    "samples_txt": "samples.txt",
-    "metaspades": {
-        "additional_params": "--only-assembler",
-        "threads": 7
-    },
-    "megahit": {
-        "--min-contig-len": 1000,
-        "--memory": 0.4,
-        "threads": 7
-    },
-    "idba_ud": {
-        "--min_contig": 1000,
-        "threads": 7
-    },
-    "iu_filter_quality_minoche": {
-        "run": true,
-        "--ignore-deflines": true
-    },
-    "gzip_fastqs": {
-        "run": true
-    },
-    "bowtie": {
-        "additional_params": "--no-unal",
-        "threads": 3
-    },
-    "samtools_view": {
-        "additional_params": "-F 4"
-    },
-    "anvi_profile": {
-        "threads": 3,
-        "--sample-name": "{sample}",
-        "--overwrite-output-destinations": true
-    },
-    "anvi_merge": {
-        "--sample-name": "{group}",
-        "--overwrite-output-destinations": true
-    },
-    "import_percent_of_reads_mapped": {
-        "run": true
-    },
-    "krakenuniq": {
-        "threads": 3,
-        "--gzip-compressed": true,
-        "additional_params": ""
-    },
     "remove_short_reads_based_on_references": {
         "delimiter-for-iu-remove-ids-from-fastq": " ",
         "references_for_removal_txt": "mock_ref_for_removal.txt"
-    },
-    "anvi_cluster_contigs": {
-        "--collection-name": "{driver}"
     },
     "workflow_name": "metagenomics",
     "references_mode": true,
@@ -90,6 +13,14 @@
     "anvi_split": {
         "run": true
     },
+    "anvi_cluster_contigs": {
+        "run": true,
+        "--collection-name": "{driver}",
+        "--driver": [ "maxbin2", "concoct" ],
+        "--just-do-it": true,
+        "--additional-params-maxbin2": "--max-iteration 20",
+        "--additional-params-concoct": "--seed 1"
+    },
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_references_mode",
         "CONTIGS_DIR": "03_CONTIGS_references_mode",
@@ -99,6 +30,5 @@
         "MERGE_DIR": "06_MERGED_references_mode",
         "LOGS_DIR": "00_LOGS_references_mode",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_references_mode"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -13,14 +13,6 @@
     "anvi_split": {
         "run": true
     },
-    "anvi_cluster_contigs": {
-        "run": true,
-        "--collection-name": "{driver}",
-        "--driver": [ "maxbin2", "concoct" ],
-        "--just-do-it": true,
-        "--additional-params-maxbin2": "--max-iteration 20",
-        "--additional-params-concoct": "--seed 1"
-    },
     "output_dirs": {
         "FASTA_DIR": "02_FASTA_references_mode",
         "CONTIGS_DIR": "03_CONTIGS_references_mode",
@@ -30,5 +22,80 @@
         "MERGE_DIR": "06_MERGED_references_mode",
         "LOGS_DIR": "00_LOGS_references_mode",
         "SHORT_READ_FILTER_DIR": "01_SHORT_READ_FILTER_references_mode"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "samples_txt": "samples.txt",
+    "metaspades": {
+        "additional_params": "--only-assembler",
+        "threads": 7
+    },
+    "megahit": {
+        "--min-contig-len": 1000,
+        "--memory": 0.4,
+        "threads": 7
+    },
+    "idba_ud": {
+        "--min_contig": 1000,
+        "threads": 7
+    },
+    "iu_filter_quality_minoche": {
+        "run": true,
+        "--ignore-deflines": true
+    },
+    "gzip_fastqs": {
+        "run": true
+    },
+    "bowtie": {
+        "additional_params": "--no-unal",
+        "threads": 3
+    },
+    "samtools_view": {
+        "additional_params": "-F 4"
+    },
+    "anvi_profile": {
+        "threads": 3,
+        "--sample-name": "{sample}",
+        "--overwrite-output-destinations": true
+    },
+    "anvi_merge": {
+        "--sample-name": "{group}",
+        "--overwrite-output-destinations": true
+    },
+    "import_percent_of_reads_mapped": {
+        "run": true
+    },
+    "krakenuniq": {
+        "threads": 3,
+        "--gzip-compressed": true,
+        "additional_params": ""
     }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -1,16 +1,62 @@
 {
     "fasta_txt": "fasta.txt",
-    "internal_genomes": "",
-    "external_genomes": "external-genomes.txt",
-    "anvi_gen_genomes_storage": {
-        "--gene-caller": "",
-        "threads": ""
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
     },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "anvi_get_sequences_for_hmm_hits": {
+        "--return-best-hit": true,
+        "--align-with": "famsa",
+        "--concatenate-genes": true,
+        "--get-aa-sequences": true,
+        "--hmm-sources": "Bacteria_71"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny"
+    },
+    "anvi-compute-genome-similarity": {
+        "run": false
+    },
+    "workflow_name": "pangenomics",
+    "internal_genomes": "",
+    "external_genomes": "external-genomes.txt",
+    "anvi_gen_genomes_storage": {
+        "--gene-caller": "",
+        "threads": ""
     },
     "anvi_compute_genome_similarity": {
         "run": true

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -1,62 +1,16 @@
 {
     "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
+    "internal_genomes": "",
+    "external_genomes": "external-genomes.txt",
+    "anvi_gen_genomes_storage": {
+        "--gene-caller": "",
+        "threads": ""
     },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
-    "anvi_get_sequences_for_hmm_hits": {
-        "--return-best-hit": true,
-        "--align-with": "famsa",
-        "--concatenate-genes": true,
-        "--get-aa-sequences": true,
-        "--hmm-sources": "Bacteria_71"
-    },
-    "trimal": {
-        "-gt": 0.5
-    },
-    "iqtree": {
-        "threads": 8,
-        "-m": "WAG",
-        "-bb": 1000
-    },
-    "anvi_pan_genome": {
-        "threads": 7
-    },
-    "import_phylogenetic_tree_to_pangenome": {
-        "tree_name": "phylogeny"
-    },
-    "anvi-compute-genome-similarity": {
-        "run": false
-    },
-    "workflow_name": "pangenomics",
-    "internal_genomes": "",
-    "external_genomes": "external-genomes.txt",
-    "anvi_gen_genomes_storage": {
-        "--gene-caller": "",
-        "threads": ""
     },
     "anvi_compute_genome_similarity": {
         "run": true
@@ -67,6 +21,5 @@
         "CONTIGS_DIR": "02_CONTIGS",
         "PAN_DIR": "03_PAN",
         "LOGS_DIR": "00_LOGS"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -7,10 +7,12 @@
         "threads": ""
     },
     "anvi_run_hmms": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "anvi_run_ncbi_cogs": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "workflow_name": "pangenomics",
     "anvi_compute_genome_similarity": {
@@ -22,5 +24,48 @@
         "CONTIGS_DIR": "02_CONTIGS",
         "PAN_DIR": "03_PAN",
         "LOGS_DIR": "00_LOGS"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "anvi_get_sequences_for_hmm_hits": {
+        "--return-best-hit": true,
+        "--align-with": "famsa",
+        "--concatenate-genes": true,
+        "--get-aa-sequences": true,
+        "--hmm-sources": "Bacteria_71"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny"
     }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -1,16 +1,62 @@
 {
     "fasta_txt": "fasta.txt",
-    "internal_genomes": "",
-    "external_genomes": "external-genomes.txt",
-    "anvi_gen_genomes_storage": {
-        "--gene-caller": "",
-        "threads": ""
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
     },
     "anvi_run_hmms": {
         "run": false
     },
     "anvi_run_ncbi_cogs": {
         "run": false
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "anvi_get_sequences_for_hmm_hits": {
+        "--return-best-hit": true,
+        "--align-with": "famsa",
+        "--concatenate-genes": true,
+        "--get-aa-sequences": true,
+        "--hmm-sources": "Bacteria_71"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny"
+    },
+    "anvi-compute-genome-similarity": {
+        "run": false
+    },
+    "workflow_name": "pangenomics",
+    "internal_genomes": "",
+    "external_genomes": "external-genomes.txt",
+    "anvi_gen_genomes_storage": {
+        "--gene-caller": "",
+        "threads": ""
     },
     "anvi_compute_genome_similarity": {
         "run": true
@@ -21,5 +67,6 @@
         "CONTIGS_DIR": "02_CONTIGS",
         "PAN_DIR": "03_PAN",
         "LOGS_DIR": "00_LOGS"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -1,10 +1,10 @@
 {
     "fasta_txt": "fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
+    "internal_genomes": "",
+    "external_genomes": "external-genomes.txt",
+    "anvi_gen_genomes_storage": {
+        "--gene-caller": "",
+        "threads": ""
     },
     "anvi_run_hmms": {
         "run": false
@@ -12,52 +12,7 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
-    "anvi_get_sequences_for_hmm_hits": {
-        "--return-best-hit": true,
-        "--align-with": "famsa",
-        "--concatenate-genes": true,
-        "--get-aa-sequences": true,
-        "--hmm-sources": "Bacteria_71"
-    },
-    "trimal": {
-        "-gt": 0.5
-    },
-    "iqtree": {
-        "threads": 8,
-        "-m": "WAG",
-        "-bb": 1000
-    },
-    "anvi_pan_genome": {
-        "threads": 7
-    },
-    "import_phylogenetic_tree_to_pangenome": {
-        "tree_name": "phylogeny"
-    },
-    "anvi-compute-genome-similarity": {
-        "run": false
-    },
     "workflow_name": "pangenomics",
-    "internal_genomes": "",
-    "external_genomes": "external-genomes.txt",
-    "anvi_gen_genomes_storage": {
-        "--gene-caller": "",
-        "threads": ""
-    },
     "anvi_compute_genome_similarity": {
         "run": true
     },
@@ -67,6 +22,5 @@
         "CONTIGS_DIR": "02_CONTIGS",
         "PAN_DIR": "03_PAN",
         "LOGS_DIR": "00_LOGS"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -67,5 +67,6 @@
         "CONTIGS_DIR": "02_CONTIGS",
         "PAN_DIR": "03_PAN",
         "LOGS_DIR": "00_LOGS"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -1,5 +1,11 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -9,8 +15,20 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
     "anvi_script_reformat_fasta": {
         "run": false
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
     },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
@@ -20,9 +38,24 @@
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
     },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
     "import_phylogenetic_tree_to_pangenome": {
         "tree_name": "phylogeny_hmms"
     },
+    "anvi-compute-genome-similarity": {
+        "run": false
+    },
+    "workflow_name": "pangenomics",
     "project_name": "FIVE_TEST",
     "internal_genomes": "",
     "external_genomes": "five-external-genomes.txt",

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -1,11 +1,5 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -15,20 +9,8 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
     "anvi_script_reformat_fasta": {
         "run": false
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
     },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
@@ -38,22 +20,8 @@
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
     },
-    "trimal": {
-        "-gt": 0.5
-    },
-    "iqtree": {
-        "threads": 8,
-        "-m": "WAG",
-        "-bb": 1000
-    },
-    "anvi_pan_genome": {
-        "threads": 7
-    },
     "import_phylogenetic_tree_to_pangenome": {
         "tree_name": "phylogeny_hmms"
-    },
-    "anvi-compute-genome-similarity": {
-        "run": false
     },
     "workflow_name": "pangenomics",
     "project_name": "FIVE_TEST",
@@ -66,6 +34,5 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN_hmms",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -7,7 +7,8 @@
         "--hmm-profile-dir": ""
     },
     "anvi_run_ncbi_cogs": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "anvi_script_reformat_fasta": {
         "run": false
@@ -34,5 +35,35 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN_hmms",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
     }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -66,5 +66,6 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN_hmms",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -1,5 +1,11 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -9,8 +15,20 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
     "anvi_script_reformat_fasta": {
         "run": false
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
     },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
@@ -20,9 +38,24 @@
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
     },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
     "import_phylogenetic_tree_to_pangenome": {
         "tree_name": "phylogeny_hmms"
     },
+    "anvi-compute-genome-similarity": {
+        "run": false
+    },
+    "workflow_name": "pangenomics",
     "project_name": "FIVE_TEST",
     "internal_genomes": "",
     "external_genomes": "five-external-genomes.txt",
@@ -33,5 +66,6 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN_hmms",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -1,11 +1,5 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -15,20 +9,8 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
     "anvi_script_reformat_fasta": {
         "run": false
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
     },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
@@ -38,24 +20,9 @@
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
     },
-    "trimal": {
-        "-gt": 0.5
-    },
-    "iqtree": {
-        "threads": 8,
-        "-m": "WAG",
-        "-bb": 1000
-    },
-    "anvi_pan_genome": {
-        "threads": 7
-    },
     "import_phylogenetic_tree_to_pangenome": {
         "tree_name": "phylogeny_hmms"
     },
-    "anvi-compute-genome-similarity": {
-        "run": false
-    },
-    "workflow_name": "pangenomics",
     "project_name": "FIVE_TEST",
     "internal_genomes": "",
     "external_genomes": "five-external-genomes.txt",
@@ -66,6 +33,5 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN_hmms",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -1,11 +1,5 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -15,43 +9,7 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
     "anvi_script_reformat_fasta": {
-        "run": false
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
-    "anvi_get_sequences_for_hmm_hits": {
-        "--return-best-hit": true,
-        "--align-with": "famsa",
-        "--concatenate-genes": true,
-        "--get-aa-sequences": true,
-        "--hmm-sources": "Bacteria_71"
-    },
-    "trimal": {
-        "-gt": 0.5
-    },
-    "iqtree": {
-        "threads": 8,
-        "-m": "WAG",
-        "-bb": 1000
-    },
-    "anvi_pan_genome": {
-        "threads": 7
-    },
-    "import_phylogenetic_tree_to_pangenome": {
-        "tree_name": "phylogeny_gene_clusters"
-    },
-    "anvi-compute-genome-similarity": {
         "run": false
     },
     "workflow_name": "pangenomics",
@@ -61,6 +19,9 @@
         "--add-into-items-additional-data-table": "GCs_for_phylogeny",
         "--align-with": "famsa",
         "--concatenate-gene-clusters": true
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny_gene_clusters"
     },
     "project_name": "FIVE_TEST",
     "internal_genomes": "",
@@ -72,6 +33,5 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -72,5 +72,6 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -1,5 +1,11 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -9,18 +15,52 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
     "anvi_script_reformat_fasta": {
         "run": false
     },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "anvi_get_sequences_for_hmm_hits": {
+        "--return-best-hit": true,
+        "--align-with": "famsa",
+        "--concatenate-genes": true,
+        "--get-aa-sequences": true,
+        "--hmm-sources": "Bacteria_71"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny_gene_clusters"
+    },
+    "anvi-compute-genome-similarity": {
+        "run": false
+    },
+    "workflow_name": "pangenomics",
     "anvi_get_sequences_for_gene_clusters": {
         "--min-num-genomes-gene-cluster-occurs": 5,
         "--max-num-genes-from-each-genome": 1,
         "--add-into-items-additional-data-table": "GCs_for_phylogeny",
         "--align-with": "famsa",
         "--concatenate-gene-clusters": true
-    },
-    "import_phylogenetic_tree_to_pangenome": {
-        "tree_name": "phylogeny_gene_clusters"
     },
     "project_name": "FIVE_TEST",
     "internal_genomes": "",

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -1,11 +1,5 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -15,52 +9,18 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
     "anvi_script_reformat_fasta": {
         "run": false
     },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
-    "anvi_get_sequences_for_hmm_hits": {
-        "--return-best-hit": true,
-        "--align-with": "famsa",
-        "--concatenate-genes": true,
-        "--get-aa-sequences": true,
-        "--hmm-sources": "Bacteria_71"
-    },
-    "trimal": {
-        "-gt": 0.5
-    },
-    "iqtree": {
-        "threads": 8,
-        "-m": "WAG",
-        "-bb": 1000
-    },
-    "anvi_pan_genome": {
-        "threads": 7
-    },
-    "import_phylogenetic_tree_to_pangenome": {
-        "tree_name": "phylogeny_gene_clusters"
-    },
-    "anvi-compute-genome-similarity": {
-        "run": false
-    },
-    "workflow_name": "pangenomics",
     "anvi_get_sequences_for_gene_clusters": {
         "--min-num-genomes-gene-cluster-occurs": 5,
         "--max-num-genes-from-each-genome": 1,
         "--add-into-items-additional-data-table": "GCs_for_phylogeny",
         "--align-with": "famsa",
         "--concatenate-gene-clusters": true
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny_gene_clusters"
     },
     "project_name": "FIVE_TEST",
     "internal_genomes": "",
@@ -72,6 +32,5 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -1,5 +1,11 @@
 {
     "fasta_txt": "five-genomes-fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
     "anvi_run_hmms": {
         "run": true,
         "threads": 5,
@@ -9,18 +15,52 @@
     "anvi_run_ncbi_cogs": {
         "run": false
     },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
     "anvi_script_reformat_fasta": {
         "run": false
     },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "anvi_get_sequences_for_hmm_hits": {
+        "--return-best-hit": true,
+        "--align-with": "famsa",
+        "--concatenate-genes": true,
+        "--get-aa-sequences": true,
+        "--hmm-sources": "Bacteria_71"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
+    },
+    "import_phylogenetic_tree_to_pangenome": {
+        "tree_name": "phylogeny_gene_clusters"
+    },
+    "anvi-compute-genome-similarity": {
+        "run": false
+    },
+    "workflow_name": "pangenomics",
     "anvi_get_sequences_for_gene_clusters": {
         "--min-num-genomes-gene-cluster-occurs": 5,
         "--max-num-genes-from-each-genome": 1,
         "--add-into-items-additional-data-table": "GCs_for_phylogeny",
         "--align-with": "famsa",
         "--concatenate-gene-clusters": true
-    },
-    "import_phylogenetic_tree_to_pangenome": {
-        "tree_name": "phylogeny_gene_clusters"
     },
     "project_name": "FIVE_TEST",
     "internal_genomes": "",
@@ -32,5 +72,6 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -7,7 +7,8 @@
         "--hmm-profile-dir": ""
     },
     "anvi_run_ncbi_cogs": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "anvi_script_reformat_fasta": {
         "run": false
@@ -33,5 +34,42 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS_FIVE_PAN",
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
+    "anvi_get_sequences_for_hmm_hits": {
+        "--return-best-hit": true,
+        "--align-with": "famsa",
+        "--concatenate-genes": true,
+        "--get-aa-sequences": true,
+        "--hmm-sources": "Bacteria_71"
+    },
+    "trimal": {
+        "-gt": 0.5
+    },
+    "iqtree": {
+        "threads": 8,
+        "-m": "WAG",
+        "-bb": 1000
+    },
+    "anvi_pan_genome": {
+        "threads": 7
     }
 }

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -54,5 +54,6 @@
     "output_dirs": {
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -1,33 +1,4 @@
 {
-    "fasta_txt": "five-genomes-fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": false
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
         "--align-with": "famsa",
@@ -35,6 +6,9 @@
         "--get-aa-sequences": true,
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": false
     },
     "trimal": {
         "-gt": 0.5,
@@ -51,9 +25,9 @@
     "project_name": "TEST",
     "internal_genomes": "",
     "external_genomes": "external-genomes.txt",
+    "fasta_txt": "five-genomes-fasta.txt",
     "output_dirs": {
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -1,4 +1,33 @@
 {
+    "fasta_txt": "five-genomes-fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": false
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
         "--align-with": "famsa",
@@ -6,9 +35,6 @@
         "--get-aa-sequences": true,
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": false
     },
     "trimal": {
         "-gt": 0.5,
@@ -21,12 +47,13 @@
         "-bb": 1000,
         "additional_params": ""
     },
+    "workflow_name": "phylogenomics",
     "project_name": "TEST",
     "internal_genomes": "",
     "external_genomes": "external-genomes.txt",
-    "fasta_txt": "five-genomes-fasta.txt",
     "output_dirs": {
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"
-    }
+    },
+    "config_version": "1"
 }

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -8,7 +8,8 @@
         "--min-num-bins-gene-occurs": 5
     },
     "anvi_run_ncbi_cogs": {
-        "run": false
+        "run": false,
+        "threads": 5
     },
     "trimal": {
         "-gt": 0.5,
@@ -29,5 +30,31 @@
     "output_dirs": {
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"
+    },
+    "config_version": "1",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
     }
 }

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -1,4 +1,33 @@
 {
+    "fasta_txt": "five-genomes-fasta.txt",
+    "anvi_gen_contigs_database": {
+        "--project-name": "{group}"
+    },
+    "centrifuge": {
+        "threads": 2
+    },
+    "anvi_run_hmms": {
+        "run": true,
+        "threads": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": false
+    },
+    "anvi_run_scg_taxonomy": {
+        "run": true,
+        "threads": 6
+    },
+    "anvi_script_reformat_fasta": {
+        "run": true
+    },
+    "emapper": {
+        "--database": "bact",
+        "--usemem": true,
+        "--override": true
+    },
+    "anvi_script_run_eggnog_mapper": {
+        "--use-version": "0.12.6"
+    },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
         "--align-with": "famsa",
@@ -6,9 +35,6 @@
         "--get-aa-sequences": true,
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": false
     },
     "trimal": {
         "-gt": 0.5,
@@ -21,10 +47,10 @@
         "-bb": 1000,
         "additional_params": ""
     },
+    "workflow_name": "phylogenomics",
     "project_name": "TEST",
     "internal_genomes": "",
     "external_genomes": "external-genomes.txt",
-    "fasta_txt": "five-genomes-fasta.txt",
     "output_dirs": {
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -1,33 +1,4 @@
 {
-    "fasta_txt": "five-genomes-fasta.txt",
-    "anvi_gen_contigs_database": {
-        "--project-name": "{group}"
-    },
-    "centrifuge": {
-        "threads": 2
-    },
-    "anvi_run_hmms": {
-        "run": true,
-        "threads": 5
-    },
-    "anvi_run_ncbi_cogs": {
-        "run": false
-    },
-    "anvi_run_scg_taxonomy": {
-        "run": true,
-        "threads": 6
-    },
-    "anvi_script_reformat_fasta": {
-        "run": true
-    },
-    "emapper": {
-        "--database": "bact",
-        "--usemem": true,
-        "--override": true
-    },
-    "anvi_script_run_eggnog_mapper": {
-        "--use-version": "0.12.6"
-    },
     "anvi_get_sequences_for_hmm_hits": {
         "--return-best-hit": true,
         "--align-with": "famsa",
@@ -35,6 +6,9 @@
         "--get-aa-sequences": true,
         "--hmm-sources": "Bacteria_71",
         "--min-num-bins-gene-occurs": 5
+    },
+    "anvi_run_ncbi_cogs": {
+        "run": false
     },
     "trimal": {
         "-gt": 0.5,
@@ -47,13 +21,12 @@
         "-bb": 1000,
         "additional_params": ""
     },
-    "workflow_name": "phylogenomics",
     "project_name": "TEST",
     "internal_genomes": "",
     "external_genomes": "external-genomes.txt",
+    "fasta_txt": "five-genomes-fasta.txt",
     "output_dirs": {
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"
-    },
-    "config_version": "1"
+    }
 }

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -31,6 +31,7 @@ run = terminal.Run()
 progress = terminal.Progress()
 r = errors.remove_spaces
 
+workflow_config_version = "1"
 
 class WorkflowSuperClass:
     def __init__(self):
@@ -95,8 +96,7 @@ class WorkflowSuperClass:
                 if param not in self.rule_acceptable_params_dict[rule]:
                     self.rule_acceptable_params_dict[rule].append(param)
 
-            general_params_that_all_workflows_must_accept = ['output_dirs', 'max_threads']
-            for param in general_params_that_all_workflows_must_accept:
+            for param in self.get_global_general_params():
                 if param not in self.general_params:
                     self.general_params.append(param)
 
@@ -122,6 +122,11 @@ class WorkflowSuperClass:
         if not self.slave_mode:
             self.check_config()
             self.check_rule_params()
+
+
+    def get_global_general_params(self):
+        ''' Return a list of the general parameters that are always acceptable.'''
+        return ['output_dirs', 'max_threads', 'config_version']
 
 
     def sanity_checks(self):
@@ -272,6 +277,7 @@ class WorkflowSuperClass:
     def get_default_config(self):
         c = self.fill_empty_config_params(self.default_config)
         c["output_dirs"] = self.dirs_dict
+        c["config_version"] = workflow_config_version
         return c
 
 

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -259,7 +259,7 @@ class WorkflowSuperClass:
             raise ConfigError('Config files must include a config_version. If\
                                this is news to you, and you don\'t know what\
                                version your config should be, then consider\
-                               using our script to upgrade you config file.')
+                               using our script to upgrade your config file.')
 
         if not self.config.get('workflow_name'):
             raise ConfigError('Config files must contain a workflow_name.')

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -91,7 +91,7 @@ class WorkflowSuperClass:
             if rule not in self.rule_acceptable_params_dict:
                 self.rule_acceptable_params_dict[rule] = []
 
-            params_that_all_rules_must_accept = ['threads']
+            params_that_all_rules_must_accept = self.get_params_that_all_rules_accept()
             for param in params_that_all_rules_must_accept:
                 if param not in self.rule_acceptable_params_dict[rule]:
                     self.rule_acceptable_params_dict[rule].append(param)
@@ -122,6 +122,10 @@ class WorkflowSuperClass:
         if not self.slave_mode:
             self.check_config()
             self.check_rule_params()
+
+
+    def get_params_that_all_rules_accept(self):
+        return ['threads']
 
 
     def get_global_general_params(self):

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -251,6 +251,15 @@ class WorkflowSuperClass:
                                    missing :(")
 
     def check_config(self):
+        if not self.config.get('config_version'):
+            raise ConfigError('Config files must include a config_version. If\
+                               this is news to you, and you don\'t know what\
+                               version your config should be, then consider\
+                               using our script to upgrade you config file.')
+
+        if not self.config.get('workflow_name'):
+            raise ConfigError('Config files must contain a workflow_name.')
+
         acceptable_params = set(self.rules + self.general_params)
         wrong_params = [p for p in self.config if p not in acceptable_params]
         if wrong_params:
@@ -278,6 +287,7 @@ class WorkflowSuperClass:
         c = self.fill_empty_config_params(self.default_config)
         c["output_dirs"] = self.dirs_dict
         c["config_version"] = workflow_config_version
+        c["workflow_name"] = self.name
         return c
 
 
@@ -620,3 +630,17 @@ def get_workflow_module_dict():
                       'phylogenomics': PhylogenomicsWorkflow}
 
     return workflows_dict
+
+
+def get_workflow_name_and_version_from_config(config_file, dont_raise=False):
+    filesnpaths.is_file_json_formatted(config_file)
+    config = json.load(open(config_file))
+    workflow_name = config.get('workflow_name')
+    # Notice that if there is no config_version then we return "0".
+    # This is in order to accomodate early contig files that had no such parameter.
+    version = config.get('config_version', "0")
+
+    if (not dont_raise) and (not workflow_name):
+        raise ConfigError('Config files must contain a workflow_name.')
+
+    return (workflow_name, version)

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -533,9 +533,9 @@ def A(_list, d, default_value = ""):
         _list = [_list]
     while _list:
         a = _list.pop(0)
-        if a in d:
+        try:
             d = d[a]
-        else:
+        except:
             return default_value
     return d
 

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -386,7 +386,6 @@ class WorkflowSuperClass:
             _list = [_list]
         while _list:
             a = _list.pop(0)
-            default_dict = default_dict[a]
             try:
                 d = d.get(a, "")
             except:
@@ -469,7 +468,7 @@ class WorkflowSuperClass:
             internal_genomes_file = self.get_param_value_from_config('internal_genomes')
             external_genomes_file = self.get_param_value_from_config('external_genomes')
 
-            fasta_txt_file = self.get_param_value_from_config('fasta_txt', repress_default=True)
+            fasta_txt_file = self.get_param_value_from_config('fasta_txt)
             if fasta_txt_file and not external_genomes_file:
                 raise ConfigError('You provided a fasta_txt, but didn\'t specify a path for an external-genomes file. \
                                    If you wish to use external genomes, you must specify a name for the external-genomes \

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -126,7 +126,7 @@ class WorkflowSuperClass:
 
     def get_global_general_params(self):
         ''' Return a list of the general parameters that are always acceptable.'''
-        return ['output_dirs', 'max_threads', 'config_version']
+        return ['output_dirs', 'max_threads', 'config_version', 'workflow_name']
 
 
     def sanity_checks(self):

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -468,7 +468,7 @@ class WorkflowSuperClass:
             internal_genomes_file = self.get_param_value_from_config('internal_genomes')
             external_genomes_file = self.get_param_value_from_config('external_genomes')
 
-            fasta_txt_file = self.get_param_value_from_config('fasta_txt)
+            fasta_txt_file = self.get_param_value_from_config('fasta_txt')
             if fasta_txt_file and not external_genomes_file:
                 raise ConfigError('You provided a fasta_txt, but didn\'t specify a path for an external-genomes file. \
                                    If you wish to use external genomes, you must specify a name for the external-genomes \

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -354,23 +354,17 @@ class WorkflowSuperClass:
         f[a] = value
 
 
-    def get_param_value_from_config(self, _list, repress_default=False):
+    def get_param_value_from_config(self, _list):
         '''
             A helper function to make sense of config details.
             string_list is a list of strings (or a single string)
 
             this function checks if the strings in x are nested values in self.config.
             For example if x = ['a','b','c'] then this function checkes if the
-            value self.config['a']['b']['c'] exists, if it does then it is returned
-
-            repress_default - If there is a default defined for the parameter (it would be defined
-            under self.default_config), and the user didn't supply a parameter
-            then the default will be returned. If this flad (repress_default) is set to True
-            then this behaviour is repressed and instead an empty string would be returned.
-
+            value self.config['a']['b']['c'] exists, if it does then it is returned.
+            If it does not exist then None is returned.
         '''
         d = self.config
-        default_dict = self.default_config
         if type(_list) is not list:
             # converting to list for the cases of only one item
             _list = [_list]
@@ -378,15 +372,11 @@ class WorkflowSuperClass:
             a = _list.pop(0)
             default_dict = default_dict[a]
             try:
-                d = d.get(a, None)
+                d = d.get(a, "")
             except:
-                # we continue becuase we want to get the value from the default config
-                continue
+                return ""
 
-        if (d is not None) or repress_default:
-            return d
-        else:
-            return default_dict
+        return d
 
 
     def get_rule_param(self, _rule, _param):

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -94,7 +94,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
     def init(self):
         super().init()
 
-        self.fasta_txt_file = self.get_param_value_from_config('fasta_txt', repress_default=True)
+        self.fasta_txt_file = self.get_param_value_from_config('fasta_txt')
 
         if self.fasta_txt_file:
             filesnpaths.is_file_exists(self.fasta_txt_file)
@@ -169,7 +169,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
 
     def sanity_check_contigs_project_name(self):
-        contigs_project_name = self.get_param_value_from_config(['anvi_gen_contigs_database', '--project-name'], repress_default=True)
+        contigs_project_name = self.get_param_value_from_config(['anvi_gen_contigs_database', '--project-name'])
         if contigs_project_name != self.default_config['anvi_gen_contigs_database']['--project-name'] and contigs_project_name is not None:
             self.run.warning('You chose to set the "project_name" for your contigs databases\
                          in the config file to %s. You are welcomed to do that, but at your own\

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -734,7 +734,7 @@ rule anvi_init_bam:
     shell: "anvi-init-bam {input} -o {output.bam} >> {log} 2>&1"
 
 
-sample_name = M.get_param_value_from_config(['anvi_profile', '--sample-name'], repress_default=True)
+sample_name = M.get_param_value_from_config(['anvi_profile', '--sample-name'])
 if sample_name != M.default_config['anvi_profile']['--sample-name'] and sample_name is not None:
     run.warning('You chose to set the "--sample-name" for your profile databases\
                  in the config file to %s. You are welcomed to do that, but at your own\
@@ -748,7 +748,7 @@ if sample_name != M.default_config['anvi_profile']['--sample-name'] and sample_n
 
 def get_cluster_contigs_param(wildcards):
     """ helper function to sort out whether to cluster contigs for a single profile database"""
-    if M.get_param_value_from_config(['anvi_profile', '--cluster-contigs'], repress_default=True):
+    if M.get_param_value_from_config(['anvi_profile', '--cluster-contigs']):
         run.warning('You chose to set the value for --cluster-contigs as %s. You can do that if you\
                      choose to, but just so you know, if you don\'t provide a value then \
                      the workflow would automatically cluster contigs for profile databases\

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -171,13 +171,12 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         self.run_qc = self.get_param_value_from_config(['iu_filter_quality_minoche', 'run']) == True
         self.run_summary = self.get_param_value_from_config(['anvi_summarize', 'run']) == True
         self.run_split = self.get_param_value_from_config(['anvi_split', 'run']) == True
-        self.references_mode = self.get_param_value_from_config('references_mode', repress_default=True)
-        self.fasta_txt_file = self.get_param_value_from_config('fasta_txt', repress_default=True)
+        self.references_mode = self.get_param_value_from_config('references_mode')
+        self.fasta_txt_file = self.get_param_value_from_config('fasta_txt')
         self.profile_databases = {}
 
         self.references_for_removal_txt = self.get_param_value_from_config(['remove_short_reads_based_on_references',\
-                                                                            'references_for_removal_txt'],\
-                                                                           repress_default=True)
+                                                                            'references_for_removal_txt'])
         if self.references_for_removal_txt:
             self.load_references_for_removal()
 
@@ -321,7 +320,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                 self.group_names = list(self.sample_names)
                 self.group_sizes = dict.fromkeys(self.group_names,1)
 
-        if self.get_param_value_from_config('all_against_all', repress_default=True):
+        if self.get_param_value_from_config('all_against_all'):
             # in all_against_all, the size of each group is as big as the number
             # of samples.
             self.group_sizes = dict.fromkeys(self.group_names,len(self.sample_names))

--- a/anvio/workflows/pangenomics/__init__.py
+++ b/anvio/workflows/pangenomics/__init__.py
@@ -59,7 +59,7 @@ class PangenomicsWorkflow(PhylogenomicsWorkflow, ContigsDBWorkflow, WorkflowSupe
         self.default_config.update({"fasta_txt": "fasta.txt",
                                     "anvi_pan_genome": {"threads": 7},
                                     "import_phylogenetic_tree_to_pangenome": {'tree_name': 'phylogeny'},
-                                    "anvi-compute-genome-similarity": {"run": False}})
+                                    "anvi_compute_genome_similarity": {"run": False}})
 
         pan_params = ["--project-name", "--genome-names", "--skip-alignments",\
                      "--align-with", "--exclude-partial-gene-calls", "--use-ncbi-blast",\

--- a/anvio/workflows/phylogenomics/Snakefile
+++ b/anvio/workflows/phylogenomics/Snakefile
@@ -30,8 +30,6 @@ if not slave_mode:
     dirs_dict = M.dirs_dict
     include: w.get_workflow_snake_file_path('contigs')
 
-localrules: generate_phylogeny
-
 
 rule phylogenomics_target_rule:
     input: M.get_phylogenomics_target_files()

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -15,7 +15,7 @@ import anvio.filesnpaths as filesnpaths
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.migrations import migration_scripts
 
-__description__ = "Migrate an anvi\'o database to a newer version."
+__description__ = "Migrate an anvi\'o database or config file to a newer version."
 
 run = terminal.Run()
 progress = terminal.Progress()
@@ -118,7 +118,7 @@ class Migrater(object):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__description__)
-    parser.add_argument('input', metavar = 'DATABASE', nargs='+', help = "Anvi'o database for migration")
+    parser.add_argument('input', metavar = 'DATABASE', nargs='+', help = "Anvi'o database or config file for migration")
     parser.add_argument('--just-do-it', default=False, action="store_true", help = "Do not bother me with warnings")
     parser.add_argument(*anvio.A('target-version'), **anvio.K('target-version'))
     args, unknown = parser.parse_known_args()

--- a/bin/anvi-migrate-db
+++ b/bin/anvi-migrate-db
@@ -40,8 +40,8 @@ class Migrater(object):
 
 
     def get_db_meta(self):
-        if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5']:
-            raise ConfigError("This program only works with files that end with `.db` extension.")
+        if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5', 'json']:
+            raise ConfigError("This program only works with files that end with `.db` or `.json` extensions.")
 
         try:
             if self.db_path.endswith('GENOMES.h5'):
@@ -53,6 +53,11 @@ class Migrater(object):
                 self.db_version = int(fp.attrs['version'])
 
                 fp.close()
+            elif self.db_path.endswith('json'):
+                import anvio.workflows as w
+                self.db_type = 'config'
+                workflow_name, config_version = w.get_workflow_name_and_version_from_config(self.db_path, dont_raise=True)
+                self.db_version = int(config_version)
             else:
                 db_conn = db.DB(self.db_path, None, ignore_version=True)
 


### PR DESCRIPTION
This closes #1313.

## The unintuitive and inconsistent treatment of parameters that were removed from a config file

This pull request modifies the way we deal with things that have been removed from the config file. Until now, most, but not all parameters that were removed from the config file would automatically get the default value from the default config file. This is a very unintuitive behavior. And to make things worse, there were a few parameters for which this didn't apply (i.e. when they were removed from the config they would not be assigned to their default value), which is down-right inconsistent.

## How we treat removed parameters as of this pull request

This pull request changes things so that when a parameter is removed from the config file, then it assumes the value of an empty string: `""`.

## Migration of old config files

Since this means that old config files would no longer give the same results, we have added a way to migrate config files. We use `anvi-migrate-db` for this (since @ozcan implement it so beautifully, it was really easy to extend). But since now `anvi-migrate-db` is upgrading more than databases, we renamed it to `anvi-migrate` (@meren, please take a look, and let me know if you are Ok with this change).

## Two mandatory parameters added to config files

In order to facilitate config file migration we added two obligatory parameters to every config file:
`workflow_name`
`config_version`

We need the `config_version` in order to track the version so we know it is compatible with the version of anvi'o that is being used.

We need to `workflow_name` because when using `anvi-migrate` we need to know which workflow generated this config file, since the upgrading process depends on that and for example, it would be different for a `contigs` workflow config file vs. a `metagenomics` workflow config file.

## How to migrate your config from version 0 to version 1 with `anvi-migrate`

In order to use `anvi-migrate` a user must manually add the `workflow_name` to their config file. For example:

```
    "workflow_name": "contigs"
```

In order to use `anvi-migrate` you don't have to add the `config_version` since `anvi-migrate` would assume that a config with no `config_version` value is of version 0.


If you have multiple config files in one directory (and you already added the `workflow_name` for all of them), you can migrate all of them like this:

```
anvi-migrate *json
```

## Can I use an old config with a newer version of anvi'o?

No. Just like with databases, anvi'o will check the version of the config and if it is not the same then the following error will be prompt letting you know that you should use `anvi-migrate`:
![image](https://user-images.githubusercontent.com/17661044/71118484-df68f080-219d-11ea-97ec-0ceb66fa52ce.png)

## What will my config file look like after migrating?

The migration step will add any default value to your config file if it was previously removed. This could include things that in practice will not affect your workflow, but to play it safe, they will be added since that would recapitulate the exact behavior that was happening behind the scenes before this pull request. You can then go ahead and re-edit you upgraded config to remove things that you don't want in your config.

@meren, please let me know if all of this sounds good to you. 