### PR TITLE
Genome desc and dereplication speed improvements

### DIFF
--- a/anvio/filesnpaths.py
+++ b/anvio/filesnpaths.py
@@ -206,8 +206,13 @@ def is_program_exists(program):
     raise FilesNPathsError("'%s' is not found" % program)
 
 
-def get_temp_directory_path():
-    return tempfile.mkdtemp()
+def get_temp_directory_path(just_the_path=False):
+    temp_directory_path = tempfile.mkdtemp()
+
+    if just_the_path:
+        shutil.rmtree(temp_directory_path)
+
+    return temp_directory_path
 
 
 def get_temp_file_path(prefix=None, just_the_path=True):

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -484,18 +484,6 @@ class GenomeDescriptions(object):
             raise ConfigError('Genes must have been called during the generation of contigs database for this workflow to work. However,\
                                 these external genomes do not have gene calls: %s' % (', '.join(genomes_missing_gene_calls)))
 
-        # if two contigs db has the same hash, we are kinda f'd:
-        if len(set([self.genomes[genome_name]['genome_hash'] for genome_name in self.external_genome_names])) != len(self.external_genome_names):
-            raise ConfigError('Not all hash values are unique across all contig databases you provided. Something '
-                               'very fishy is going on :/')
-
-
-        if len(set([self.genomes[genome_name]['genome_hash'] for genome_name in self.internal_genome_names])) != len(self.internal_genome_names):
-            raise ConfigError("Not all hash values are unique across internal genomes. This is almost impossible to happen unless something very "
-                              "wrong with your workflow :/ It is most likely you managed to list the same information for different genome names. "
-                              "Please double check whether you internal genomes file looks perfectly fine. If it does, then perhaps let the "
-                              "developers know about the problem.")
-
         if not self.full_init:
             # if this is not full init, stop the sanity check here.
             self.progress.end()

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -655,11 +655,9 @@ class MetagenomeDescriptions(object):
 
     def get_metagenome_hash(self, entry):
         utils.is_contigs_db(entry['contigs_db_path'])
-        contigs_db = dbops.ContigsDatabase(entry['contigs_db_path'])
-        genome_hash = contigs_db.meta['contigs_db_hash']
-        contigs_db.disconnect()
+        contigs_db_hash = db.DB(entry['contigs_db_path'], None, ignore_version=True).get_meta_value('contigs_db_hash')
 
-        return genome_hash
+        return contigs_db_hash
 
 
     def sanity_check(self):

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -392,8 +392,7 @@ class GenomeDescriptions(object):
             c = self.genomes[genome_name]
             c['external_genome'] = True
 
-            self.progress.increment() 
-            self.progress.update('working on %s' % (genome_name))
+            self.progress.update('working on %s' % (genome_name), increment=True)
 
             contigs_db_summary = summarizer.ContigSummarizer(c['contigs_db_path']).get_contigs_db_info_dict(gene_caller_to_use=self.gene_caller)
 

--- a/anvio/genomesimilarity.py
+++ b/anvio/genomesimilarity.py
@@ -103,8 +103,6 @@ class Dereplicate:
 
 
     def is_genome_names_compatible_with_similarity_matrix(self, similarity_matrix, genome_names):
-        matrix_names = similarity_matrix.keys()
-
         missing_in_matrix = [n for n in genome_names if n not in similarity_matrix]
         missing_in_names = [n for n in similarity_matrix if n not in genome_names]
 
@@ -170,8 +168,8 @@ class Dereplicate:
                                       "--just-do-it. Otherwise, have the results regenerated here by removing '%s' "
                                       "as an input." % (self.ani_dir or self.mash_dir))
             else:
-                additional_msg = (' In addition, no FASTAs will be generated since you did not provide any sequence '
-                                  'sources for anvi\'o.')
+                additional_msg = ("In addition, no FASTAs will be generated since you did not provide any sequence "
+                                  "sources for anvi'o.")
 
             run.warning("You chose to work with an already existing results folder. Please keep in mind that you "
                         "are now burdened with the responsibility of knowing what parameters you used to generate "
@@ -241,7 +239,7 @@ class Dereplicate:
             # With sourmash you don't always know the metric name, you only be sure of what it
             # contains. This is because the kmer is a part of the result name. This is my fault but
             # I'm too lazy to fix the design because sourmash is not appropriate for genome
-            # comparison anyways. 
+            # comparison anyways.
             for result_name in self.similarity.results:
                 if self.program_info['metric_name'] in result_name:
                     similarity_matrix = self.similarity.results[result_name]
@@ -789,9 +787,6 @@ class FastANI(GenomeSimilarity):
 
         self.program = fastani.ManyToMany(args=self.args)
 
-        A = lambda x, t: t(args.__dict__[x]) if x in args.__dict__ else None
-        null = lambda x: x
-
         self.fastANI_sanity_check()
 
 
@@ -1030,13 +1025,12 @@ class ANI(GenomeSimilarity):
         try:
             df = lambda matrix_name: pd.DataFrame(results[matrix_name]).astype(float)
             results['full_percentage_identity'] = (df('percentage_identity') * df('alignment_coverage')).to_dict()
-        except KeyError as e:
+        except KeyError:
             # method did not produce percentage_identity score--that's okay, no full percentage
             # identity for you
             pass
 
         return results
-
 
 
 class SourMash(GenomeSimilarity):

--- a/anvio/genomesimilarity.py
+++ b/anvio/genomesimilarity.py
@@ -414,12 +414,16 @@ class Dereplicate:
                 full_dict[name]['total_length'] = sum(utils.get_read_lengths_from_fasta(fastas[name]['path']).values())
 
         if self.representative_method == 'Qscore':
+            missing_completion = False
             for genome in full_dict:
                 if not full_dict[genome].get('percent_completion') or not full_dict[genome].get('percent_redundancy'):
                     self.representative_method = 'centrality'
-                    run.warning('At least one of your genomes does not have completion and/or redundancy scores, which makes '
-                                'it impossible to use Qscore to pick best representatives from each cluster. One of these '
-                                'genomes is %s. Anvi\'o will switch you to the \'centrality\' method for picking representatives.')
+                    missing_completion = genome
+
+            if missing_completion:
+                run.warning("At least one of your genomes does not have completion and/or redundancy scores, which makes "
+                            "it impossible to use Qscore to pick best representatives from each cluster. One of these "
+                            "genomes is %s. Anvi'o switched you to the 'centrality' method for picking representatives." % (genome))
 
         self.genomes_info_dict = full_dict
 

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -219,7 +219,7 @@ class Progress:
         self.step = None
 
 
-    def update(self, msg):
+    def update(self, msg, increment=False):
         self.msg = msg
 
         if not self.verbose:
@@ -227,6 +227,9 @@ class Progress:
 
         if not self.pid:
             raise TerminalError('Progress with null pid will not update for msg "%s"' % msg)
+
+        if increment:
+            self.increment()
 
         self.clear()
         self.write('\r[%s] %s' % (self.pid, msg))

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -2092,10 +2092,11 @@ def check_contig_names(contig_names, dont_raise=False):
 
 def create_fasta_dir_from_sequence_sources(genome_desc, fasta_txt=None):
     """genome_desc is an instance of GenomeDescriptions"""
+
     if genome_desc is None and fasta_txt is None:
         raise ConfigError("Anvi'o was given no internal genomes, no external genomes, and no fasta "
-                         "files. Although anvi'o can technically go ahead and create a temporary "
-                         "FASTA directory, what's the point if there's nothing to do?")
+                          "files. Although anvi'o can technically go ahead and create a temporary "
+                          "FASTA directory, what's the point if there's nothing to do?")
 
     temp_dir = filesnpaths.get_temp_directory_path()
     hash_to_name = {}

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -2103,42 +2103,66 @@ def create_fasta_dir_from_sequence_sources(genome_desc, fasta_txt=None):
     name_to_path = {}
     genome_names = set([])
     file_paths = set([])
+
     if genome_desc is not None:
-        for genome_name in genome_desc.genomes:
-            genome_names.add(genome_name)
-            contigs_db_path = genome_desc.genomes[genome_name]['contigs_db_path']
-            hash_for_output_file = hashlib.sha256(genome_name.encode('utf-8')).hexdigest()
-            hash_to_name[hash_for_output_file] = genome_name
+        # first figure out internal genomes that are bound by the same collection name and
+        # profile db path
+        genome_subsets = {}
+        for entry in genome_desc.genomes.values():
+            if 'bin_id' in entry:
+                # if we are here, this entry represents an internal genome. we will add this genome
+                # to genome_subsets data structure to be processed later.
+                profile_and_collection_descriptor = '_'.join([entry['profile_db_path'], entry['collection_id']])
+                if profile_and_collection_descriptor in genome_subsets:
+                    genome_subsets[profile_and_collection_descriptor]['genome_name_bin_name_tpl'].add((entry['name'], entry['bin_id']),)
+                else:
+                    genome_subsets[profile_and_collection_descriptor] = {'genome_name_bin_name_tpl': set([(entry['name'], entry['bin_id'])]),
+                                                                         'profile_db_path': entry['profile_db_path'],
+                                                                         'contigs_db_path': entry['contigs_db_path'],
+                                                                         'collection_id': entry['collection_id']}
+            else:
+                # If we are here, this means this is an external genome, so we can basically take care of it here immediately.
+                genome_name = entry['name']
+                genome_names.add(genome_name)
+                contigs_db_path = genome_desc.genomes[genome_name]['contigs_db_path']
+                hash_for_output_file = hashlib.sha256(genome_name.encode('utf-8')).hexdigest()
+                hash_to_name[hash_for_output_file] = genome_name
 
-            path = os.path.join(temp_dir, hash_for_output_file + '.fa')
-            file_paths.add(path)
+                path = os.path.join(temp_dir, hash_for_output_file + '.fa')
+                file_paths.add(path)
 
-            name_to_path[genome_name] = path
+                name_to_path[genome_name] = path
 
-            if 'bin_id' in genome_desc.genomes[genome_name]:
-                # Internal genome
-                bin_id = genome_desc.genomes[genome_name]['bin_id']
-                collection_id = genome_desc.genomes[genome_name]['collection_id']
-                profile_db_path = genome_desc.genomes[genome_name]['profile_db_path']
+                export_sequences_from_contigs_db(contigs_db_path, path)
 
-                class Args: None
-                summary_args = Args()
+        # when we are here, all we have are interanl genomes as genome subsets.
+        for genome_subset in genome_subsets.values():
+            args = anvio.summarizer.ArgsTemplateForSummarizerClass()
+            args.contigs_db = genome_subset['contigs_db_path']
+            args.profile_db = genome_subset['profile_db_path']
+            args.collection_name = genome_subset['collection_id']
+            args.output_dir = filesnpaths.get_temp_directory_path(just_the_path=True)
+            args.quick_summary = True
 
-                summary_args.profile_db = profile_db_path
-                summary_args.contigs_db = contigs_db_path
-                summary_args.collection_name = collection_id
-                summary_args.quick = True
+            # note that we're initializing the summary class only for once for a given
+            # genome subset
+            summary = anvio.summarizer.ProfileSummarizer(args, r=Run(verbose=False))
+            summary.init()
 
-                summary = anvio.summarizer.ProfileSummarizer(summary_args, r=Run(verbose=False))
-                summary.init()
+            for genome_name, bin_name in genome_subset['genome_name_bin_name_tpl']:
+                genome_names.add(genome_name)
 
-                bin_summary = anvio.summarizer.Bin(summary, bin_id)
+                hash_for_output_file = hashlib.sha256(genome_name.encode('utf-8')).hexdigest()
+                hash_to_name[hash_for_output_file] = genome_name
+                path = os.path.join(temp_dir, hash_for_output_file + '.fa')
+                file_paths.add(path)
+                name_to_path[genome_name] = path
+
+                bin_summary = anvio.summarizer.Bin(summary, bin_name)
 
                 with open(path, 'w') as fasta:
                     fasta.write(bin_summary.get_bin_sequence())
-            else:
-                # External genome
-                export_sequences_from_contigs_db(contigs_db_path, path)
+
 
     if fasta_txt is not None:
         fastas = get_TAB_delimited_file_as_dictionary(fasta_txt, expected_fields=['name', 'path'], only_expected_fields=True)


### PR DESCRIPTION
@ekiefl, @mahmoudyousef98, while trying to solve a problem @brymerr921 run into, I realized some significant speed issues with `anvi-dereplicate-genomes`. This PR addresses some of them.

The most critical issue was in `utils:: create_fasta_dir_from_sequence_sources`. There, for each entry in internal genomes file was treated separately, hence, the summary class was initialized for each entry over and over again even if all entries in the file were bins in the same profile database.

The current workaround first collapses entries into `genome_subsets` (you can search in "Files changed" tab to take a quick look) based on collection name / profile db path properties of each entry before summarizing bins in a single collection.

I will merge this immediately since I will ask @brymerr921 to test it, the least you can do to help is to run your own tests to make sure it is still working as expected :) I already have run standard tests, but it is always better to have things tested by multiple people.


Best,