### PR TITLE
Ability to scan tRNAs in anvi'o contigs databases

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1460,6 +1460,12 @@ D = {
              'help': "Minimum score to assume a hit comes from a proper tRNA gene (passed to the tRNAScan-SE). "
                      "The default is %(default)d. It can get any value between 0-100."}
                 ),
+    'skip-scanning-trnas': (
+            ['--skip-scanning-trnas'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Don't scan tRNAs. Leave them be."}
+                ),
     'output-db-path': (
             ['-o', '--output-db-path'],
             {'metavar': 'DB_FILE_PATH',

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1445,6 +1445,21 @@ D = {
              'type': str,
              'help': "File path to store debug/output messages."}
                 ),
+    'trna-hits-file': (
+            ['--trna-hits-file'],
+            {'metavar': 'FILE_PATH',
+             'default': None,
+             'type': str,
+             'help': "File path to store raw hits from tRNA scan."}
+                ),
+    'trna-cutoff-score': (
+            ['--trna-cutoff-score'],
+            {'metavar': 'INT',
+             'default': 20,
+             'type': int,
+             'help': "Minimum score to assume a hit comes from a proper tRNA gene (passed to the tRNAScan-SE). "
+                     "The default is %(default)d. It can get any value between 0-100."}
+                ),
     'output-db-path': (
             ['-o', '--output-db-path'],
             {'metavar': 'DB_FILE_PATH',

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -541,7 +541,7 @@ function createCharts(state){
        .attr('transform', 'translate(50, 10)');
 
     // Define arrow markers
-    ['green', 'gray', 'firebrick'].forEach(function(color){
+    ['green', 'gray', 'firebrick', '#226ab2'].forEach(function(color){
       defs.append('svg:marker')
           .attr('id', 'arrow_' + color )
           .attr('markerHeight', 2)

--- a/anvio/data/interactive/js/constants.js
+++ b/anvio/data/interactive/js/constants.js
@@ -453,9 +453,24 @@ function getNamedLayerDefaults(layer, attribute, default_value, group)
 
     /* Some ad-hoc manipulation of special hmms_ single hmm layers */
     if (layer.substring(0, 5) == "hmms_"){
+        if (attribute == 'type') return 'intensity';
         if (attribute == 'height') return '150';
         if (attribute == 'norm')   return 'sqrt';
-        if (attribute == 'color')  return '#882222'
+
+        if (layer.substring(0, 13) == "hmms_Transfer"){
+            console.log(layer, attribute);
+            if (attribute == 'color-start')  return '#bfd9f3';
+            if (attribute == 'color')  return '#226ab2';
+        }
+        else if (layer.substring(0, 14) == "hmms_Ribosomal"){
+            if (attribute == 'color-start')  return '#FFDDDD';
+            if (attribute == 'color')  return '#882222';
+        }
+        else {
+            if (attribute == 'color')  return '#444444';
+            if (attribute == 'color-start')  return '#DDDDDD';
+        }
+
     }
 
     if (layer in named_layers)

--- a/anvio/data/interactive/js/inspectionutils.js
+++ b/anvio/data/interactive/js/inspectionutils.js
@@ -270,6 +270,9 @@ function drawArrows(_start, _stop) {
       if (gene.source == 'Ribosomal_RNAs') {
         color = 'firebrick';
       }
+      else if (gene.source == 'Transfer_RNAs') {
+        color = 'firebrick';
+      }
       else if (gene.functions !== null) {
         color = 'green';
       }
@@ -318,7 +321,7 @@ function drawArrows(_start, _stop) {
 
     $('[data-toggle="popover"]').on('shown.bs.popover', function (e) {
       var popover = $(e.target).data("bs.popover").$tip;
-      
+
       if ($(popover).css('top').charAt(0) === '-') {
         $(popover).css('top', '0px');
       }

--- a/anvio/data/interactive/js/inspectionutils.js
+++ b/anvio/data/interactive/js/inspectionutils.js
@@ -271,7 +271,7 @@ function drawArrows(_start, _stop) {
         color = 'firebrick';
       }
       else if (gene.source == 'Transfer_RNAs') {
-        color = 'firebrick';
+        color = '#226ab2';
       }
       else if (gene.functions !== null) {
         color = 'green';

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -1280,8 +1280,8 @@ function buildLayersTable(order, settings)
                         var type = getNamedLayerDefaults(layer_name, 'type', 'intensity');
                         var color_start = "#EEEEEE";
                     } else {
-                        var type = 'bar'
-                        var color_start = "#FFFFFF";
+                        var type = getNamedLayerDefaults(layer_name, 'type', 'bar');
+                        var color_start = getNamedLayerDefaults(layer_name, 'color-start', '#FFFFFF');
                     }
                 }
 

--- a/anvio/drivers/trnscan_se.py
+++ b/anvio/drivers/trnscan_se.py
@@ -130,6 +130,7 @@ class tRNAScanSE:
                 output.readline()
 
             entry_no = 0
+            num_introns = 0
             while 1:
                 self.progress.update(entry_no)
                 line = output.readline().strip('\n')
@@ -169,6 +170,7 @@ class tRNAScanSE:
         self.progress.end()
 
         self.run.info("Num tRNA genes parsed", entry_no)
+        self.run.info("Num tRNA genes with introns", num_introns, nl_after=1)
 
         return d
 

--- a/anvio/drivers/trnscan_se.py
+++ b/anvio/drivers/trnscan_se.py
@@ -153,7 +153,18 @@ class tRNAScanSE:
                                'stop': int(fields[3]),
                                'amino_acid': fields[4],
                                'anticodon': fields[5],
+                               'intron_start': int(fields[6]),
+                               'intron_end': int(fields[7]),
                                'score': float(fields[8])}
+
+                if d[entry_no]['intron_start']:
+                    num_introns += 1
+                    if d[entry_no]['start'] < d[entry_no]['stop']:
+                        d[entry_no]['intron_start'] = int(fields[6]) - d[entry_no]['start']
+                        d[entry_no]['intron_end'] = int(fields[7]) - int(fields[6])
+                    else:
+                        d[entry_no]['intron_start'] = d[entry_no]['start'] - int(fields[6])
+                        d[entry_no]['intron_end'] = int(fields[6]) - int(fields[7]) 
 
         self.progress.end()
 

--- a/anvio/drivers/trnscan_se.py
+++ b/anvio/drivers/trnscan_se.py
@@ -79,14 +79,14 @@ class tRNAScanSE:
             raise ConfigError("The cutoff score must be between 20 and 100.")
 
 
-    def check_programs(self):
+    def check_programs(self, quiet=False):
         utils.is_program_exists(self.program_name)
 
         output, ret_code = utils.get_command_output_from_shell('%s -h' % self.program_name)
-
         try:
             version_found = output.split(b'\n')[1].split()[1].split(b':')[0].lower().decode("utf-8")
-            self.run.info('%s version found' % self.program_name, version_found, mc="green", nl_after=1)
+            if not quiet:
+                self.run.info('%s version found' % self.program_name, version_found, mc="green", nl_after=1)
         except:
             version_found = 'Unknown'
             self.run.warning("Anvi'o failed to learn the version of %s installed on this system :/")

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -215,7 +215,9 @@ class TablesForTransferRNAs:
         for entry_id in search_results_dict:
             entry = search_results_dict[entry_id]
 
-            function_text = 'tRNA gene for amino acid %s (codon: %s; anticodon:%s; score:%.1f)' % (entry['amino_acid'], codon, entry['anticodon'], entry['score'])
+            function_text = 'tRNA gene for amino acid %s (codon: %s; anticodon:%s; score:%.1f; intron_start:%d; intron_end:%d)' \
+                                            % (entry['amino_acid'], codon, entry['anticodon'], \
+                                               entry['score'], entry['intron_start'], entry['intron_end'])
 
             functions_dict[entry_id] = {'gene_callers_id': entry['gene_callers_id'],
                                         'source': self.source_name,

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -51,7 +51,7 @@ class TablesForTransferRNAs:
 
         # just to make sure we have what it takes to continue later:
         trnascandriver = trnascan_se.tRNAScanSE(self.args, skip_sanity_check=True)
-        trnascandriver.check_programs()
+        trnascandriver.check_programs(quiet=True)
 
         self.tmp_directory_path = filesnpaths.get_temp_directory_path()
 

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8
+# pylint: disable=line-too-long
+"""
+    The purpose of this module is to help the dealing with tRNA genes
+    in contigs.
+"""
+
+import os
+import shutil
+
+from collections import Counter
+
+import anvio
+import anvio.utils as utils
+import anvio.terminal as terminal
+import anvio.constants as constants
+import anvio.filesnpaths as filesnpaths
+import anvio.drivers.trnscan_se as trnascan_se
+
+from anvio.tables.hmmhits import TablesForHMMHits
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2020, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "A. Murat Eren"
+__email__ = "a.murat.eren@gmail.com"
+
+
+
+class TablesForTransferRNAs:
+    """ This class follows the structure of how Ribosomal RNAs are populated in contigs databases. A
+        critical point is that ribosomal RNAs are identified in contigs context (rather than gene
+        context), JUST LIKE the transfer RNAs will be, but with a major difference: we identify rRNAs
+        through HMMs, and so this logic for ribosomal RNAs has ben neatly implemented in anvio/tables/hmmhits.
+        But for tRNAs we don't have HMMs, therefore we can't directly benefit from the comprehensive HMM
+        infrastructure of anvi'o for tRNAs. BUT WE MUST be able to use it to not implement a lot of
+        redundant code to get tRNAs into contigs databases while still benefiting from what is already
+        in place. HENCE This class. Which knits a workflow parallel to how ribosomal RNAs are added to
+        contigs databases through the HMMs. But instaed of using models, it uses tRNAScan-SE output by
+        default.
+    """
+
+    def __init__(self, args, run=terminal.Run(), progress=terminal.Progress()):
+        self.args = args
+        self.run = run
+        self.progress = progress
+
+        # just to make sure we have what it takes to continue later:
+        trnascandriver = trnascan_se.tRNAScanSE(self.args, skip_sanity_check=True)
+        trnascandriver.check_programs()
+
+        self.tmp_directory_path = filesnpaths.get_temp_directory_path()
+
+        P = lambda p: os.path.abspath(os.path.expanduser(p))
+        A = lambda x: args.__dict__[x] if x in args.__dict__ else None
+        self.num_threads = A('num_threads') or 1
+        self.hits_file_path = P(A('trna_hits_file') or os.path.join(self.tmp_directory_path, 'hits_file.txt'))
+        self.log_file_path = P(A('log_file') or os.path.join(self.tmp_directory_path, 'log.txt'))
+        self.cutoff_score = A('trna_cutoff_score') or 20
+
+        self.amino_acids = set([aa for aa in constants.AA_to_codons.keys() if aa != 'STP'])
+        self.codons = set([cdn for cdn in constants.codon_to_AA.keys() if constants.codon_to_AA[cdn] in self.amino_acids])
+
+        # the following variable is to meet the requirements of TablesForHMMHits to work with a new HMM
+        # source.
+        self.source = {'ref': 'Chan and Lowe, https://doi.org/10.1007/978-1-4939-9173-0_1',
+                       'kind': 'Transfer_RNAs',
+                       'domain': None,
+                       'genes': ['%s_%s' % (constants.codon_to_AA[cdn], cdn) for cdn in self.codons],
+                       'target': 'RNA:CONTIG',
+                       'noise_cutoff_terms': None,
+                       'model': None}
+
+        self.source_name = 'Transfer_RNAs'
+        self.kind_of_search = self.source['kind']
+        self.domain = self.source['domain']
+        self.all_genes_searched_against = self.source['genes']
+        self.hmm_model = self.source['model']
+        self.reference = self.source['ref']
+        self.noise_cutoff_terms = self.source['noise_cutoff_terms']
+
+
+    def run_trnascan_on_FASTA(self, fasta_file_path):
+        self.run.info("Temporary dir", self.tmp_directory_path)
+        self.run.info("FASTA file for contigs", fasta_file_path)
+        self.run.info("tRNA hits output", self.hits_file_path)
+        self.run.info("Log file", self.log_file_path)
+        self.run.info("Cutoff score", self.cutoff_score)
+
+        self.args.fasta_file = fasta_file_path
+        self.args.log_file = self.log_file_path
+        self.args.trna_hits_file = self.hits_file_path
+
+        trnascandriver = trnascan_se.tRNAScanSE(self.args)
+        results_dict = trnascandriver.process()
+
+        return results_dict
+
+
+    def populate_search_tables(self, contigs_db_path):
+        utils.is_contigs_db(contigs_db_path)
+        filesnpaths.is_output_file_writable(contigs_db_path, ok_if_exists=True)
+
+        contig_sequences_fasta_path = os.path.join(self.tmp_directory_path, 'contig_sequences.fa')
+
+        utils.export_sequences_from_contigs_db(contigs_db_path,
+                                               contig_sequences_fasta_path)
+
+        search_results_dict = self.run_trnascan_on_FASTA(fasta_file_path=contig_sequences_fasta_path)
+
+        # At this point we need to turn this search_results_dict into one that matches how it is used
+        # in HMM operations. Here is an entry from tRNA results dict:
+        #
+        # {1: {'contig': 'Bfragilis_0100_000000000001',
+        #      'trna_no': '1',
+        #      'start': 135361,
+        #      'stop': 135433,
+        #      'amino_acid': 'Thr',
+        #      'codon': 'CGT',
+        #      'score': 67.6}}
+        #
+        # and here is one exmple from the rRNA HMMs results dict:
+        #
+        # {1: {'entry_id': 0,
+        #      'gene_name': 'Bacterial_23S_rRNA',
+        #      'gene_hmm_id': '-',
+        #      'contig_name': 'Bfragilis_0100_000000000001',
+        #      'start': 1110877,
+        #      'stop': 1113757,
+        #      'e_value': 0.0}}
+        #
+        # so we will have to make the former look like the latter. I have the feeling that the
+        # score / e_value will cause issues later :(
+
+        missing_amino_acids = Counter()
+        missing_codons = Counter()
+        entries_to_remove = set([])
+        for entry_id in search_results_dict:
+            entry = search_results_dict[entry_id]
+
+            aa, codon = entry['amino_acid'], utils.rev_comp(entry['anticodon'])
+
+            if codon not in self.codons:
+                missing_codons[codon] += 1
+                entries_to_remove.add(entry_id)
+                continue
+
+            if aa not in self.amino_acids:
+                missing_amino_acids[aa] += 1
+                entries_to_remove.add(entry_id)
+                continue
+
+            aa_codon = '%s_%s' % (aa, codon)
+
+            entry['gene_name'] = aa_codon
+            entry['e_value'] = entry['score']
+            entry['gene_hmm_id'] = '-'
+
+        for entry_id in entries_to_remove:
+            search_results_dict.pop(entry_id)
+
+        self.run.info("Num tRNA genes recovered", len(search_results_dict))
+
+        if len(missing_codons):
+            self.run.warning("While anvi'o was trying to parse the output from tRNAScan-SE, it "
+                             "became clear that some of the codons the tool identified was not "
+                             "known to anvi'o, so we conservatively discareded those entries. "
+                             "Here is the list of codons that were discareded and their frequency "
+                             "among your contigs: '%s'." % (', '.join(['%s (%d)' % (codon, missing_codons[codon]) for codon in missing_codons])),
+                             header="WEIRD CODONS ALERT")
+
+        if len(missing_amino_acids):
+            self.run.warning("While anvi'o was trying to parse the output from tRNAScan-SE, it "
+                             "run into some amino acid names that were not known to anvi'o. "
+                             "All those entries are now gone :/ But here is the list of amino "
+                             "acids and their frequencies: '%s'." % (', '.join(['%s (%d)' % (amino_acid, missing_amino_acids[amino_acid]) for amino_acid in missing_amino_acids])),
+                             header="WEIRD AMINO ACIDS ALERT")
+
+        search_results_dict = utils.get_pruned_HMM_hits_dict(search_results_dict)
+
+        tables_for_hmm_hits = TablesForHMMHits(contigs_db_path, run=self.run, progress=self.progress)
+        search_results_dict = tables_for_hmm_hits.add_new_gene_calls_to_contigs_db_and_update_serach_results_dict(self.kind_of_search,
+                                                                                                                  search_results_dict,
+                                                                                                                  skip_amino_acid_sequences=True)
+        tables_for_hmm_hits.append(self.source_name, self.reference, self.kind_of_search, self.domain, self.all_genes_searched_against, search_results_dict)
+
+        if not anvio.DEBUG:
+            self.clean_tmp_directory()
+            self.run.info_single("Temp directory is now cleaned (if you would like to keep it the "
+                                 "next time use the flag `--debug`).")
+        else:
+            self.run.info_single("Due to the `--debug` flag, anvi'o did not remove the temoporary files "
+                                 "directory (which is still at '%s')." % (self.tmp_directory_path))
+
+    def clean_tmp_directory(self):
+        shutil.rmtree(self.tmp_directory_path)

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -159,6 +159,12 @@ class TablesForTransferRNAs:
             entry['gene_name'] = aa_codon
             entry['e_value'] = entry['score']
             entry['gene_hmm_id'] = '-'
+            if entry['stop'] > entry['start']:
+                # so we are forward
+                entry['start'] = entry['start'] - 1 # setting the pythonic start.
+            else:
+                # so this one is reverse
+                entry['stop'] = entry['stop'] - 1
 
         for entry_id in entries_to_remove:
             search_results_dict.pop(entry_id)

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -225,7 +225,7 @@ class TablesForTransferRNAs:
                                         'function': function_text,
                                         'e_value': 0.0}
 
-        gene_function_calls_table = TableForGeneFunctions(contigs_db_path, self.run, self.progress)
+        gene_function_calls_table = TableForGeneFunctions(contigs_db_path, run=terminal.Run(verbose=False), progress=terminal.Progress(verbose=False))
         gene_function_calls_table.create(functions_dict)
 
 
@@ -236,6 +236,7 @@ class TablesForTransferRNAs:
         else:
             self.run.info_single("Due to the `--debug` flag, anvi'o did not remove the temoporary files "
                                  "directory (which is still at '%s')." % (self.tmp_directory_path), nl_before=1)
+
 
     def clean_tmp_directory(self):
         shutil.rmtree(self.tmp_directory_path)

--- a/bin/anvi-run-hmms
+++ b/bin/anvi-run-hmms
@@ -16,6 +16,7 @@ available_hmm_sources = list(hmm_data.sources.keys())
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 from anvio.tables.hmmhits import TablesForHMMHits
+from anvio.tables.trnahits import TablesForTransferRNAs
 
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
@@ -69,6 +70,12 @@ def main(args):
     search_tables = TablesForHMMHits(args.contigs_db, num_threads_to_use = args.num_threads)
     search_tables.populate_search_tables(sources)
 
+    if not args.hmm_profile_dir and not args.installed_hmm_profile and not args.skip_scanning_trnas:
+        tables_for_trna_hits = TablesForTransferRNAs(args)
+        tables_for_trna_hits.populate_search_tables(args.contigs_db)
+
+
+
 
 if __name__ == '__main__':
     import argparse
@@ -88,6 +95,12 @@ if __name__ == '__main__':
                                                 (len(available_hmm_sources),
                                                  ', '.join(['"%s" (type: %s)' % (s, hmm_data.sources[s]['kind']) \
                                                                                     for s in available_hmm_sources]))}))
+    groupC = parser.add_argument_group("tRNAs", "If you are running this program with everything, it will also scan "
+                                                "Transfer RNA sequences in your contigs database for free. But if you "
+                                                "do not like tRNAs for some reason (you're not alone) you can skip that "
+                                                "step.")
+    groupC.add_argument(*anvio.A('skip-scanning-trnas'), **anvio.K('skip-scanning-trnas'))
+
     groupD = parser.add_argument_group("PERFORMANCE", "Stuff everyone forgets to set and then get upset with how slow "
                                                       "science goes.")
     groupD.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))

--- a/bin/anvi-run-hmms
+++ b/bin/anvi-run-hmms
@@ -74,16 +74,23 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description=__description__)
 
-    parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
-    parser.add_argument(*anvio.A('hmm-profile-dir'), **anvio.K('hmm-profile-dir'))
-    parser.add_argument(*anvio.A('installed-hmm-profile'), **anvio.K('installed-hmm-profile', {'help': "When you run this\
+    groupA = parser.add_argument_group("DB", "An anvi'o contigs adtabase to populate with HMM hits")
+    groupA.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+
+    groupB = parser.add_argument_group("HMM OPTIONS", "If you have your own HMMs, or if you would like to run only a set of "
+                                                      "default anvi'o HMM profiles rather than running them all, this is "
+                                                      "your stop.")
+    groupB.add_argument(*anvio.A('hmm-profile-dir'), **anvio.K('hmm-profile-dir'))
+    groupB.add_argument(*anvio.A('installed-hmm-profile'), **anvio.K('installed-hmm-profile', {'help': "When you run this\
                                   program without any parameter, it runs all %d HMM profiles installed on your system. If\
                                   you want only a specific one to run, you can select it by using this parameter. These\
                                   are the currently available ones: %s." % \
                                                 (len(available_hmm_sources),
                                                  ', '.join(['"%s" (type: %s)' % (s, hmm_data.sources[s]['kind']) \
                                                                                     for s in available_hmm_sources]))}))
-    parser.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
+    groupD = parser.add_argument_group("PERFORMANCE", "Stuff everyone forgets to set and then get upset with how slow "
+                                                      "science goes.")
+    groupD.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
 
     args = anvio.get_args(parser)
 

--- a/bin/anvi-scan-trnas
+++ b/bin/anvi-scan-trnas
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+
+import anvio
+import anvio.terminal as terminal
+
+from anvio.tables.trnahits import TablesForTransferRNAs
+from anvio.errors import ConfigError, FilesNPathsError
+from anvio.terminal import time_program
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "A. Murat Eren"
+__email__ = "a.murat.eren@gmail.com"
+__requires__ = ['contigs-db',]
+__provides__ = ['trna-genes',]
+__description__ = ("Identify and store tRNA genes in a contigs database.")
+
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+
+@time_program
+def main(args):
+    tables_for_trna_hits = TablesForTransferRNAs(args)
+    tables_for_trna_hits.populate_search_tables(args.contigs_db)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description=__description__)
+
+    parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+    parser.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
+    parser.add_argument(*anvio.A('log-file'), **anvio.K('log-file'))
+    parser.add_argument(*anvio.A('trna-hits-file'), **anvio.K('trna-hits-file'))
+    parser.add_argument(*anvio.A('trna-cutoff-score'), **anvio.K('trna-cutoff-score'))
+
+    args = anvio.get_args(parser)
+
+    try:
+        main(args)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)
+    except FilesNPathsError as e:
+        print(e)
+        sys.exit(-2)


### PR DESCRIPTION
This PR introduces a new feature to anvi'o through a new program, `anvi-scan-trnas`, to identify transfer RNAs in contigs databases, and add them into the database as new gene calls.

An example. `Bfragilis_0100-contigs.db` is a regular contigs database on which `anvi-run-hmms` was already run:

```
anvi-get-sequences-for-hmm-hits -c Bfragilis_0100-contigs.db --list-hmm-sources
* CPSHMM [type: CPS] [num genes: 1]
* Bacteria_71 [type: singlecopy] [num genes: 71]
* Archaea_76 [type: singlecopy] [num genes: 76]
* Protista_83 [type: singlecopy] [num genes: 83]
* Ribosomal_RNAs [type: Ribosomal_RNAs] [num genes: 12]
```

When I run `anvi-scan-trnas`, this is what happens:

```
$ anvi-scan-trnas -c Bfragilis_0100-contigs.db --num-threads 5
tRNAscan-SE version found ....................: 2.0.5

Temporary dir ................................: /var/folders/x5/gt4031w53fs63csv1fp0r_3w0000gn/T/tmpdwvvuafl
FASTA file for contigs .......................: /var/folders/x5/gt4031w53fs63csv1fp0r_3w0000gn/T/tmpdwvvuafl/contig_sequences.fa
tRNA hits output .............................: /var/folders/x5/gt4031w53fs63csv1fp0r_3w0000gn/T/tmpdwvvuafl/hits_file.txt
Log file .....................................: /var/folders/x5/gt4031w53fs63csv1fp0r_3w0000gn/T/tmpdwvvuafl/log.txt
Cutoff score .................................: 20
tRNAscan-SE version found ....................: 2.0.5


CITATION
===============================================
Anvi'o will use 'tRNAScan-SE' by Chan and Lowe (doi:10.1007/978-1-4939-9173-0_1)
to identify tRNA sequences in your data. When you publish your findings, please
do not forget to properly credit their work.

Num tRNA genes parsed ........................: 77
Num tRNA genes recovered .....................: 76

WEIRD CODONS ALERT
===============================================
While anvi'o was trying to parse the output from tRNAScan-SE, it became clear
that some of the codons the tool identified was not known to anvi'o, so we
conservatively discareded those entries. Here is the list of codons that were
discareded and their frequency among your contigs: 'NNN (1)'.

Gene calls added to db .......................: 76 (from source "Transfer_RNAs")
* Temp directory is now cleaned (if you would like to keep it the next time use
the flag `--debug`).

✓ anvi-scan-trnas took 0:00:05.348886
```

Aaand voilà (notice `Transfer_RNAs` at the end):

```
 anvi-get-sequences-for-hmm-hits -c Bfragilis_0100-contigs.db --list-hmm-sources
* CPSHMM [type: CPS] [num genes: 1]
* Bacteria_71 [type: singlecopy] [num genes: 71]
* Archaea_76 [type: singlecopy] [num genes: 76]
* Protista_83 [type: singlecopy] [num genes: 83]
* Ribosomal_RNAs [type: Ribosomal_RNAs] [num genes: 12]
* Transfer_RNAs [type: Transfer_RNAs] [num genes: 61]
```

Because it goes into the HMMs tables as the `anvio/tables/trnahits.py` doctors the to fit into the HMMs workflow, everything else works. Such as,

```
$ anvi-get-sequences-for-hmm-hits -c Bfragilis_0100-contigs.db \
                                  --hmm-source Transfer_RNAs \
                                  -o trnas.fa

Contigs DB ...................................: Initialized: Bfragilis_0100-contigs.db (v. 14)
Hits .........................................: 76 hits for 1 source(s)
Mode .........................................: DNA sequences
Genes are concatenated .......................: False
Output .......................................: trnas.fa
```

The resulting file looks like this:

```
$ head -n 20 trnas.fa
>Thr_ACG___Transfer_RNAs___251692f466b8467c13e7a42bb49810d73bef551dfe212bfa1ffdbd28 bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:67.6|contig:Bfragilis_0100_000000000001|gene_callers_id:4426|start:135361|stop:135433|length:72
CCGCTATAGCTCAGTTGGTAGAGCAACGCATTCGTAACGCGTAGGTCTCCAGTTCAAGTCTGGATAGCGGCT
>Thr_ACA___Transfer_RNAs___ef00abaac23964a5cba778f8a312ad283053fb1480d3fffc6ebeb617 bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:69.6|contig:Bfragilis_0100_000000000001|gene_callers_id:4427|start:448045|stop:448120|length:75
CCTCTTTAGCTCAGTTGGCCAGAGCACGTGATTTGTAATCTCGGGGTCGTTGGTTCGAATCCGACAAGAGGCTCA
>Cys_TGC___Transfer_RNAs___f0011e5cca43be77138d81e41ad7581d31508300d703e6a8d748b93e bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:56|contig:Bfragilis_0100_000000000001|gene_callers_id:4440|start:476759|stop:476830|length:71
GGTTCCTTGGATGAGTGGTTTAGTCAGCGGTCTGCAAAACCGTGTACGGCGGTTCGAATCCGCCAGGAACC
>Ser_TCA___Transfer_RNAs___a6b63471ad154fcc5dab88bf324aed80fd4027d86e8931a32497aafd bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:65.7|contig:Bfragilis_0100_000000000001|gene_callers_id:4439|start:511856|stop:511940|length:84
GGAGAGGTGGCAGAGTGGTCGATTGCGGCGGTCTTGAAAACCGTTGTACTGCGAGGTACCCGGGGTTCGAATCCCTGTCTCTCC
>Ser_TCA___Transfer_RNAs___ae886868ba161d8e6cf92ec9367de1e7b96f988f107e63acf021cc2a bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:65.7|contig:Bfragilis_0100_000000000001|gene_callers_id:4438|start:615303|stop:615387|length:84
GGAGAGGTGGCAGAGTGGTCGATTGCGGCGGTCTTGAAAACCGTTGTACTGCGAGGTACCCGGGGTTCGAATCCCTGTCTCTCC
>Tyr_TAC___Transfer_RNAs___63295383180d2ae19cba0d2dd353dd872a9ba8ab5720ebf9cdd49e14 bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:64.3|contig:Bfragilis_0100_000000000001|gene_callers_id:4428|start:915005|stop:915087|length:82
GGCAAATACCAGAGTGGCCAAATGGGGCAGACTGTAAATCTGCTGTCTTTCGACTTCGGTGGTTCGAATCCATCTTTGCCCA
>Gly_GGA___Transfer_RNAs___3187f17f7b5d5ddd95c8b7a966e8180a9c3e89f7b4ca30dd63281d53 bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:67|contig:Bfragilis_0100_000000000001|gene_callers_id:4429|start:915096|stop:915168|length:72
CGGAAGTAGCTCAGTTGATAGAGCATTAGCCTTCCAAGCTGAGGGTCGCGGGTTTGAGCCCCGTCTTCCGCT
>Gln_CAA___Transfer_RNAs___42ecaf4d6c9ac5d80b98cce8a83358d9505b93c122ea74539c827c98 bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:48.5|contig:Bfragilis_0100_000000000001|gene_callers_id:4437|start:950062|stop:950132|length:70
TGTCCTATGGTGTAATGGTAGCACAACAGTTTTTGGTTCTGTTTGTCTAAGTTCGAATCTTGGTAGGACA
>Ile_ATC___Transfer_RNAs___1f5ae90b82f73bf28c7300336d6cea28ef4c63dd0b6df50c85547638 bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:71.6|contig:Bfragilis_0100_000000000001|gene_callers_id:4430|start:1110543|stop:1110619|length:76
GTCCTATAGCTCAGTTGGTTAGAGCGCTACACTGATAATGTAGAGGTCGGCAGTTCAACTCTGCCTGGGACTACCA
>Ala_GCA___Transfer_RNAs___329787e5a4afa1b1a3abc9bd4e11dbdd24edb38daea58b4e8facd5fc bin_id:Bfragilis_0100-contigs|source:Transfer_RNAs|e_value:71|contig:Bfragilis_0100_000000000001|gene_callers_id:4431|start:1110646|stop:1110722|length:76
GGGGATTAGCTCAGCTGGCTAGAGCATCTGCCTTGCACGCAGAGGGTCAACGGTTCGAATCCGTTATTCTCCACCA
```

So far so good.

In fact, we can even see them in the interface automatically:

![image](https://user-images.githubusercontent.com/197307/72847125-89d5a700-3c67-11ea-8ba2-89c9047fafa4.png)

And in the inspect page:

![image](https://user-images.githubusercontent.com/197307/72847197-aa9dfc80-3c67-11ea-9fb5-ef8cf0fb6b06.png)

The only problem I see is that we don't actually see what amino acid and codon a given tRNA gene is about. We will have to fix that at some point:

![image](https://user-images.githubusercontent.com/197307/72847282-dde08b80-3c67-11ea-9f5b-5802fef5eabe.png)

_Update:_

Now it is fixed.

![image](https://user-images.githubusercontent.com/197307/72928151-17270300-3d1d-11ea-84d5-b1db4d9610d4.png)

By populating gene functions table with this information enables us to search through the interface for tRNAs by amino acid they decode,

![image](https://user-images.githubusercontent.com/197307/72928389-84d32f00-3d1d-11ea-90cd-c0829e0faba5.png)

Highlight results in the display with one button:

![image](https://user-images.githubusercontent.com/197307/72928715-13e04700-3d1e-11ea-9515-c3e6297dcc2a.png)

and/or doing this without a line of additional code from the terminal:

```
anvi-search-functions -c Bfragilis_0100-contigs.db \
                                       --search-terms Trp \
                                       --verbose \
                                       --full-report full-report.txt \
                                       --include-sequences

Searching in Contigs Database ................: Bfragilis_0100-contigs.db
Contigs DB ...................................: Initialized: Bfragilis_0100-contigs.db (v. 14)
Search terms .................................: 1 found
Matches ......................................: 2 unique gene calls contained the search term "Trp"

Matching names for 'Trp' (up to 25)
===============================================
tRNA gene for amino acid Trp (codon: CAG; anticodon:CCA; score:72.9)

Items additional data compatible output ......: search_results.txt
Full report ..................................: full-report.txt


cat full-report.txt
gene_callers_id	source	accession	function	search_term	contigs	direction	rev_compd	dna_sequence	aa_sequence
4828	Transfer_RNAs	Gln_CAG_4828	tRNA gene for amino acid Trp (codon: CAG; anticodon:CCA; score:72.9)	Trp	Bfragilis_0100_000000000002_split_00063	f	False	CGGGAGTAGCTCAGTTGGTAGAGCACCGGTCTCCAAAACCGGGTGTCGGGAGTTCGAGCCTCTCCTCCCGTG
4843	Transfer_RNAs	Gln_CAG_4843	tRNA gene for amino acid Trp (codon: CAG; anticodon:CCA; score:72.9)	Trp	Bfragilis_0100_000000000002_split_00011	r	True	ACGGGAGTAGCTCAGTTGGTAGAGCACCGGTCTCCAAAACCGGGTGTCGGGAGTTCGAGCCTCTCCTCCCGT
```


I think the design is not too dirty, and being able to add tRNAs into our current HMMs infrastructure with minimal change in the codebase attests to that :) @semiller10, I think it would be great if you were to run this on a genome and make sure that things check out.