### PR TITLE
Profile improvements

### DIFF
--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -131,17 +131,33 @@ class Contig:
         x = anvio.terminal.compare_times(x)
         print(x)
 
-
         self.coverage.run(bam, self, method='accurate2', ignore_orphans=self.ignore_orphans)
         c = self.coverage.c
-        self.coverage.run(bam, self, method='approximate')
+        self.coverage.run(bam, self, method='accurate')
         cc = self.coverage.c
-        assert numpy.array_equal(c, cc)
 
         for split in self.splits:
             split.coverage = Coverage()
             split.coverage.c = self.coverage.c[split.start:split.end]
             split.coverage.process_c(split.coverage.c)
+
+            if split.name == 'cluster_000005_CACHEF01_000000000007_split_00001':
+                c_split = c[split.start:split.end]
+                cc_split = cc[split.start:split.end]
+                print('asdfasdfasdf')
+                print('asdfasdfasdf')
+                print('asdfasdfasdf')
+                print('asdfasdfasdf')
+
+                print(len(numpy.nonzero(c_split - cc_split)[0]))
+                print(numpy.sum(c_split - cc_split))
+                print(numpy.nonzero(c_split - cc_split))
+                print(c_split[numpy.nonzero(c_split - cc_split)[0][0]])
+                print(cc_split[numpy.nonzero(c_split - cc_split)[0][0]])
+                print('asdfasdfasdf')
+                print('asdfasdfasdf')
+                print('asdfasdfasdf')
+                print('asdfasdfasdf')
 
 
     def analyze_auxiliary(self, bam):

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -8,6 +8,7 @@ import os
 import re
 import io
 import gzip
+import numpy
 import string
 import argparse
 
@@ -107,19 +108,33 @@ class Contig:
 
 
     def analyze_coverage(self, bam):
-        contig_coverage = []
+        with anvio.terminal.TimeCode(success_msg="old: ") as old_time:
+            contig_coverage = []
 
-        counter = 1
-        for split in self.splits:
-            split.coverage = Coverage()
-            split.coverage.run(bam, split, 
-                            ignore_orphans=self.ignore_orphans, 
-                            max_coverage_depth=self.max_coverage_depth)
-            contig_coverage.extend(split.coverage.c)
+            counter = 1
+            for split in self.splits:
+                split.coverage = Coverage()
+                split.coverage.run(bam, split,
+                                   ignore_orphans=self.ignore_orphans,
+                                   max_coverage_depth=self.max_coverage_depth)
+                contig_coverage.extend(split.coverage.c)
 
-            counter += 1
+                counter += 1
 
-        self.coverage.process_c(contig_coverage)
+            contig_coverage = numpy.asarray(contig_coverage)
+            self.coverage.process_c(contig_coverage)
+
+        with anvio.terminal.TimeCode(success_msg="new: ") as new_time:
+            contig_coverage = numpy.zeros(self.length)
+
+            for split in self.splits:
+                split.coverage = Coverage()
+                split.coverage.run(bam, split, ignore_orphans=self.ignore_orphans, max_coverage_depth=self.max_coverage_depth)
+                contig_coverage[split.start:split.end] = split.coverage.c
+
+            self.coverage.process_c(contig_coverage)
+
+        print(old_time.time - new_time.time)
 
 
     def analyze_auxiliary(self, bam):

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -3,6 +3,7 @@
 """Classes and functions for handling, storing, and retrieving atomic data
    from contigs and splits. Also includes classes to deal with external
    contig data such as GenbankToAnvio."""
+timesave=[]
 
 import os
 import re
@@ -108,7 +109,8 @@ class Contig:
 
 
     def analyze_coverage(self, bam):
-        with anvio.terminal.TimeCode(success_msg='old: ') as old_time:
+        global timesave
+        with anvio.terminal.TimeCode(success_msg='old: ', quiet=True) as old_time:
             contig_coverage = numpy.zeros(self.length).astype(int)
 
             old_splits = []
@@ -121,7 +123,7 @@ class Contig:
             self.coverage.process_c(contig_coverage)
             old_contig = contig_coverage
 
-        with anvio.terminal.TimeCode(success_msg='new: ') as new_time:
+        with anvio.terminal.TimeCode(success_msg='new: ', quiet=True) as new_time:
 
             self.coverage.run(bam, self, ignore_orphans=self.ignore_orphans, max_coverage_depth=self.max_coverage_depth)
 
@@ -134,7 +136,12 @@ class Contig:
 
             new_contig = self.coverage.c
 
-        print(old_time.time - new_time.time)
+        dt = old_time.time.total_seconds() - new_time.time.total_seconds()
+        timesave.append(dt)
+        print('')
+        print(f'{len(self.splits)} split(s)')
+        print('{:.3f} seconds saved'.format(dt))
+        print('{:.3f} total running seconds saved'.format(sum(timesave)))
         assert numpy.array_equal(new_contig, old_contig)
         for i, j in zip(old_splits, new_splits):
             assert numpy.array_equal(i, j)

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -124,8 +124,10 @@ class Contig:
             contig_coverage = numpy.asarray(contig_coverage)
             self.coverage.process_c(contig_coverage)
 
+            old = contig_coverage
+
         with anvio.terminal.TimeCode(success_msg="new: ") as new_time:
-            contig_coverage = numpy.zeros(self.length)
+            contig_coverage = numpy.zeros(self.length).astype(int)
 
             for split in self.splits:
                 split.coverage = Coverage()
@@ -134,7 +136,10 @@ class Contig:
 
             self.coverage.process_c(contig_coverage)
 
+            new = contig_coverage
+
         print(old_time.time - new_time.time)
+        assert numpy.array_equal(old, new)
 
 
     def analyze_auxiliary(self, bam):

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -108,38 +108,14 @@ class Contig:
 
 
     def analyze_coverage(self, bam):
-        with anvio.terminal.TimeCode(success_msg="old: ") as old_time:
-            contig_coverage = []
+        contig_coverage = numpy.zeros(self.length).astype(int)
 
-            counter = 1
-            for split in self.splits:
-                split.coverage = Coverage()
-                split.coverage.run(bam, split,
-                                   ignore_orphans=self.ignore_orphans,
-                                   max_coverage_depth=self.max_coverage_depth)
-                contig_coverage.extend(split.coverage.c)
+        for split in self.splits:
+            split.coverage = Coverage()
+            split.coverage.run(bam, split, ignore_orphans=self.ignore_orphans, max_coverage_depth=self.max_coverage_depth)
+            contig_coverage[split.start:split.end] = split.coverage.c
 
-                counter += 1
-
-            contig_coverage = numpy.asarray(contig_coverage)
-            self.coverage.process_c(contig_coverage)
-
-            old = contig_coverage
-
-        with anvio.terminal.TimeCode(success_msg="new: ") as new_time:
-            contig_coverage = numpy.zeros(self.length).astype(int)
-
-            for split in self.splits:
-                split.coverage = Coverage()
-                split.coverage.run(bam, split, ignore_orphans=self.ignore_orphans, max_coverage_depth=self.max_coverage_depth)
-                contig_coverage[split.start:split.end] = split.coverage.c
-
-            self.coverage.process_c(contig_coverage)
-
-            new = contig_coverage
-
-        print(old_time.time - new_time.time)
-        assert numpy.array_equal(old, new)
+        self.coverage.process_c(contig_coverage)
 
 
     def analyze_auxiliary(self, bam):

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -159,9 +159,9 @@ class Split:
 
 
 class Auxiliary:
-    def __init__(self, split, bam, parent_outlier_positions, 
-                 min_coverage=10, 
-                 report_variability_full=False, 
+    def __init__(self, split, bam, parent_outlier_positions,
+                 min_coverage=10,
+                 report_variability_full=False,
                  ignore_orphans=False,
                  max_coverage_depth=constants.max_depth_for_coverage):
         self.v = []
@@ -182,7 +182,7 @@ class Auxiliary:
     def run(self, bam):
         ratios = []
 
-        for pileupcolumn in bam.pileup(self.split.parent, self.split.start, self.split.end, 
+        for pileupcolumn in bam.pileup(self.split.parent, self.split.start, self.split.end,
                                     ignore_orphans=self.ignore_orphans, max_depth=self.max_coverage_depth):
 
             pos_in_contig = pileupcolumn.pos

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -108,56 +108,12 @@ class Contig:
 
 
     def analyze_coverage(self, bam):
-        x = [
-            (
-                'oldschool',
-                self.coverage.run,
-                [bam, self],
-                {'method': 'accurate2', 'ignore_orphans':self.ignore_orphans}
-            ),
-            (
-                'accurate',
-                self.coverage.run,
-                [bam, self],
-                {'method': 'accurate'}
-            ),
-            (
-                'approximate',
-                self.coverage.run,
-                [bam, self],
-                {'method': 'approximate'}
-            ),
-        ]
-        x = anvio.terminal.compare_times(x)
-        print(x)
-
-        self.coverage.run(bam, self, method='accurate2', ignore_orphans=self.ignore_orphans)
-        c = self.coverage.c
         self.coverage.run(bam, self, method='accurate')
-        cc = self.coverage.c
 
         for split in self.splits:
             split.coverage = Coverage()
             split.coverage.c = self.coverage.c[split.start:split.end]
             split.coverage.process_c(split.coverage.c)
-
-            if split.name == 'cluster_000005_CACHEF01_000000000007_split_00001':
-                c_split = c[split.start:split.end]
-                cc_split = cc[split.start:split.end]
-                print('asdfasdfasdf')
-                print('asdfasdfasdf')
-                print('asdfasdfasdf')
-                print('asdfasdfasdf')
-
-                print(len(numpy.nonzero(c_split - cc_split)[0]))
-                print(numpy.sum(c_split - cc_split))
-                print(numpy.nonzero(c_split - cc_split))
-                print(c_split[numpy.nonzero(c_split - cc_split)[0][0]])
-                print(cc_split[numpy.nonzero(c_split - cc_split)[0][0]])
-                print('asdfasdfasdf')
-                print('asdfasdfasdf')
-                print('asdfasdfasdf')
-                print('asdfasdfasdf')
 
 
     def analyze_auxiliary(self, bam):

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -108,7 +108,7 @@ class Contig:
 
 
     def analyze_coverage(self, bam):
-        self.coverage.run(bam, self, ignore_orphans=self.ignore_orphans, max_coverage_depth=self.max_coverage_depth)
+        self.coverage.run(bam, self, ignore_orphans=self.ignore_orphans)
 
         for split in self.splits:
             split.coverage = Coverage()

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -108,7 +108,35 @@ class Contig:
 
 
     def analyze_coverage(self, bam):
-        self.coverage.run(bam, self, ignore_orphans=self.ignore_orphans)
+        x = [
+            (
+                'oldschool',
+                self.coverage.run,
+                [bam, self],
+                {'method': 'accurate2', 'ignore_orphans':self.ignore_orphans}
+            ),
+            (
+                'accurate',
+                self.coverage.run,
+                [bam, self],
+                {'method': 'accurate'}
+            ),
+            (
+                'approximate',
+                self.coverage.run,
+                [bam, self],
+                {'method': 'approximate'}
+            ),
+        ]
+        x = anvio.terminal.compare_times(x)
+        print(x)
+
+
+        self.coverage.run(bam, self, method='accurate2', ignore_orphans=self.ignore_orphans)
+        c = self.coverage.c
+        self.coverage.run(bam, self, method='approximate')
+        cc = self.coverage.c
+        assert numpy.array_equal(c, cc)
 
         for split in self.splits:
             split.coverage = Coverage()

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -673,7 +673,6 @@ class BAMProfiler(dbops.ContigsSuperclass):
         last_memory_update = int(time.time())
 
         self.progress.update('contigs are being processed ...')
-        self.progress.increment(recieved_contigs)
         while recieved_contigs < self.num_contigs:
             try:
                 contig = output_queue.get()
@@ -691,6 +690,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
                     memory_usage = utils.get_total_memory_usage()
                     last_memory_update = int(time.time())
 
+                self.progress.increment(recieved_contigs)
                 self.progress.update('%d of %d contigs ⚙  / MEM ☠️  %s' % \
                             (recieved_contigs, self.num_contigs, memory_usage or '??'))
 

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -175,20 +175,20 @@ class Coverage:
 
         if isinstance(contig_or_split, anvio.contigops.Split):
             contig_name = contig_or_split.parent
-            if not start: start = contig_or_split.start
-            if not end: end = contig_or_split.end
+            start = contig_or_split.start if not start else start
+            end = contig_or_split.end if not end else end
 
         elif isinstance(contig_or_split, anvio.contigops.Contig):
             contig_name = contig_or_split.name
-            if not start: start = 0
-            if not end: end = contig_or_split.length
+            start = 0 if not start else start
+            end = contig_or_split.length if not end else end
 
         elif isinstance(contig_or_split, str):
             contig_name = contig_or_split
             if contig_name not in bam.references:
                 raise ConfigError('Coverage.run :: Your contig %s was not found in the bam file' % contig_name)
-            if not start: start = 0
-            if not end: end = dict(zip(bam.references, bam.lengths))[contig_name]
+            start = 0 if not start else start
+            end = dict(zip(bam.references, bam.lengths))[contig_name] if not end else end
 
         else:
             raise ConfigError("Coverage.run :: You can't pass an object of type %s as contig_or_split" % type(contig_or_split))

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -3,10 +3,7 @@
 
 '''Primitive classes for basic DNA sequence properties.'''
 
-test = []
-
 import numpy
-import pysamstats
 import collections
 
 from itertools import permutations
@@ -155,7 +152,7 @@ class Coverage:
         self.mean_Q2Q3 = 0.0
 
 
-    def run(self, bam, contig_or_split, start=None, end=None, ignore_orphans=False, max_coverage_depth=constants.max_depth_for_coverage):
+    def run(self, bam, contig_or_split, start=None, end=None, ignore_orphans=False):
         """Loop through the bam pileup and calculate coverage over a defined region of a contig or split
 
         Parameters
@@ -196,31 +193,11 @@ class Coverage:
         else:
             raise ConfigError("Coverage.run :: You can't pass an object of type %s as contig_or_split" % type(contig_or_split))
 
-        with anvio.terminal.TimeCode(quiet=True) as old:
-            # a coverage array the size of the defined range is allocated in memory
-            self.c = numpy.zeros(end - start).astype(int)
+        # a coverage array the size of the defined range is allocated in memory
+        self.c = numpy.zeros(end - start).astype(int)
 
-            for pileupcolumn in bam.pileup(contig_name, start, end, ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
-                if pileupcolumn.pos < start or pileupcolumn.pos >= end:
-                    continue
-
-                self.c[pileupcolumn.pos - start] = pileupcolumn.n
-
-        with anvio.terminal.TimeCode(quiet=True) as new:
-            # a coverage array the size of the defined range is allocated in memory
-            self.c = numpy.zeros(end - start).astype(int)
-
-            for read in bam.fetch(contig_name, start, end):
-                self.cc[read.reference_start:read.reference_end] += 1
-
-
-        global test
-        dt = old.time.total_seconds() - new.time.total_seconds()
-        print('')
-        test.append(dt)
-        print(f"{dt} seconds saved")
-        print(f"{sum(test)} total running seconds saved")
-        assert numpy.array_equal(self.cc, self.c)
+        for read in bam.fetch(contig_name, start, end):
+            self.c[read.reference_start:read.reference_end] += 1
 
         if len(self.c):
             try:

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -207,14 +207,12 @@ class Coverage:
                 self.c[pileupcolumn.pos - start] = pileupcolumn.n
 
         with anvio.terminal.TimeCode(quiet=True) as new:
-            self.cc = pysamstats.load_coverage(
-                bam,
-                chrom=contig_name,
-                start=start,
-                end=end,
-                pad=True, 
-                fields=['reads_all']
-            )
+            # a coverage array the size of the defined range is allocated in memory
+            self.c = numpy.zeros(end - start).astype(int)
+
+            for read in bam.fetch(contig_name, start, end):
+                self.cc[read.reference_start:read.reference_end] += 1
+
 
         global test
         dt = old.time.total_seconds() - new.time.total_seconds()

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -151,52 +151,21 @@ class Coverage:
 
 
     def run(self, bam, split, ignore_orphans=False, max_coverage_depth=constants.max_depth_for_coverage):
-        with anvio.terminal.TimeCode(success_msg='new: ', quiet=True) as new_time:
-            # a coverage array the size of the split is allocated in memory
-            self.c = numpy.zeros(split.end - split.start).astype(int)
+        # a coverage array the size of the split is allocated in memory
+        self.c = numpy.zeros(split.end - split.start).astype(int)
 
-            for pileupcolumn in bam.pileup(split.parent, split.start, split.end, ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
-                if pileupcolumn.pos < split.start or pileupcolumn.pos >= split.end:
-                    continue
+        for pileupcolumn in bam.pileup(split.parent, split.start, split.end, ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
+            if pileupcolumn.pos < split.start or pileupcolumn.pos >= split.end:
+                continue
 
-                self.c[pileupcolumn.pos - split.start] = pileupcolumn.n
+            self.c[pileupcolumn.pos - split.start] = pileupcolumn.n
 
-
-            if len(self.c):
-                split.explicit_length = len(self.c)
-                self.process_c(self.c)
-
-            new = self.c
-
-        with anvio.terminal.TimeCode(success_msg='old: ', quiet=True) as old_time:
-            coverage_profile = {}
-            self.c = []
-
-            for pileupcolumn in bam.pileup(split.parent, split.start, split.end, 
-                                           ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
-                if pileupcolumn.pos < split.start or pileupcolumn.pos >= split.end:
-                    continue
-
-                coverage_profile[pileupcolumn.pos] = pileupcolumn.n
-
-            for i in range(split.start, split.end):
-                if i in coverage_profile:
-                    self.c.append(coverage_profile[i])
-                else:
-                    self.c.append(0)
-
-            if self.c:
-                split.explicit_length = len(self.c)
-                self.process_c(self.c)
-
-            old = self.c
-
-        print(old_time.time-new_time.time)
-        assert numpy.array_equal(old, new)
+        if len(self.c):
+            split.explicit_length = len(self.c)
+            self.process_c(self.c)
 
 
     def process_c(self, c):
-        c = numpy.asarray(c)
         self.min = numpy.amin(c)
         self.max = numpy.amax(c)
         self.median = numpy.median(c)

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -3,8 +3,6 @@
 
 '''Primitive classes for basic DNA sequence properties.'''
 
-test = []
-
 import numpy
 import collections
 
@@ -174,7 +172,6 @@ class Coverage:
             The index end of where coverage is calculated. Relative to the contig, even when
             `contig_or_split` is a Split object.
         """
-        global test
 
         if isinstance(contig_or_split, anvio.contigops.Split):
             contig_name = contig_or_split.parent
@@ -196,27 +193,17 @@ class Coverage:
         else:
             raise ConfigError("Coverage.run :: You can't pass an object of type %s as contig_or_split" % type(contig_or_split))
 
-        with anvio.terminal.TimeCode(quiet=True) as old:
-            # a coverage array the size of the defined range is allocated in memory
-            self.c = numpy.zeros(end - start).astype(int)
+        # a coverage array the size of the defined range is allocated in memory
+        self.c = numpy.zeros(end - start).astype(int)
 
-            for pileupcolumn in bam.pileup(contig_name, start, end, ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
-                if pileupcolumn.pos < start or pileupcolumn.pos >= end:
-                    # NOTE It is not understood what causes the pileup iterator to give pileup positions
-                    #      outside of the explicitly defined start and end. These positions are
-                    #      nevertheless a minority
-                    continue
+        for pileupcolumn in bam.pileup(contig_name, start, end, ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
+            if pileupcolumn.pos < start or pileupcolumn.pos >= end:
+                # NOTE It is not understood what causes the pileup iterator to give pileup positions
+                #      outside of the explicitly defined start and end. These positions are
+                #      nevertheless a minority
+                continue
 
-                self.c[pileupcolumn.pos - start] = pileupcolumn.n
-
-        with anvio.terminal.TimeCode(quiet=True) as new:
-            dummy = bam.count_coverage(contig_name, start, end)
-
-        print('')
-        dt = old.time.total_seconds() - new.time.total_seconds()
-        test.append(dt)
-        print(f'{dt} seconds saved')
-        print(f'{sum(test)} total running seconds saved')
+            self.c[pileupcolumn.pos - start] = pileupcolumn.n
 
         if len(self.c):
             try:

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -160,7 +160,7 @@ class Coverage:
 
         Parameters
         ==========
-        bam : pysam.Samfile
+        bam : pysam.Samfile (deprecated) or pysam.AlignmentFile
 
         contig_or_split : anvio.contigops.Split or anvio.contigops.Contig or str
             If Split object is passed, and `start` or `end` are None, they are automatically set to

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -196,10 +196,8 @@ class Coverage:
 
         elif isinstance(contig_or_split, str):
             contig_name = contig_or_split
-            if contig_name not in bam.references:
-                raise ConfigError('Coverage.run :: Your contig %s was not found in the bam file' % contig_name)
             start = 0 if not start else start
-            end = dict(zip(bam.references, bam.lengths))[contig_name] if not end else end
+            end = bam.get_reference_length(contig_name) if not end else end
 
         else:
             raise ConfigError("Coverage.run :: You can't pass an object of type %s as contig_or_split" % type(contig_or_split))

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -198,6 +198,9 @@ class Coverage:
 
         for pileupcolumn in bam.pileup(contig_name, start, end, ignore_orphans=ignore_orphans, max_depth=max_coverage_depth):
             if pileupcolumn.pos < start or pileupcolumn.pos >= end:
+                # NOTE It is not understood what causes the pileup iterator to give pileup positions
+                #      outside of the explicitly defined start and end. These positions are
+                #      nevertheless a minority
                 continue
 
             self.c[pileupcolumn.pos - start] = pileupcolumn.n

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -662,6 +662,56 @@ class TimeCode(object):
         self.run.info_single(msg + str(self.time), nl_before=1, mc=color, level=return_code)
 
 
+def compare_times(calls, as_matrix=False, as_datetime=False):
+    """Compare times between function calls
+
+    Parameters
+    ==========
+    calls : list of tuples
+        Each element should be a (name, function, args, kwargs) tuples. If there are no args or
+        kwargs, the element should look like (name, function, [], {})
+
+    as_matrix : bool, False
+        If True, results are output as a pandas matrix, where each element is a time difference between
+        calls. Otherwise, a dictionary is returned
+
+    as_datetime : bool, False
+        If True, times are datetime objects (by default they are floats [seconds])
+
+    Returns
+    =======
+    times : pd.DataFrame or dict
+        If as_matrix, pd.DataFrame is returned, where times[i, j] is how much faster i is than j.
+        Otherwise, dictionary of {name: time} is returned
+    """
+
+    call_times = []
+    names = []
+    for call in calls:
+        name, function, args, kwargs = call
+        names.append(name)
+        with TimeCode(quiet=True) as t:
+            function(*args, **kwargs)
+
+        call_times.append(t.time.total_seconds() if not as_datetime else t.time)
+
+    if not as_matrix:
+        return dict(zip(names, call_times))
+
+    import pandas as pd
+
+    matrix = []
+    for i, time in enumerate(call_times):
+        row = []
+
+        for j, time in enumerate(call_times):
+            row.append(call_times[j] - call_times[i] if i > j else 'NA')
+
+        matrix.append(row)
+
+    return pd.DataFrame(matrix, columns=names, index=names)
+
+
 def time_program(program_method):
     """
     A decorator used to time anvio programs. See below for example.

--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -126,7 +126,7 @@ class ColumnProfile:
 
         competing_nts = get_competing_items(reference, nts_sorted)
         if not competing_nts:
-            # ther eis no action here, we can return without further processing.
+            # there is no action here, we can return without further processing.
             return
 
         self.profile['competing_nts'] = ''.join(competing_nts)

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -33,14 +33,6 @@ class ComputeCoverage(object):
 
         self.args = args
         self.sanity_check()
-
-        if self.args.contig_name:
-            self.input_type = 'contig_name'
-        elif self.args.contigs_of_interest:
-            self.input_type = 'contigs_of_interest'
-        elif self.args.collection_txt:
-            self.input_type = 'collection_txt'
-
         self.f = self.init_output()
 
         self.bam = pysam.Samfile(self.args.bam_file, 'rb')
@@ -55,7 +47,21 @@ class ComputeCoverage(object):
         if sum([has_arg(x) for x in ('contig_name', 'contigs_of_interest', 'collection_txt')]) != 1:
             raise ConfigError("Provide input for exactly one of --contig-name, --contigs-of-interest, or --collections-txt")
 
+        if self.args.contig_name:
+            self.input_type = 'contig_name'
+        elif self.args.contigs_of_interest:
+            self.input_type = 'contigs_of_interest'
+        else:
+            self.input_type = 'collection_txt'
+
         filesnpaths.is_file_exists(self.args.bam_file)
+
+        self.run.info('BAM file', self.args.bam_file)
+        self.run.info('Input type', self.input_type)
+        self.run.info('Coverage will be reported for each', self.args.method)
+
+        if (self.input_type == 'contig_name' or self.input_type == 'contigs_of_interest') and self.args.method == 'bin':
+            raise ConfigError("Choosing --method bin is only available with --collection-txt")
 
 
     def get_column_names(self):
@@ -114,6 +120,8 @@ class ComputeCoverage(object):
         ==========
         contig_name : str
         """
+        self.progress.increment()
+        self.progress.update('%s (%d/%d)' % (contig_name, self.progress.progress_current_item, self.progress.progress_total_items))
 
         cov = seq.Coverage()
         cov.run(self.bam, contig_name)
@@ -153,21 +161,29 @@ class ComputeCoverage(object):
         elif self.input_type == 'collection_txt':
             self.process_collection_txt()
 
+        self.progress.end()
+        self.run.info_single('Output file %s has been written' % self.args.output, nl_before=1)
+
 
     def process_contig(self):
         m = self.args.method
         contig_name = self.args.contig_name
 
+        self.progress.new('Processing', progress_total_items=1)
+
         if m == 'contig':
             self.run_contig_method_for_contig(contig_name, (contig_name, ))
         else: # m == 'pos'
             self.run.warning("Warning, your file will contain %d lines" % self.lengths[contig_name])
+
             self.run_pos_method_for_contig(contig_name, tuple())
 
 
     def process_contigs_of_interest(self):
         m = self.args.method
         contigs_of_interest = self.setup_contigs_of_interest()
+
+        self.progress.new('Processing', progress_total_items=len(contigs_of_interest))
 
         if m == 'contig':
             for contig_name in contigs_of_interest:
@@ -205,6 +221,8 @@ class ComputeCoverage(object):
         collection = self.setup_collection_txt()
 
         d = {k: v for k, v in self.lengths.items() if k in collection['contig_name'].to_list()}
+
+        self.progress.new('Processing', progress_total_items=len(collection['contig_name']))
 
         if m == 'bin':
             for bin_name, contigs_in_bin in collection.groupby('bin')['contig_name']:

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -33,6 +33,14 @@ class ComputeCoverage(object):
 
         self.args = args
         self.sanity_check()
+
+        if self.args.contig_name:
+            self.input_type = 'contig_name'
+        elif self.args.contigs_of_interest:
+            self.input_type = 'contigs_of_interest'
+        elif self.args.collection_txt:
+            self.input_type = 'collection_txt'
+
         self.f = self.init_output()
 
         self.bam = pysam.Samfile(self.args.bam_file, 'rb')
@@ -51,19 +59,19 @@ class ComputeCoverage(object):
 
 
     def get_column_names(self):
-        if self.args.contig_name:
+        if self.input_type == 'contig_name':
             if self.args.method == 'pos':
                 colnames = ('pos', 'coverage')
             elif self.args.method == 'contig':
                 colnames = ('contig', 'coverage')
 
-        elif self.args.contigs_of_interest:
+        elif self.input_type == 'contigs_of_interest':
             if self.args.method == 'pos':
                 colnames = ('contig', 'pos', 'coverage')
             elif self.args.method == 'contig':
                 colnames = ('contig', 'coverage')
 
-        elif self.args.collection_txt:
+        elif self.input_type == 'collection_txt':
             if self.args.method == 'pos':
                 colnames = ('bin', 'contig', 'pos', 'coverage')
             elif self.args.method == 'contig':
@@ -138,12 +146,11 @@ class ComputeCoverage(object):
 
 
     def process(self):
-        if self.args.contig_name:
-            
+        if self.input_type == 'contig_name':
             self.process_contig()
-        elif self.args.contigs_of_interest:
+        elif self.input_type == 'contigs_of_interest':
             self.process_contigs_of_interest()
-        elif self.args.collection_txt:
+        elif self.input_type == 'collection_txt':
             self.process_collection_txt()
 
 
@@ -154,7 +161,7 @@ class ComputeCoverage(object):
         if m == 'contig':
             self.run_contig_method_for_contig(contig_name, (contig_name, ))
         else: # m == 'pos'
-            run.warning("Warning, your file will contain %d lines" % self.lengths[contig_name])
+            self.run.warning("Warning, your file will contain %d lines" % self.lengths[contig_name])
             self.run_pos_method_for_contig(contig_name, tuple())
 
 
@@ -169,7 +176,7 @@ class ComputeCoverage(object):
         else: # m == 'pos'
             d = {k: v for k, v in self.lengths.items() if k in contigs_of_interest}
 
-            run.warning("Warning, your file will contain %d lines" % sum(d.values()))
+            self.run.warning("Warning, your file will contain %d lines" % sum(d.values()))
 
             for contig_name in contigs_of_interest:
                 self.run_pos_method_for_contig(contig_name, (contig_name, ))
@@ -220,7 +227,7 @@ class ComputeCoverage(object):
                     self.run_contig_method_for_contig(contig_name, (bin_name, contig_name))
 
         else: # m == 'pos'
-            run.warning("Warning, your file will contain %d lines" % sum(d.values()))
+            self.run.warning("Warning, your file will contain %d lines" % sum(d.values()))
 
             for bin_name, contigs_in_bin in collection.groupby('bin')['contig_name']:
                 for i, contig_name in enumerate(contigs_in_bin):

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -50,32 +50,24 @@ class ComputeCoverage(object):
         if self.args.contig_name:
             if self.args.method == 'pos':
                 colnames = ('pos', 'coverage')
-                formatters = ('%s', '%s')
             elif self.args.method == 'contig':
                 colnames = ('contig', 'coverage')
-                formatters = ('%s', '%s')
 
         elif self.args.contigs_of_interest:
             if self.args.method == 'pos':
                 colnames = ('contig', 'pos', 'coverage')
-                formatters = ('%s', '%s', '%s')
             elif self.args.method == 'contig':
                 colnames = ('contig', 'coverage')
-                formatters = ('%s', '%s')
 
         elif self.args.collection_txt:
             if self.args.method == 'pos':
                 colnames = ('bin', 'contig', 'pos', 'coverage')
-                formatters = ('%s', '%s', '%s', '%s')
             elif self.args.method == 'contig':
                 colnames = ('bin', 'contig', 'coverage')
-                formatters = ('%s', '%s', '%s')
             elif self.args.method == 'bin':
                 colnames = ('bin', 'coverage')
-                formatters = ('%s', '%s')
 
         self.colnames = colnames
-        self.formatters = formatters
 
 
     def is_contigs_in_bam(self, contigs):
@@ -143,6 +135,7 @@ class ComputeCoverage(object):
 
     def process(self):
         if self.args.contig_name:
+            
             self.process_contig()
         elif self.args.contigs_of_interest:
             self.process_contigs_of_interest()

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -25,12 +25,12 @@ __maintainer__ = "Evan Kiefl"
 __email__ = "kiefl.evan@gmail.com"
 __description__ = ("Get nucleotide-level, contig-level, or bin-level coverage values from a BAM file")
 
-run = terminal.Run()
-progress = terminal.Progress()
-
 
 class ComputeCoverage(object):
-    def __init__(self, args):
+    def __init__(self, args, run=terminal.Run(), progress=terminal.Progress()):
+        self.run = run
+        self.progress = progress
+
         self.args = args
         self.sanity_check()
         self.set_column_names_and_formatters()
@@ -241,7 +241,7 @@ class ComputeCoverage(object):
 
 @terminal.time_program
 def main(args):
-    c = ComputeCoverage(args)
+    c = ComputeCoverage(args, terminal.Run(), terminal.Progress())
     c.process()
 
 

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -1,0 +1,339 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import os
+import sys
+import pysam
+import numpy as np
+import pandas as pd
+import argparse
+
+import anvio
+import anvio.contigops
+import anvio.sequence as seq
+import anvio.terminal as terminal
+import anvio.filesnpaths as filesnpaths
+
+from anvio.errors import ConfigError, FilesNPathsError
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2020, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "Evan Kiefl"
+__email__ = "kiefl.evan@gmail.com"
+__description__ = ("Get nucleotide-level, contig-level, or bin-level coverage values from a BAM file")
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+
+class ComputeCoverage(object):
+    def __init__(self, args):
+        self.args = args
+        self.sanity_check()
+        self.set_column_names_and_formatters()
+        self.f = self.init_output()
+
+        self.bam = pysam.Samfile(self.args.bam_file, 'rb')
+
+        # lengths is {contig_name: contig_length} of each contig in the bam
+        self.lengths = dict(zip(self.bam.references, self.bam.lengths))
+
+
+    def sanity_check(self):
+        pass
+
+
+    def set_column_names_and_formatters(self):
+        if self.args.contig_name:
+            if self.args.method == 'pos':
+                colnames = ('pos', 'coverage')
+                formatters = ('%s', '%s')
+            elif self.args.method == 'contig':
+                colnames = ('contig', 'coverage')
+                formatters = ('%s', '%s')
+
+        elif self.args.contigs_of_interest:
+            if self.args.method == 'pos':
+                colnames = ('contig', 'pos', 'coverage')
+                formatters = ('%s', '%s', '%s')
+            elif self.args.method == 'contig':
+                colnames = ('contig', 'coverage')
+                formatters = ('%s', '%s')
+
+        elif self.args.collection_txt:
+            if self.args.method == 'pos':
+                colnames = ('bin', 'contig', 'pos', 'coverage')
+                formatters = ('%s', '%s', '%s', '%s')
+            elif self.args.method == 'contig':
+                colnames = ('bin', 'contig', 'coverage')
+                formatters = ('%s', '%s', '%s')
+            elif self.args.method == 'bin':
+                colnames = ('bin', 'coverage')
+                formatters = ('%s', '%s')
+
+        self.colnames = colnames
+        self.formatters = formatters
+
+
+    def is_contigs_in_bam(self, contigs):
+        """Raises error if any contigs are not found in the bam"""
+
+        for contig_name in contigs:
+            if contig_name not in self.bam.references:
+                raise ConfigError("%s is not in your bam file. Make sure you're using contig names "
+                                  "and not split names.")
+
+
+    def init_output(self):
+        # write the headers
+        f = open(self.args.output, 'w')
+        f.write('\t'.join(self.colnames) + '\n')
+        f.close()
+
+        # reopen file in append mode
+        f = open(self.args.output, 'ab')
+
+        return f
+
+
+    def write_cache_to_output(self, array):
+        np.savetxt(self.f, array, delimiter='\t', fmt="%s")
+
+
+    def get_nt_coverage_of_contig(self, contig_name):
+        """Returns nucleotide array of coverage values
+
+        Parameters
+        ==========
+        contig_name : str
+        """
+
+        cov = seq.Coverage()
+        cov.run(self.bam, contig_name)
+
+        return cov.c
+
+
+    def run_pos_method_for_contig(self, contig_name, columns):
+        nt_cov = self.get_nt_coverage_of_contig(contig_name)
+
+        array_tuple = tuple()
+        for column in columns:
+            array_tuple += (np.array([column] * len(nt_cov)), )
+
+        data_cache = np.vstack(
+            array_tuple + (np.arange(len(nt_cov)), nt_cov)
+        ).T
+
+        self.write_cache_to_output(data_cache)
+
+
+    def run_contig_method_for_contig(self, contig_name, columns):
+        nt_cov = self.get_nt_coverage_of_contig(contig_name)
+
+        data_cache = np.array([
+            columns + (np.mean(nt_cov), )
+        ])
+
+        self.write_cache_to_output(data_cache)
+
+
+    def process(self):
+        if self.args.contig_name:
+            self.process_contig()
+        elif self.args.contigs_of_interest:
+            self.process_contigs_of_interest()
+        elif self.args.collection_txt:
+            self.process_collection_txt()
+
+
+    def process_contig(self):
+        m = self.args.method
+        contig_name = self.args.contig_name
+
+        if m == 'contig':
+            self.run_contig_method_for_contig(contig_name, (contig_name, ))
+        else: # m == 'pos'
+            run.warning("Warning, your file will contain %d lines" % self.lengths[contig_name])
+            self.run_pos_method_for_contig(contig_name, tuple())
+
+
+    def process_contigs_of_interest(self):
+        m = self.args.method
+        contigs_of_interest = self.setup_contigs_of_interest()
+
+        if m == 'contig':
+            for contig_name in contigs_of_interest:
+                self.run_contig_method_for_contig(contig_name, (contig_name, ))
+
+        else: # m == 'pos'
+            d = {k: v for k, v in self.lengths.items() if k in contigs_of_interest}
+
+            run.warning("Warning, your file will contain %d lines" % sum(d.values()))
+
+            for contig_name in contigs_of_interest:
+                self.run_pos_method_for_contig(contig_name, (contig_name, ))
+
+
+    def setup_contigs_of_interest(self):
+        """Check contigs of interest file and then return list of contigs"""
+        filesnpaths.is_file_exists(args.contigs_of_interest)
+        contigs_of_interest = [x.strip() for x in open(args.contigs_of_interest).readlines()]
+
+        self.is_contigs_in_bam(contigs_of_interest)
+
+        return contigs_of_interest
+
+
+    def process_collection_txt(self):
+        """Compute average when --collection-txt is chosen
+
+        Because each bin could contain an extremely large number of nucleotide position, which could
+        be too much information to allocate in memory, if the chosen method is 'bin', i.e the user wants
+        the mean coverage for each bin, bin averages are actually weighted averages of mean contig
+        coverages, where each each is the contig length.
+        """
+
+        m = self.args.method
+        collection = self.setup_collection_txt()
+
+        d = {k: v for k, v in self.lengths.items() if k in collection['contig_name'].to_list()}
+
+        if m == 'bin':
+            for bin_name, contigs_in_bin in collection.groupby('bin')['contig_name']:
+                # allocate empty array to store each contig's coverage
+                contig_coverages = np.zeros(len(contigs_in_bin))
+
+                # get a contig length array for weighting
+                contig_lengths = np.array([d[c] for c in contigs_in_bin])
+
+                for i, contig_name in enumerate(contigs_in_bin):
+                    contig_coverages[i] = np.mean(self.get_nt_coverage_of_contig(contig_name))
+
+                data_cache = np.array([[bin_name, np.average(contig_coverages, weights=contig_lengths/np.sum(contig_lengths))]])
+
+                self.write_cache_to_output(data_cache)
+
+        elif m == 'contig':
+            for bin_name, contigs_in_bin in collection.groupby('bin')['contig_name']:
+                for contig_name in contigs_in_bin:
+                    self.run_contig_method_for_contig(contig_name, (bin_name, contig_name))
+
+        else: # m == 'pos'
+            run.warning("Warning, your file will contain %d lines" % sum(d.values()))
+
+            for bin_name, contigs_in_bin in collection.groupby('bin')['contig_name']:
+                for i, contig_name in enumerate(contigs_in_bin):
+                    self.run_pos_method_for_contig(contig_name, (bin_name, contig_name))
+
+
+    def setup_collection_txt(self):
+        filesnpaths.is_file_exists(args.collection_txt)
+        collection = pd.read_csv(args.collection_txt, sep='\t', names=('contig_name', 'bin'))
+        self.is_contigs_in_bam(collection['contig_name'])
+
+        return collection
+
+
+
+@terminal.time_program
+def main(args):
+    c = ComputeCoverage(args)
+    c.process()
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description=__description__)
+
+    groupI = parser.add_argument_group(
+        'REQUIRED',
+        'Declare your BAM file here'
+    )
+    groupI.add_argument(
+        '-b',
+        '--bam-file',
+        required = True,
+        help = "Sorted and indexed BAM file to analyze."
+    )
+
+
+    group1 = parser.add_argument_group(
+        'OPTION #1',
+        "This is the first and simplest option. Provide a contig name"
+    )
+    group1.add_argument(
+        '-c',
+        '--contig-name',
+        default = None,
+        help = "The name of a single contig"
+    )
+
+
+    group2 = parser.add_argument_group(
+        'OPTION #2',
+        ("Use this to characterize coverage for a list of contigs")
+    )
+    group2.add_argument(
+        '-l',
+        '--contigs-of-interest',
+        default = None,
+        help = "Provide here a file where each line is a contig name."
+    )
+
+
+    group3 = parser.add_argument_group(
+        'OPTION #3',
+        ("Use this to characterize coverage for a list of contigs")
+    )
+    group3.add_argument(
+        '-C',
+        '--collection-txt',
+        default = None,
+        help = ("Provide a collection text file. The first column should be "
+                "contig names and the second column should be the bin to which "
+                "the contig belongs. If you have a collection from a profile "
+                "database, you can export it in this format with anvi-export-collection.")
+    )
+
+    groupM = parser.add_argument_group(
+        'METHOD',
+        ("Do you want to report coverage at a nucleotide level? Contig averages?"
+         "Bin averages? Pick the method here.")
+    )
+    groupM.add_argument(
+        '-m',
+        '--method',
+        choices=('pos','contig','bin'),
+        required=True,
+        help = ("If pos, each nucleotide position will be reported (valid for "
+                "OPTION #1, #2, #3). If contig, report contains contig averages "
+                "(valid for OPTION #2, #3). If bin, report contains bin averages "
+                "(valid for OPTION #3).")
+    )
+
+    groupO = parser.add_argument_group(
+        'METHOD',
+        ("Do you want to report coverage at a nucleotide level? Contig averages?"
+         "Bin averages? Pick the method here.")
+    )
+    groupO.add_argument(
+        '-o',
+        '--output',
+        required=True,
+        help = ("Output tab-delimited file path. Will overwrite existing files.")
+    )
+
+    args = anvio.get_args(parser)
+
+    try:
+        main(args)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)
+    except FilesNPathsError as e:
+        print(e)
+        sys.exit(-2)

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -33,7 +33,6 @@ class ComputeCoverage(object):
 
         self.args = args
         self.sanity_check()
-        self.set_column_names_and_formatters()
         self.f = self.init_output()
 
         self.bam = pysam.Samfile(self.args.bam_file, 'rb')
@@ -43,10 +42,15 @@ class ComputeCoverage(object):
 
 
     def sanity_check(self):
-        pass
+        has_arg = lambda x: True if self.args.__dict__.get(x) else False
+
+        if sum([has_arg(x) for x in ('contig_name', 'contigs_of_interest', 'collection_txt')]) != 1:
+            raise ConfigError("Provide input for exactly one of --contig-name, --contigs-of-interest, or --collections-txt")
+
+        filesnpaths.is_file_exists(self.args.bam_file)
 
 
-    def set_column_names_and_formatters(self):
+    def get_column_names(self):
         if self.args.contig_name:
             if self.args.method == 'pos':
                 colnames = ('pos', 'coverage')
@@ -67,7 +71,7 @@ class ComputeCoverage(object):
             elif self.args.method == 'bin':
                 colnames = ('bin', 'coverage')
 
-        self.colnames = colnames
+        return colnames
 
 
     def is_contigs_in_bam(self, contigs):
@@ -82,7 +86,7 @@ class ComputeCoverage(object):
     def init_output(self):
         # write the headers
         f = open(self.args.output, 'w')
-        f.write('\t'.join(self.colnames) + '\n')
+        f.write('\t'.join(self.get_column_names()) + '\n')
         f.close()
 
         # reopen file in append mode

--- a/sandbox/anvi-script-get-coverage
+++ b/sandbox/anvi-script-get-coverage
@@ -291,7 +291,7 @@ if __name__ == '__main__':
 
     group3 = parser.add_argument_group(
         'OPTION #3',
-        ("Use this to characterize coverage for a list of contigs")
+        ("Use this to characterize coverage for a collection of contig sets (bins)")
     )
     group3.add_argument(
         '-C',
@@ -305,7 +305,7 @@ if __name__ == '__main__':
 
     groupM = parser.add_argument_group(
         'METHOD',
-        ("Do you want to report coverage at a nucleotide level? Contig averages?"
+        ("Do you want to report coverage at a nucleotide level? Contig averages? "
          "Bin averages? Pick the method here.")
     )
     groupM.add_argument(
@@ -320,9 +320,9 @@ if __name__ == '__main__':
     )
 
     groupO = parser.add_argument_group(
-        'METHOD',
-        ("Do you want to report coverage at a nucleotide level? Contig averages?"
-         "Bin averages? Pick the method here.")
+        'OUTPUT',
+        ("Your output file is decided here. Keep in mind if you use --method pos, this "
+         "file will contain as many lines as there are nucleotides defined by your input option")
     )
     groupO.add_argument(
         '-o',

--- a/sandbox/anvi-script-get-coverage-from-bam
+++ b/sandbox/anvi-script-get-coverage-from-bam
@@ -31,6 +31,8 @@ class ComputeCoverage(object):
         self.run = run
         self.progress = progress
 
+        self.progress.new('Initializing')
+
         self.args = args
         self.sanity_check()
         self.f = self.init_output()
@@ -39,6 +41,8 @@ class ComputeCoverage(object):
 
         # lengths is {contig_name: contig_length} of each contig in the bam
         self.lengths = dict(zip(self.bam.references, self.bam.lengths))
+
+        self.progress.end()
 
 
     def sanity_check(self):
@@ -190,10 +194,6 @@ class ComputeCoverage(object):
                 self.run_contig_method_for_contig(contig_name, (contig_name, ))
 
         else: # m == 'pos'
-            d = {k: v for k, v in self.lengths.items() if k in contigs_of_interest}
-
-            self.run.warning("Warning, your file will contain %d lines" % sum(d.values()))
-
             for contig_name in contigs_of_interest:
                 self.run_pos_method_for_contig(contig_name, (contig_name, ))
 
@@ -203,7 +203,8 @@ class ComputeCoverage(object):
         filesnpaths.is_file_exists(args.contigs_of_interest)
         contigs_of_interest = [x.strip() for x in open(args.contigs_of_interest).readlines()]
 
-        self.is_contigs_in_bam(contigs_of_interest)
+        if not self.args.skip_contig_check:
+            self.is_contigs_in_bam(contigs_of_interest)
 
         return contigs_of_interest
 
@@ -220,8 +221,6 @@ class ComputeCoverage(object):
         m = self.args.method
         collection = self.setup_collection_txt()
 
-        d = {k: v for k, v in self.lengths.items() if k in collection['contig_name'].to_list()}
-
         self.progress.new('Processing', progress_total_items=len(collection['contig_name']))
 
         if m == 'bin':
@@ -230,7 +229,7 @@ class ComputeCoverage(object):
                 contig_coverages = np.zeros(len(contigs_in_bin))
 
                 # get a contig length array for weighting
-                contig_lengths = np.array([d[c] for c in contigs_in_bin])
+                contig_lengths = np.array([self.lengths[c] for c in contigs_in_bin])
 
                 for i, contig_name in enumerate(contigs_in_bin):
                     contig_coverages[i] = np.mean(self.get_nt_coverage_of_contig(contig_name))
@@ -245,8 +244,6 @@ class ComputeCoverage(object):
                     self.run_contig_method_for_contig(contig_name, (bin_name, contig_name))
 
         else: # m == 'pos'
-            self.run.warning("Warning, your file will contain %d lines" % sum(d.values()))
-
             for bin_name, contigs_in_bin in collection.groupby('bin')['contig_name']:
                 for i, contig_name in enumerate(contigs_in_bin):
                     self.run_pos_method_for_contig(contig_name, (bin_name, contig_name))
@@ -255,7 +252,9 @@ class ComputeCoverage(object):
     def setup_collection_txt(self):
         filesnpaths.is_file_exists(args.collection_txt)
         collection = pd.read_csv(args.collection_txt, sep='\t', names=('contig_name', 'bin'))
-        self.is_contigs_in_bam(collection['contig_name'])
+
+        if not self.args.skip_contigs_check:
+            self.is_contigs_in_bam(collection['contig_name'])
 
         return collection
 
@@ -348,6 +347,17 @@ if __name__ == '__main__':
         help = ("Output tab-delimited file path. Will overwrite existing files.")
     )
 
+    groupE = parser.add_argument_group(
+        'EXTRAS',
+        ("All the misfits")
+    )
+    groupE.add_argument(
+        '--skip-contigs-check',
+        action='store_true',
+        help = ("Checking to see that your collection text or contigs of interest file has correct "
+                "names can take a really long time if you have a large enough number of contigs. Use "
+                "this flag to forego checking, and find out the hard way.")
+    )
     args = anvio.get_args(parser)
 
     try:

--- a/sandbox/anvi-script-get-coverage-from-bam
+++ b/sandbox/anvi-script-get-coverage-from-bam
@@ -260,7 +260,6 @@ class ComputeCoverage(object):
         return collection
 
 
-
 @terminal.time_program
 def main(args):
     c = ComputeCoverage(args, terminal.Run(), terminal.Progress())

--- a/sandbox/anvi-script-get-coverage-from-bam
+++ b/sandbox/anvi-script-get-coverage-from-bam
@@ -98,7 +98,7 @@ class ComputeCoverage(object):
         for contig_name in contigs:
             if contig_name not in self.bam.references:
                 raise ConfigError("%s is not in your bam file. Make sure you're using contig names "
-                                  "and not split names.")
+                                  "and not split names." % contig_name)
 
 
     def init_output(self):

--- a/sandbox/anvi-script-get-coverage-from-bam
+++ b/sandbox/anvi-script-get-coverage-from-bam
@@ -203,7 +203,7 @@ class ComputeCoverage(object):
         filesnpaths.is_file_exists(args.contigs_of_interest)
         contigs_of_interest = [x.strip() for x in open(args.contigs_of_interest).readlines()]
 
-        if not self.args.skip_contig_check:
+        if not self.args.skip_contigs_check:
             self.is_contigs_in_bam(contigs_of_interest)
 
         return contigs_of_interest


### PR DESCRIPTION
Alright so this branch was initially created to try and find a way to speed up anvi-profile by only accessing every nth nucleotide position pileup object and then interpolating the coverage values. The idea being that if you only sampled every hundredth nucleotide position, you could interpolate with at least somewhat decent accuracy faster than it would take to loop through each pileup object.

This approach eventually failed because there is no way to create an iterator object with pysam that samples only every nth object. 

To create an analogy, we wanted this:

```python
for pileup in range(0,1000,10):
    something()
```

but all we could get was this:

```python
for pileup in range(0,1000):
    if pileup % 10 != 0:
        continue
    something()
```

By this point, the coverage is already loaded into memory, so we may as well store it. To extend the analogy further, I also tried this approach, but its extremely slow.

```python
counter = 0
for i in range(0,100,10):
    for pileup in range(i, i+1):
        something()
```

----------------------------

So what's in this branch? 4 things

1. Profile is now a little bit faster after switching to numpy arrays. Primarily speedups resulted from numpy's ability to preallocate memory via arrays and then populate them with splicing operations.

2. Coverage class is now generalized and can be run for anvio.contigops.Split, anvio.contigops.Contig, and just plain old strings of contig names.

3. There's a new program called `anvi-script-get-coverage-from-bam` that uses the new and improved Coverage class to get per-nucleotide, per-contig, or per-bin coverage values. It currently takes 3 inputs: either a contig name, a list of contig names, or a collection txt file. Obviously one can imagine incorporating contigs db as an input and do things like gene coverages, and when that day comes maybe this program will graduate from sandbox to bin

4. The results were yielding different results from anvi-summarize. Investigating a little further, I noticed that bin coverage values were different between anvi-summarize and anvi-script-get-coverage-from-bam. The reason is because anvi-summarize calculates bin averages by taking the mean split averages, but it should really take weighted average of its split coverages, where the weight is the length of the split. After considering for a while, I am convinced that all tables for a collection should be weighted in this manner, not just coverage values. If 60% of a bin's length is contributed by just one split, then all of these summary statistics of this split should be upweighted when defining the bin-wide average.