### PR TITLE
Ensure cleanup of contigs databases when new HMM sources are added/updated

### DIFF
--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -296,6 +296,7 @@ class TablesForHMMHits(Table):
         tables_with_gene_callers_id = [
             t.gene_amino_acid_sequences_table_name,
             t.genes_taxonomy_table_name,
+            t.genes_in_splits_table_name
         ]
 
         # delete entries from tables with 'source' column

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -283,6 +283,8 @@ class TablesForHMMHits(Table):
 
 
     def remove_source(self, source):
+        """Remove an HMM source from the database."""
+
         tables_with_source = [
             t.hmm_hits_info_table_name,
             t.hmm_hits_table_name,
@@ -317,6 +319,8 @@ class TablesForHMMHits(Table):
 
 
     def append(self, source, reference, kind_of_search, domain, all_genes, search_results_dict):
+        """Append a new HMM source in the contigs database."""
+
         # we want to define unique identifiers for each gene first. this information will be used to track genes that will
         # break into multiple pieces due to arbitrary split boundaries. while doing that, we will add the 'source' info
         # into the dictionary, so it perfectly matches to the table structure

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -321,6 +321,13 @@ class TablesForHMMHits(Table):
     def append(self, source, reference, kind_of_search, domain, all_genes, search_results_dict):
         """Append a new HMM source in the contigs database."""
 
+        # just to make 100% sure.
+        if source in list(hmmops.SequencesForHMMHits(self.db_path).hmm_hits_info.keys()):
+            raise ConfigError("The source '%s' you're trying to append is already in the database :( "
+                              "You should have never been able to come here in the code unless you "
+                              "have passed the `check_sources` sanity check. Very good but not "
+                              "good really. Bad. Bad you." % source)
+
         # we want to define unique identifiers for each gene first. this information will be used to track genes that will
         # break into multiple pieces due to arbitrary split boundaries. while doing that, we will add the 'source' info
         # into the dictionary, so it perfectly matches to the table structure

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -332,7 +332,6 @@ class TablesForHMMHits(Table):
         # we want to define unique identifiers for each gene first. this information will be used to track genes that will
         # break into multiple pieces due to arbitrary split boundaries. while doing that, we will add the 'source' info
         # into the dictionary, so it perfectly matches to the table structure
-
         for entry_id in search_results_dict:
             hit = search_results_dict[entry_id]
 
@@ -344,8 +343,6 @@ class TablesForHMMHits(Table):
                                                                      str(gene_call['start']),
                                                                      str(gene_call['stop'])]).encode('utf-8')).hexdigest()
             hit['source'] = source
-
-        self.remove_source(source)
 
         database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
 

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -35,9 +35,10 @@ pp = terminal.pretty_print
 
 
 class TablesForHMMHits(Table):
-    def __init__(self, db_path, num_threads_to_use=1, run=run, progress=progress, initializing_for_deletion=False):
+    def __init__(self, db_path, num_threads_to_use=1, run=run, progress=progress, initializing_for_deletion=False, just_do_it=False):
         self.num_threads_to_use = num_threads_to_use
         self.db_path = db_path
+        self.just_do_it = just_do_it
 
         utils.is_contigs_db(self.db_path)
 

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -61,6 +61,7 @@ class TablesForTransferRNAs:
         self.hits_file_path = P(A('trna_hits_file') or os.path.join(self.tmp_directory_path, 'hits_file.txt'))
         self.log_file_path = P(A('log_file') or os.path.join(self.tmp_directory_path, 'log.txt'))
         self.cutoff_score = A('trna_cutoff_score') or 20
+        self.just_do_it = A('just_do_it')
 
         self.amino_acids = set([aa for aa in constants.AA_to_codons.keys() if aa != 'STP'])
         self.codons = set([cdn for cdn in constants.codon_to_AA.keys() if constants.codon_to_AA[cdn] in self.amino_acids])

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -12,11 +12,13 @@ from collections import Counter
 
 import anvio
 import anvio.utils as utils
+import anvio.hmmops as hmmops
 import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
 import anvio.drivers.trnscan_se as trnascan_se
 
+from anvio.errors import ConfigError
 from anvio.tables.hmmhits import TablesForHMMHits
 from anvio.tables.genefunctions import TableForGeneFunctions
 
@@ -104,6 +106,17 @@ class TablesForTransferRNAs:
 
     def populate_search_tables(self, contigs_db_path):
         utils.is_contigs_db(contigs_db_path)
+
+        info_table = hmmops.SequencesForHMMHits(contigs_db_path).hmm_hits_info
+
+        if self.source_name in info_table:
+            if self.just_do_it:
+                TablesForHMMHits(contigs_db_path, run=self.run, progress=self.progress).remove_source(self.source_name)
+            else:
+                raise ConfigError("There is already information for %s in the database :/ Anvi'o will not overwrite this "
+                                  "unless you ask for it explicitly. You can either use `anvi-delete-hmms` to remove it first, "
+                                  "or run `anvi-scan-trnas` with `--just-do-it` flag so anvi'o would remove it for you." % (self.source_name))
+
         filesnpaths.is_output_file_writable(contigs_db_path, ok_if_exists=True)
 
         contig_sequences_fasta_path = os.path.join(self.tmp_directory_path, 'contig_sequences.fa')

--- a/bin/anvi-run-hmms
+++ b/bin/anvi-run-hmms
@@ -67,14 +67,12 @@ def main(args):
         # sources will be loaded from defaults.
         pass
 
-    search_tables = TablesForHMMHits(args.contigs_db, num_threads_to_use = args.num_threads)
+    search_tables = TablesForHMMHits(args.contigs_db, num_threads_to_use=args.num_threads, just_do_it=args.just_do_it)
     search_tables.populate_search_tables(sources)
 
     if not args.hmm_profile_dir and not args.installed_hmm_profile and not args.skip_scanning_trnas:
         tables_for_trna_hits = TablesForTransferRNAs(args)
         tables_for_trna_hits.populate_search_tables(args.contigs_db)
-
-
 
 
 if __name__ == '__main__':
@@ -104,6 +102,9 @@ if __name__ == '__main__':
     groupD = parser.add_argument_group("PERFORMANCE", "Stuff everyone forgets to set and then get upset with how slow "
                                                       "science goes.")
     groupD.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
+
+    groupE = parser.add_argument_group("AUTHORITY", "Because you are the boss.")
+    groupE.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     args = anvio.get_args(parser)
 

--- a/bin/anvi-scan-trnas
+++ b/bin/anvi-scan-trnas
@@ -42,6 +42,7 @@ if __name__ == '__main__':
     parser.add_argument(*anvio.A('log-file'), **anvio.K('log-file'))
     parser.add_argument(*anvio.A('trna-hits-file'), **anvio.K('trna-hits-file'))
     parser.add_argument(*anvio.A('trna-cutoff-score'), **anvio.K('trna-cutoff-score'))
+    parser.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     args = anvio.get_args(parser)
 


### PR DESCRIPTION
This PR offers a code cleanup that prevents future errors related with HMM addition, removal, and updates to contigs databases independent of target context (whether models work on genes or contigs).

It is compatible with previous contigs databases, so no version update is necessary.

Related to #1369.