### PR TITLE
Add trna scan to contig workflow

### DIFF
--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -380,6 +380,23 @@ rule anvi_run_scg_taxonomy:
                                         {params.scg_taxonomy_data_dir} >> {log} 2>&1""")
 
 
+rule anvi_run_trna_scan:
+    version: anvio.__contigs__version__
+    log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_trna_scan.log"
+    input:
+        # make sure HMMs were done before running this rule
+        hmms_done = ancient(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done"),
+        contigs = ancient(M.get_contigs_db_path())
+    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_trna_scan-{group}.done")
+    params:
+        scg_taxonomy_data_dir = M.get_rule_param('anvi_run_trna_scan', '--scgs-taxonomy-data-dir'),
+    threads: M.T('anvi_run_trna_scan')
+    resources: nodes = M.T('anvi_run_scg_taxonomy'),
+    shell: w.r("""anvi-run-scg-taxonomy -c {input.contigs} \
+                                        -T {threads} \
+                                        {params.scg_taxonomy_data_dir} >> {log} 2>&1""")
+
+
 rule anvi_get_sequences_for_gene_calls:
     version: 1.0
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_get_sequences_for_gene_calls.log"

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -384,17 +384,17 @@ rule anvi_run_trna_scan:
     version: anvio.__contigs__version__
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_trna_scan.log"
     input:
-        # make sure HMMs were done before running this rule
-        hmms_done = ancient(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done"),
         contigs = ancient(M.get_contigs_db_path())
     output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_trna_scan-{group}.done")
     params:
-        scg_taxonomy_data_dir = M.get_rule_param('anvi_run_trna_scan', '--scgs-taxonomy-data-dir'),
+        # FIXME not sure how to handle optional --trna-hits-file parameter
+        #trna_scan_hits_file = M.get_rule_param('anvi_run_trna_scan', '--trna-hits-file'),
+        trna_cutoff_score = M.get_rule_param('anvi_run_trna_scan', '--trna-cutoff-score'),
     threads: M.T('anvi_run_trna_scan')
-    resources: nodes = M.T('anvi_run_scg_taxonomy'),
-    shell: w.r("""anvi-run-scg-taxonomy -c {input.contigs} \
-                                        -T {threads} \
-                                        {params.scg_taxonomy_data_dir} >> {log} 2>&1""")
+    resources: nodes = M.T('anvi_run_trna_scan'),
+    shell: w.r("""anvi-scan-trnas -c {input.contigs} \
+                                  -T {threads} \
+                                  {params.trna_cutoff_score} >> {log} 2>&1""")
 
 
 rule anvi_get_sequences_for_gene_calls:

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -42,7 +42,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         self.rules.extend(['gen_external_genome_file',
                            'anvi_script_reformat_fasta',
                            'anvi_gen_contigs_database', 'export_gene_calls_for_centrifuge', 'centrifuge',
-                           'anvi_import_taxonomy_for_genes', 'anvi_run_scg_taxonomy', 'anvi_run_hmms', 'anvi_run_ncbi_cogs',
+                           'anvi_import_taxonomy_for_genes', 'anvi_run_scg_taxonomy', 'anvi_run_trna_scan', 'anvi_run_hmms', 'anvi_run_ncbi_cogs',
                            'annotate_contigs_database', 'anvi_get_sequences_for_gene_calls', 'emapper',
                            'anvi_script_run_eggnog_mapper', 'gunzip_fasta', 'reformat_external_gene_calls_table',
                            'reformat_external_functions', 'import_external_functions', 'anvi_run_pfams'])
@@ -58,6 +58,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                     "anvi_run_hmms": {"run": True, "threads": 5},
                                     "anvi_run_ncbi_cogs": {"run": True, "threads": 5},
                                     "anvi_run_scg_taxonomy": {"run": True, "threads": 6},
+                                    'anvi_run_trna_scan': {"run": '', "threads": 6},
                                     "anvi_script_reformat_fasta": {"run": True, "--prefix": "{group}", "--simplify-names": True},
                                     "emapper": {"--database": "bact", "--usemem": True, "--override": True},
                                     "anvi_script_run_eggnog_mapper": {"--use-version": "0.12.6"}})
@@ -65,6 +66,8 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         self.rule_acceptable_params_dict['anvi_run_ncbi_cogs'] = ['run', '--cog-data-dir', '--sensitive', '--temporary-dir-path', '--search-with']
 
         self.rule_acceptable_params_dict['anvi_run_scg_taxonomy'] = ['run', '--scgs-taxonomy-data-dir']
+
+        self.rule_acceptable_params_dict['anvi_run_trna_scan'] = ['run', '--trna-hits-file', '--trna-cutoff-score']
 
         self.rule_acceptable_params_dict['anvi_run_hmms'] = ['run', '--installed-hmm-profile', '--hmm-profile-dir', '--also-scan-trnas']
 

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -58,7 +58,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                     "anvi_run_hmms": {"run": True, "threads": 5},
                                     "anvi_run_ncbi_cogs": {"run": True, "threads": 5},
                                     "anvi_run_scg_taxonomy": {"run": True, "threads": 6},
-                                    'anvi_run_trna_scan': {"run": '', "threads": 6},
+                                    'anvi_run_trna_scan': {"run": True, "threads": 6},
                                     "anvi_script_reformat_fasta": {"run": True, "--prefix": "{group}", "--simplify-names": True},
                                     "emapper": {"--database": "bact", "--usemem": True, "--override": True},
                                     "anvi_script_run_eggnog_mapper": {"--use-version": "0.12.6"}})

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -67,7 +67,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
         self.rule_acceptable_params_dict['anvi_run_scg_taxonomy'] = ['run', '--scgs-taxonomy-data-dir']
 
-        self.rule_acceptable_params_dict['anvi_run_trna_scan'] = ['run', '--trna-hits-file', '--trna-cutoff-score']
+        self.rule_acceptable_params_dict['anvi_run_trna_scan'] = ['run', '--trna-cutoff-score']
 
         self.rule_acceptable_params_dict['anvi_run_hmms'] = ['run', '--installed-hmm-profile', '--hmm-profile-dir', '--also-scan-trnas']
 
@@ -154,6 +154,10 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                  'anvi_run_hmms. Continue at your own risk. If your contigs databases '
                                  'don\'t have HMM hits stored already then anvi_run_scg_taxonomy will fail.')
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_scg_taxonomy-{group}.done"))
+
+        run_anvi_run_trna_scan = self.get_param_value_from_config(["anvi_run_trna_scan", "run"]) == True
+        if run_anvi_run_trna_scan:
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_trna_scan-{group}.done"))
 
         if self.get_param_value_from_config(["anvi_script_run_eggnog_mapper", "run"]) == True:
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-anvi_script_run_eggnog_mapper.done"))


### PR DESCRIPTION
Hi Meren, I ran the contigs workflow with the newly added `anvi_run_trna_scan` on a staph genome and everything seemed checkout. FYI I left the `anvi_run_trna_scan` to run in the default snakemake config file so it would be easier to test immediately. There is also one FIXME where I wasn't sure how to work with one parameter in `anvi_run_trna_scan`, the `--trna-hits-file` parameter. 

Cheers,
Matt