### PR TITLE
Find bin name from split name prior to refine

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1183,6 +1183,14 @@ D = {
             {'metavar': 'FILE_PATH',
              'help': "Text file for bins (each line should be a unique bin id)."}
                 ),
+    'find-from-split-name': (
+            ['--find-from-split-name'],
+            {'metavar': 'SPLIT_NAME',
+             'help': "If you don't know the bin name you want to work with but if you know the split name it contains "
+                     "you can use this parameter to tell anvi'o the split name, and so it can find the bin for you "
+                     "automatically. This is something extremely difficult for anvi'o to do, but it does it anyway "
+                     "because you."}
+                ),
     'collection-name': (
             ['-C', '--collection-name'],
             {'metavar': 'COLLECTION_NAME',

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -2127,8 +2127,6 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
         self.progress.new('Filtering %s' % ('SCVs' if selected_engine == 'CDN' else 'SAAVs'), discard_previous_if_exists=True)
         output = {}
 
-        list_of_filter_functions = []
-        F = lambda f, **kwargs: (f, kwargs)
         for group in options['groups']:
             self.progress.update('Group `%s`...' % group)
             samples_in_group = options['groups'][group]
@@ -2144,8 +2142,6 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
                 'data': var.merged.to_json(orient='index'),
                 'entries_after_filtering': var.merged.shape[0]
             }
-
-            list_of_filter_functions = []
 
         self.progress.end()
         return output

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -1576,6 +1576,25 @@ def is_amino_acid_functionally_conserved(amino_acid_residue_1, amino_acid_residu
     return False
 
 
+def get_bin_name_from_item_name(anvio_db_path, item_name, collection_name=None):
+    is_pan_or_profile_db(anvio_db_path, genes_db_is_also_accepted=True)
+    database = db.DB(anvio_db_path, None, ignore_version=True)
+
+    if t.collections_splits_table_name not in database.get_table_names():
+        raise ConfigError("The database %s does not contain a collections table :/")
+
+    if collection_name:
+        where_clause = 'split = "%s" and collection_name = "%s"' % (item_name, collection_name)
+    else:
+        where_clause = 'split = "%s"' % (item_name)
+
+    rows = database.get_some_rows_from_table(t.collections_splits_table_name, where_clause=where_clause)
+
+    database.disconnect()
+
+    return rows
+
+
 def get_contig_name_to_splits_dict(splits_basic_info_dict, contigs_basic_info_dict):
     """
     Returns a dict for contig name to split name conversion.

--- a/bin/anvi-refine
+++ b/bin/anvi-refine
@@ -56,6 +56,7 @@ if __name__ == '__main__':
     groupB.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
     groupB.add_argument(*anvio.A('bin-id'), **anvio.K('bin-id'))
     groupB.add_argument(*anvio.A('bin-ids-file'), **anvio.K('bin-ids-file'))
+    groupB.add_argument(*anvio.A('find-from-split-name'), **anvio.K('find-from-split-name'))
 
     groupC = parser.add_argument_group('ADDITIONAL STUFF', "Parameters to provide additional layers, views, or layer data.")
     groupC.add_argument(*anvio.A('tree'), **anvio.K('tree'))
@@ -91,6 +92,31 @@ if __name__ == '__main__':
     args = anvio.get_args(parser)
 
     try:
+        A = lambda x: args.__dict__[x] if x in args.__dict__ else None
+        find_from_split_name = A('find_from_split_name')
+        collection_name = A('collection_name')
+
+        if find_from_split_name and not collection_name:
+            raise ConfigError("If you would like anvi'o to find the bin name for your split, you should "
+                              "also specify a collection name.")
+
+        if find_from_split_name:
+            rows = utils.get_bin_name_from_item_name(args.profile_db, find_from_split_name, collection_name=args.collection_name)
+
+            if not rows:
+                raise ConfigError("The split name you requested was not found in collection %s :/" % collection_name)
+
+            if not len(rows) == 1:
+                raise ConfigError("There is something silly going on here. The split name is found in more "
+                                  "than one collection. Which is not really possible so goodbye.")
+
+            entry_id, collection_name, split_name, bin_name = rows[0]
+            run.warning("Anvi'o found your split, and will set the bin name for your "
+                        "refinement analysis to '%s'." % (bin_name),
+                        header="SPLIT FOUND IN %s!" % (bin_name), lc="green")
+
+            args.bin_id = bin_name
+
         args.mode = 'refine'
         d = interactive.Interactive(args)
         args.port_number = utils.get_port_num(args.port_number, args.ip_address, run=run)

--- a/bin/anvi-refine
+++ b/bin/anvi-refine
@@ -49,19 +49,15 @@ if __name__ == '__main__':
                                                           to start the interface using ad-hoc input files. See 'MANUAL\
                                                           INPUT' section for other set of parameters that are mutually\
                                                           exclusive with datanases.")
-    groupB = parser.add_argument_group('REFINE-SPECIFICS', "Parameters that are essential to the refinement process.")
-    groupC = parser.add_argument_group('ADDITIONAL STUFF', "Parameters to provide additional layers, views, or layer data.")
-    groupD = parser.add_argument_group('VISUALS RELATED', "Parameters that give access to various adjustements regarding\
-                                                           the interface.")
-    groupE = parser.add_argument_group('SWEET PARAMS OF CONVENIENCE', "Parameters and flags that are not quite essential (but\
-                                                                       nice to have).")
-    groupF = parser.add_argument_group('SERVER CONFIGURATION', "For power users.")
-
     groupA.add_argument(*anvio.A('profile-db'), **anvio.K('profile-db'))
     groupA.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+
+    groupB = parser.add_argument_group('REFINE-SPECIFICS', "Parameters that are essential to the refinement process.")
     groupB.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
     groupB.add_argument(*anvio.A('bin-id'), **anvio.K('bin-id'))
     groupB.add_argument(*anvio.A('bin-ids-file'), **anvio.K('bin-ids-file'))
+
+    groupC = parser.add_argument_group('ADDITIONAL STUFF', "Parameters to provide additional layers, views, or layer data.")
     groupC.add_argument(*anvio.A('tree'), **anvio.K('tree'))
     groupC.add_argument(*anvio.A('skip-hierarchical-clustering'), **anvio.K('skip-hierarchical-clustering', {'help':
                                     'Skip hierarchical clustering for the splits in the refined bin, if you skip clustering \
@@ -69,13 +65,21 @@ if __name__ == '__main__':
     groupC.add_argument(*anvio.A('load-full-state'), **anvio.K('load-full-state'))
     groupC.add_argument(*anvio.A('additional-view'), **anvio.K('additional-view'))
     groupC.add_argument(*anvio.A('additional-layers'), **anvio.K('additional-layers'))
+
+    groupD = parser.add_argument_group('VISUALS RELATED', "Parameters that give access to various adjustements regarding\
+                                                           the interface.")
     groupD.add_argument(*anvio.A('split-hmm-layers'), **anvio.K('split-hmm-layers'))
     groupD.add_argument(*anvio.A('taxonomic-level'), **anvio.K('taxonomic-level'))
     groupD.add_argument(*anvio.A('hide-outlier-SNVs'), **anvio.K('hide-outlier-SNVs'))
     groupD.add_argument(*anvio.A('title'), **anvio.K('title'))
     groupD.add_argument(*anvio.A('export-svg'), **anvio.K('export-svg'))
+
+    groupE = parser.add_argument_group('SWEET PARAMS OF CONVENIENCE', "Parameters and flags that are not quite essential (but\
+                                                                       nice to have).")
     groupE.add_argument(*anvio.A('dry-run'), **anvio.K('dry-run'))
     groupE.add_argument(*anvio.A('skip-init-functions'), **anvio.K('skip-init-functions'))
+
+    groupF = parser.add_argument_group('SERVER CONFIGURATION', "For power users.")
     groupE.add_argument(*anvio.A('skip-auto-ordering'), **anvio.K('skip-auto-ordering'))
     groupF.add_argument(*anvio.A('ip-address'), **anvio.K('ip-address'))
     groupF.add_argument(*anvio.A('port-number'), **anvio.K('port-number'))


### PR DESCRIPTION
With this PR anvi'o program `anvi-refine` can be called with a split name instead of a bin name. In mini test directory, the following command will find `Bin_1` and initiate refine:

```
anvi-refine -p SAMPLES-MERGED/PROFILE.db \
            -c CONTIGS.db \
            --find-from-split-name 204_10M_MERGED.PERFECT.gz.keep_contig_878_split_00001 \
            -C CONCOCT

SPLIT FOUND IN Bin_1!
===============================================
Anvi'o found your split, and will set the bin name for your refinement analysis
to 'Bin_1'.

Contigs DB ...................................: Initialized: CONTIGS.db (v. 14)
Interactive mode .............................: refine

(...)
```