### PR TITLE
Delete all remnant info from the dbs

### DIFF
--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -265,8 +265,6 @@ class TablesForHMMHits(Table):
 
 
     def remove_source(self, source):
-        gene_caller_ids_to_remove = set(key for key, val in self.gene_calls_dict.items() if val['source'] == source)
-
         tables_with_source = [
             t.hmm_hits_info_table_name,
             t.hmm_hits_table_name,
@@ -283,14 +281,21 @@ class TablesForHMMHits(Table):
         # delete entries from tables with 'source' column
         self.delete_entries_for_key('source', source, tables_with_source)
 
-        # delete entries from tables with 'gene_callers_id' column
-        database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
+        # collect gene caller ids that were added to the db via the HMM source
+        gene_caller_ids_to_remove = set(key for key, val in self.gene_calls_dict.items() if val['source'] == source)
 
-        CLAUSE = "gene_callers_id in (%s)" % (','.join([str(x) for x in gene_caller_ids_to_remove]))
-        for table in tables_with_gene_callers_id:
-            database.remove_some_rows_from_table(table, CLAUSE)
+        # if there are any, remove them from tables with 'gene_callers_id' column
+        if len(gene_caller_ids_to_remove):
+            database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
 
-        database.disconnect()
+            CLAUSE = "gene_callers_id in (%s)" % (','.join([str(x) for x in gene_caller_ids_to_remove]))
+            for table in tables_with_gene_callers_id:
+                database.remove_some_rows_from_table(table, CLAUSE)
+
+            database.disconnect()
+
+            run.warning("%d gene caller ids that were added via the HMM source have been removed from \"%s\"" \
+                        % (len(gene_caller_ids_to_remove), ', '.join(tables_with_gene_callers_id)))
 
 
     def append(self, source, reference, kind_of_search, domain, all_genes, search_results_dict):

--- a/bin/anvi-delete-hmms
+++ b/bin/anvi-delete-hmms
@@ -60,7 +60,7 @@ def main(args):
         for source in info_table:
             hmm_tables.remove_source(source)
     else:
-        raise ConfigError("Anvi'o does not know how the hell did you end this part of its code. Please find a "
+        raise ConfigError("Anvi'o does not know how the hell you ended up in this part of its code. Please find a "
                           "developer, explain how you ended up here, and collect your prize.")
 
 


### PR DESCRIPTION
aims to solve https://github.com/merenlab/anvio/issues/1366

Is this an appropriate change to make? If `anvi-profile` is run, then `anvi-delete-hmms`, there will now be incompatibilities in genes. On the other hand, if you ask to delete an HMM, it seems correct to get rid of the impact it had on the contigs database.

@meren please go ahead and merge if you agree with this change.