### PR TITLE
Amino Acid Conservation Code Clean Up

### DIFF
--- a/anvio/constants.py
+++ b/anvio/constants.py
@@ -239,12 +239,12 @@ conserved_amino_acid_groups = {
     'None': []
 }
 
-conserved_amino_acid_groups['N'] = conserved_amino_acid_groups['Neutral Amines'].append('B')
-conserved_amino_acid_groups['D'] = conserved_amino_acid_groups['Acids'].append('B')
-conserved_amino_acid_groups['Q'] = conserved_amino_acid_groups['Neutral Amines'].append('Z')
-conserved_amino_acid_groups['E'] = conserved_amino_acid_groups['Acids'].append('Z')
-conserved_amino_acid_groups['L'] = conserved_amino_acid_groups['Nonpolar'].append('J')
-conserved_amino_acid_groups['I'] = conserved_amino_acid_groups['Nonpolar'].append('J')
+conserved_amino_acid_groups['N'] = conserved_amino_acid_groups['Neutral Amines'] + ['B']
+conserved_amino_acid_groups['D'] = conserved_amino_acid_groups['Acids'] + ['B']
+conserved_amino_acid_groups['Q'] = conserved_amino_acid_groups['Neutral Amines'] + ['Z']
+conserved_amino_acid_groups['E'] = conserved_amino_acid_groups['Acids'] + ['Z']
+conserved_amino_acid_groups['LI'] = conserved_amino_acid_groups['Nonpolar'] + ['J']
+
 
 amino_acid_property_group = {}
 for key in ['A','V','M','C']:
@@ -266,8 +266,8 @@ amino_acid_property_group['N'] = 'N'
 amino_acid_property_group['D'] = 'D'
 amino_acid_property_group['Q'] = 'Q'
 amino_acid_property_group['E'] = 'E'
-amino_acid_property_group['L'] = 'L'
-amino_acid_property_group['I'] = 'I'
+amino_acid_property_group['L'] = 'LI'
+amino_acid_property_group['I'] = 'LI'
 
 codons = sorted(list(set(codon_to_AA.keys())))
 coding_codons = [x for x in codons if codon_to_AA[x] != "STP"]

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -1561,7 +1561,7 @@ def is_amino_acid_functionally_conserved(amino_acid_residue_1, amino_acid_residu
     group = constants.amino_acid_property_group[amino_acid_residue_1]
     conserved_group = constants.conserved_amino_acid_groups[group]
 
-    if conserved_group and amino_acid_residue_2 in conserved_group:
+    if amino_acid_residue_2 in conserved_group:
         return True
 
     if group == 'Polar and Nonpolar':


### PR DESCRIPTION
Addresses the bug that caused the fatal crash in #1349. 

I forgot that list.append changes the original list and does not return a new list. All of the ambiguous amino acids (as well as their representative groups) thus had a conservation group of "None" because nothing was returned. @meren 's fix suppressed the error but didn't prevent homogeneity from being miscalculated.  Everything works on my end now.

Lesson learned: rigorous tests on every line of code changed