### PR TITLE
Indel

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -376,6 +376,15 @@ D = {
                      "computational complexity, this feature comes 'off' by default. Using this flag you can rise against the "
                      "authority, as you always should, and make anvi'o profile codons."}
                 ),
+    'profile-indels': (
+            ['--profile-indels'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "The alignment of a read to a reference genome/sequence can be imperfect, such that the read exhibits "
+                     "insertions or deletions relative to the reference. Anvi'o normally accounts for this information "
+                     "but does not _store_ it in the profile database. If you would like this information, you could use "
+                     "this flag. It comes at significant computational cost."}
+                ),
     'drop-previous-annotations': (
             ['--drop-previous-annotations'],
             {'default': False,

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -383,7 +383,8 @@ D = {
              'help': "The alignment of a read to a reference genome/sequence can be imperfect, such that the read exhibits "
                      "insertions or deletions relative to the reference. Anvi'o normally accounts for this information "
                      "but does not _store_ it in the profile database. If you would like this information, you could use "
-                     "this flag. It comes at significant computational cost."}
+                     "this flag. It comes at significant computational cost. If --skip-SNV-profiling is set, --profile-indels "
+                     "will be unset."}
                 ),
     'drop-previous-annotations': (
             ['--drop-previous-annotations'],

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -358,6 +358,16 @@ D = {
                      "will instruct profiler to skip that step. Please remember that parameters and flags must be "
                      "identical between different profiles using the same contigs database for them to merge properly."}
                 ),
+    'skip-INDEL-profiling': (
+            ['--skip-INDEL-profiling'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "The alignment of a read to a reference genome/sequence can be imperfect, such that the read exhibits "
+                     "insertions or deletions relative to the reference. Anvi'o normally stores this information in the "
+                     "profile database since the time taken and extra storage do not amount to much, but if insist on not "
+                     "having this information, you can skip storing this information by providing this flag. Note: If "
+                     "--skip-SNV-profiling is provided, --skip-INDEL-profiling will automatically be enforced."}
+                ),
     'return-AA-frequencies-instead': (
             ['--return-AA-frequencies-instead'],
             {'default': False,
@@ -375,16 +385,6 @@ D = {
                      "codon frequencies opens doors to powerful evolutionary insights in downstream analyses, due to its "
                      "computational complexity, this feature comes 'off' by default. Using this flag you can rise against the "
                      "authority, as you always should, and make anvi'o profile codons."}
-                ),
-    'profile-indels': (
-            ['--profile-indels'],
-            {'default': False,
-             'action': 'store_true',
-             'help': "The alignment of a read to a reference genome/sequence can be imperfect, such that the read exhibits "
-                     "insertions or deletions relative to the reference. Anvi'o normally accounts for this information "
-                     "but does not _store_ it in the profile database. If you would like this information, you could use "
-                     "this flag. It comes at significant computational cost. If --skip-SNV-profiling is set, --profile-indels "
-                     "will be unset."}
                 ),
     'drop-previous-annotations': (
             ['--drop-previous-annotations'],

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -992,6 +992,7 @@ def _vectorize_read(cigartuples, query_sequence, reference_sequence, reference_s
             ref_consumed += length
 
         elif consumes_read:
+            v[count:(count + length), 0] = ref_consumed + reference_start - 1
             v[count:(count + length), 1] = query_sequence[read_consumed:(read_consumed + length)]
             v[count:(count + length), 2] = 1
 

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -102,7 +102,7 @@ class BAMFileObject(pysam.AlignmentFile):
 
         percent_id_cutoff : float, 0
             Reads with a percentage ID relative to their mapped segments of the reference genome
-            less than this amount will be excluded. I.e. if you want 95% as a cutoff, use
+            less than this amount will be excluded. E.g. if you want 95% as a cutoff, use
             percent_id_cutoff=95.0
         """
 
@@ -128,7 +128,6 @@ class BAMFileObject(pysam.AlignmentFile):
 
             if read.reference_end - end > 0:
                 read.trim(trim_by=(read.reference_end - end), side='right')
-
 
             yield read
 
@@ -382,6 +381,7 @@ class Coverage:
         self.median = 0.0
         self.detection = 0.0
         self.mean_Q2Q3 = 0.0
+        self.num_reads = 0
 
         self.read_iterator_dict = {
             'fetch': self._fetch_iterator,
@@ -458,6 +458,8 @@ class Coverage:
             else:
                 for start, end in read.get_blocks():
                     c[start:end] += 1
+
+            self.num_reads += 1
 
         self.c = c
 

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -132,7 +132,7 @@ class BAMFileObject(pysam.AlignmentFile):
             yield read
 
 
-    def reads_have_MD_tags(num_reads=10000, require=all):
+    def reads_have_MD_tags(self, num_reads=10000, require=all):
         """A holistic approach to testing if reads in the BAM file have MD tags
 
         Tests the first `num_reads` in the file to see if they contain the MD tag.  The MD tag

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -148,9 +148,13 @@ class Read:
         # attributes, all attributes of interest are redefined here
         self.cigartuples = np.array(read.cigartuples)
         self.query_sequence = np.frombuffer(read.query_sequence.encode('ascii'), np.uint8)
-        self.reference_sequence = np.frombuffer(read.get_reference_sequence().upper().encode('ascii'), np.uint8)
         self.reference_start = read.reference_start
         self.reference_end = read.reference_end
+
+        if read.has_tag('MD'):
+            self.reference_sequence = np.frombuffer(read.get_reference_sequence().upper().encode('ascii'), np.uint8)
+        else:
+            self.reference_sequence = np.array([ord('N')] * (self.reference_end - self.reference_start))
 
         # See self.vectorize
         self.v = None

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -183,7 +183,7 @@ class Split:
 
 class Auxiliary:
     def __init__(self, split, min_coverage=10, report_variability_full=False, profile_SCVs=False,
-                 profile_indels=False, skip_SNV_profiling=False, min_percent_identity=None):
+                 skip_INDEL_profiling=False, skip_SNV_profiling=False, min_percent_identity=None):
 
         if anvio.DEBUG:
             self.run = terminal.Run()
@@ -194,7 +194,7 @@ class Auxiliary:
         self.min_percent_identity = min_percent_identity
         self.skip_SNV_profiling = skip_SNV_profiling
         self.profile_SCVs = profile_SCVs
-        self.profile_indels = profile_indels
+        self.skip_INDEL_profiling = skip_INDEL_profiling
         self.report_variability_full = report_variability_full
 
         # used during array processing
@@ -424,14 +424,14 @@ class Auxiliary:
 
 
     def run_SNVs_and_indels(self, bam):
-        """Profile SNVs (and indels if self.profile_indels)
+        """Profile SNVs (and indels if not self.skip_INDEL_profiling)
 
         Parameters
         ==========
         bam : bamops.BAMFileObject
         """
 
-        if self.profile_indels:
+        if not self.skip_INDEL_profiling:
             indels_profiles = {}
 
         # make an array with as many rows as there are nucleotides in the split, and as many rows as
@@ -456,7 +456,7 @@ class Auxiliary:
 
             allele_counts_array = utils.add_to_2D_numeric_array(aligned_sequence_as_index, reference_positions_in_split, allele_counts_array)
 
-            if self.profile_indels:
+            if not self.skip_INDEL_profiling:
                 read.vectorize()
 
                 for ins_segment in read.iterate_blocks_by_mapping_type(mapping_type=1):
@@ -524,7 +524,7 @@ class Auxiliary:
         nt_profile.process()
 
         self.split.SNV_profiles = nt_profile.d
-        if self.profile_indels:
+        if not self.skip_INDEL_profiling:
             self.split.indels_profiles = indels_profiles
 
         self.split.num_SNV_entries = len(nt_profile.d['coverage'])

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -424,6 +424,8 @@ class Auxiliary:
 
             if self.profile_indels:
                 read.vectorize()
+                for ins_segment in read.iterate_blocks_by_mapping_type(mapping_type=1):
+                    print(ins_segment)
 
             read_count += 1
 

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -104,7 +104,7 @@ class Contig:
 
     def analyze_coverage(self, bam):
 
-        self.coverage.run(bam, self, method='accurate', max_coverage=anvio.auxiliarydataops.COVERAGE_MAX_VALUE)
+        self.coverage.run(bam, self, read_iterator='fetch', max_coverage=anvio.auxiliarydataops.COVERAGE_MAX_VALUE)
 
         if len(self.splits) == 1:
             # Coverage.process_c is a potentially expensive operation (taking up ~90% of the time of

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -102,9 +102,23 @@ class Contig:
         return d
 
 
-    def analyze_coverage(self, bam):
+    def analyze_coverage(self, bam, min_percent_identity):
 
-        self.coverage.run(bam, self, read_iterator='fetch', max_coverage=anvio.auxiliarydataops.COVERAGE_MAX_VALUE)
+        if min_percent_identity is None:
+            self.coverage.run(
+                bam,
+                self,
+                read_iterator='fetch',
+                max_coverage=anvio.auxiliarydataops.COVERAGE_MAX_VALUE,
+            )
+        else:
+            self.coverage.run(
+                bam,
+                self,
+                read_iterator='fetch_filter_and_trim',
+                max_coverage=anvio.auxiliarydataops.COVERAGE_MAX_VALUE,
+                percent_id_cutoff=min_percent_identity,
+            )
 
         if len(self.splits) == 1:
             # Coverage.process_c is a potentially expensive operation (taking up ~90% of the time of

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3293,6 +3293,7 @@ class ProfileDatabase:
         self.db.create_table(t.layer_orders_table_name, t.layer_orders_table_structure, t.layer_orders_table_types)
         self.db.create_table(t.variable_nts_table_name, t.variable_nts_table_structure, t.variable_nts_table_types)
         self.db.create_table(t.variable_codons_table_name, t.variable_codons_table_structure, t.variable_codons_table_types)
+        self.db.create_table(t.indels_table_name, t.indels_table_structure, t.indels_table_types)
         self.db.create_table(t.views_table_name, t.views_table_structure, t.views_table_types)
         self.db.create_table(t.collections_info_table_name, t.collections_info_table_structure, t.collections_info_table_types)
         self.db.create_table(t.collections_bins_info_table_name, t.collections_bins_info_table_structure, t.collections_bins_info_table_types)

--- a/anvio/merger.py
+++ b/anvio/merger.py
@@ -19,6 +19,7 @@ import anvio.filesnpaths as filesnpaths
 import anvio.auxiliarydataops as auxiliarydataops
 
 from anvio.errors import ConfigError
+from anvio.tables.indels import TableForIndels
 from anvio.tables.variability import TableForVariability
 from anvio.tables.codonfrequencies import TableForCodonFrequencies
 from anvio.tables.miscdata import TableForLayerOrders, TableForLayerAdditionalData
@@ -288,7 +289,8 @@ class MultipleRuns:
                      ('min_coverage_for_variability', 'The minimum coverage values to report variability (-V)'),
                      ('report_variability_full', 'Whether to report full variability (--report-variability-full) flags'),
                      ('SCVs_profiled', 'Profile SCVs flags (--profile-SCVs)'),
-                     ('SNVs_profiled', 'SNV profiling flags (--skip-SNV-profiling)')]:
+                     ('SNVs_profiled', 'SNV profiling flags (--skip-SNV-profiling)'),
+                     ('indels_profiled', 'Profile indels flags (--profile-indels)')]:
             v = set([r[k] for r in list(self.profile_dbs_info_dict.values())])
             if len(v) > 1:
                 if anvio.FORCE:
@@ -376,6 +378,21 @@ class MultipleRuns:
         variable_codons_table.store()
 
 
+    def merge_indels_tables(self):
+        indels_table = TableForIndels(self.merged_profile_db_path, progress=self.progress)
+
+        for input_profile_db_path in self.profile_dbs_info_dict:
+            sample_profile_db = dbops.ProfileDatabase(input_profile_db_path, quiet=True)
+            sample_indels_table = sample_profile_db.db.get_table_as_list_of_tuples(tables.indels_table_name, tables.indels_table_structure)
+            sample_profile_db.disconnect()
+
+            for tpl in sample_indels_table:
+                entry = tuple([indels_table.next_id(tables.indels_table_name)] + list(tpl[1:]))
+                indels_table.append_entry(entry)
+
+        indels_table.store()
+
+
     def merge_split_coverage_data(self):
         output_file_path = os.path.join(self.output_directory, 'AUXILIARY-DATA.db')
         merged_split_coverage_values = auxiliarydataops.AuxiliaryDataForSplitCoverages(output_file_path, self.contigs_db_hash, create_new=True)
@@ -461,6 +478,7 @@ class MultipleRuns:
         self.report_variability_full = C('report_variability_full')
         self.SCVs_profiled = C('SCVs_profiled')
         self.SNVs_profiled = C('SNVs_profiled')
+        self.indels_profiled = int(C('indels_profiled'))
         self.total_length = C('total_length')
 
         if self.num_splits > self.max_num_splits_for_hierarchical_clustering and not self.enforce_hierarchical_clustering:
@@ -500,6 +518,7 @@ class MultipleRuns:
                        'max_contig_length': self.max_contig_length,
                        'SNVs_profiled': self.SNVs_profiled,
                        'SCVs_profiled': self.SCVs_profiled,
+                       'indels_profiled': self.indels_profiled,
                        'num_contigs': self.num_contigs,
                        'num_splits': self.num_splits,
                        'total_length': self.total_length,
@@ -545,6 +564,14 @@ class MultipleRuns:
             self.progress.end()
         else:
             self.run.warning("Codon frequencies were not profiled, hence, these tables will be empty in the merged profile database.")
+
+        if self.indels_profiled:
+            self.progress.new('Merging indels tables')
+            self.progress.update('...')
+            self.merge_indels_tables()
+            self.progress.end()
+        else:
+            self.run.warning("Indels were not profiled, hence, these tables will be empty in the merged profile database.")
 
         # critical part:
         self.gen_view_data_tables_from_atomic_data()

--- a/anvio/merger.py
+++ b/anvio/merger.py
@@ -290,7 +290,7 @@ class MultipleRuns:
                      ('report_variability_full', 'Whether to report full variability (--report-variability-full) flags'),
                      ('SCVs_profiled', 'Profile SCVs flags (--profile-SCVs)'),
                      ('SNVs_profiled', 'SNV profiling flags (--skip-SNV-profiling)'),
-                     ('indels_profiled', 'Profile indels flags (--profile-indels)')]:
+                     ('INDELs_profiled', 'Profile indels flags (--profile-indels)')]:
             v = set([r[k] for r in list(self.profile_dbs_info_dict.values())])
             if len(v) > 1:
                 if anvio.FORCE:
@@ -478,7 +478,7 @@ class MultipleRuns:
         self.report_variability_full = C('report_variability_full')
         self.SCVs_profiled = C('SCVs_profiled')
         self.SNVs_profiled = C('SNVs_profiled')
-        self.indels_profiled = int(C('indels_profiled'))
+        self.INDELs_profiled = int(C('INDELs_profiled'))
         self.total_length = C('total_length')
 
         if self.num_splits > self.max_num_splits_for_hierarchical_clustering and not self.enforce_hierarchical_clustering:
@@ -518,7 +518,7 @@ class MultipleRuns:
                        'max_contig_length': self.max_contig_length,
                        'SNVs_profiled': self.SNVs_profiled,
                        'SCVs_profiled': self.SCVs_profiled,
-                       'indels_profiled': self.indels_profiled,
+                       'INDELs_profiled': self.INDELs_profiled,
                        'num_contigs': self.num_contigs,
                        'num_splits': self.num_splits,
                        'total_length': self.total_length,
@@ -565,7 +565,7 @@ class MultipleRuns:
         else:
             self.run.warning("Codon frequencies were not profiled, hence, these tables will be empty in the merged profile database.")
 
-        if self.indels_profiled:
+        if self.INDELs_profiled:
             self.progress.new('Merging indels tables')
             self.progress.update('...')
             self.merge_indels_tables()

--- a/anvio/merger.py
+++ b/anvio/merger.py
@@ -433,7 +433,6 @@ class MultipleRuns:
         # this is not the best way to do it. a better way probably required all reads obtained from each
         # run, yet even that would wrongly assume equal eukaryotic contamination, etc. normalization is a bitch.
 
-        smallest_sample_size = min(self.total_reads_mapped_per_sample.values())
         smallest_non_zero_sample_size = min([v for v in self.total_reads_mapped_per_sample.values() if v] or [0])
 
         if smallest_non_zero_sample_size == 0 and not self.skip_hierarchical_clustering:

--- a/anvio/migrations/profile/v31_to_v32.py
+++ b/anvio/migrations/profile/v31_to_v32.py
@@ -5,6 +5,7 @@ import sys
 import argparse
 
 import anvio.db as db
+import anvio.tables as t
 import anvio.utils as utils
 import anvio.terminal as terminal
 
@@ -27,13 +28,20 @@ def migrate(db_path):
     if str(profile_db.get_version()) != current_version:
         raise ConfigError("Version of this profile database is not %s (hence, this script cannot really do anything)." % current_version)
 
+    try:
+        profile_db.create_table(t.indels_table_name, t.indels_table_structure, t.indels_table_types)
+    except:
+        pass
+
+    profile_db.set_meta_value('indels_profiled', 0)
+
+    # set the version
+    profile_db.remove_meta_key_value_pair('version')
+    profile_db.set_version(next_version)
+
+    # full as opposed to a "blank profile"
     tables_in_db = profile_db.get_table_names()
     is_full_profile = 'mean_coverage_Q2Q3_splits' in tables_in_db or 'atomic_data_splits' in tables_in_db
-
-    if is_full_profile:
-        # contigs_ordered -> items_ordered
-        profile_db.set_meta_value('items_ordered', profile_db.get_meta_value('contigs_ordered'))
-        profile_db.remove_meta_key_value_pair('contigs_ordered')
 
     # set the version
     profile_db.remove_meta_key_value_pair('version')
@@ -44,7 +52,7 @@ def migrate(db_path):
     progress.end()
 
     if is_full_profile:
-        run.info_single("Your profile db is now %s (WRONG .. anvi'o never takes breaks)." % next_version, nl_after=1, nl_before=1, mc='green')
+        run.info_single("Your profile db is now %s." % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. But essentially nothing really happened to your "
                         "database since it was a blank profile (which is OK, move along)." \

--- a/anvio/migrations/profile/v31_to_v32.py
+++ b/anvio/migrations/profile/v31_to_v32.py
@@ -33,7 +33,7 @@ def migrate(db_path):
     except:
         pass
 
-    profile_db.set_meta_value('indels_profiled', 0)
+    profile_db.set_meta_value('INDELs_profiled', 0)
     profile_db.set_meta_value('min_percent_identity', 0)
 
     # set the version

--- a/anvio/migrations/profile/v31_to_v32.py
+++ b/anvio/migrations/profile/v31_to_v32.py
@@ -34,6 +34,7 @@ def migrate(db_path):
         pass
 
     profile_db.set_meta_value('indels_profiled', 0)
+    profile_db.set_meta_value('min_percent_identity', 0)
 
     # set the version
     profile_db.remove_meta_key_value_pair('version')

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -188,7 +188,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
                        'max_contig_length': self.max_contig_length,
                        'SNVs_profiled': not self.skip_SNV_profiling,
                        'SCVs_profiled': self.profile_SCVs,
-                       'indels_profiled': self.profile_indels,
+                       'INDELs_profiled': self.profile_indels,
                        'min_percent_identity': self.min_percent_identity or 0,
                        'min_coverage_for_variability': self.min_coverage_for_variability,
                        'report_variability_full': self.report_variability_full,

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -70,6 +70,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.skip_SNV_profiling = A('skip_SNV_profiling')
         self.profile_SCVs = A('profile_SCVs')
         self.profile_indels = A('profile_indels')
+        self.min_percent_identity = A('min_percent_identity')
         self.gen_serialized_profile = A('gen_serialized_profile')
         self.distance = A('distance') or constants.distance_metric_default
         self.linkage = A('linkage') or constants.linkage_method_default
@@ -659,7 +660,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
         timer.make_checkpoint('Gene info for split added')
 
         # analyze coverage for each split
-        contig.analyze_coverage(bam_file)
+        contig.analyze_coverage(bam_file, self.min_percent_identity)
         timer.make_checkpoint('Coverage done')
 
         # test the mean coverage of the contig.

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -636,9 +636,6 @@ class BAMProfiler(dbops.ContigsSuperclass):
                 # We mark these for deletion the next time garbage is collected
                 for split in contig.splits:
                     del split.coverage
-                    del split.auxiliary.split.SNV_profiles
-                    del split.auxiliary.split.SCV_profiles
-                    del split.auxiliary.split
                     del split.auxiliary
                     del split
                 del contig.splits[:]
@@ -770,9 +767,6 @@ class BAMProfiler(dbops.ContigsSuperclass):
                 for c in self.contigs:
                     for split in c.splits:
                         del split.coverage
-                        del split.auxiliary.split.SNV_profiles
-                        del split.auxiliary.split.SCV_profiles
-                        del split.auxiliary.split
                         del split.auxiliary
                         del split
                     del c.splits[:]

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -344,7 +344,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
         for contig in self.contigs:
             for split in contig.splits:
                 for entry in split.indels_profiles.values():
-                    self.indels_table.append(entry.values())
+                    self.indels_table.append([self.sample_id] + list(entry.values()))
 
         self.indels_table.store()
 

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -337,6 +337,18 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.variable_nts_table.store()
 
 
+    def generate_indels_table(self):
+        if not self.profile_indels:
+            return
+
+        for contig in self.contigs:
+            for split in contig.splits:
+                for entry in split.indels_profiles.values():
+                    self.indels_table.append(entry.values())
+
+        self.indels_table.store()
+
+
     def store_split_coverages(self):
         for contig in self.contigs:
             for split in contig.splits:
@@ -895,6 +907,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
 
         self.generate_variable_nts_table()
         self.generate_variable_codons_table()
+        self.generate_indels_table()
         self.store_split_coverages()
 
         # creating views in the database for atomic data we gathered during the profiling. Meren, please note

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -471,6 +471,13 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.contig_names = self.bam.references
         self.contig_lengths = self.bam.lengths
 
+        if self.min_percent_identity and not self.bam.reads_have_MD_tags():
+            raise ConfigError("Your BAM file has reads that do not have MD "
+                              "tags, which give essential information about the "
+                              "reference bases in alignments. Unfortunately, "
+                              "this is required to use --min-percent-identity. "
+                              "Please remove this flag or redo your mapping.")
+
         utils.check_contig_names(self.contig_names)
 
         self.run.info('input_bam', self.input_file_path)

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -679,7 +679,8 @@ class BAMProfiler(dbops.ContigsSuperclass):
                                                       profile_indels=self.profile_indels,
                                                       skip_SNV_profiling=self.skip_SNV_profiling,
                                                       min_coverage=self.min_coverage_for_variability,
-                                                      report_variability_full=self.report_variability_full)
+                                                      report_variability_full=self.report_variability_full,
+                                                      min_percent_identity=self.min_percent_identity)
 
                 split.auxiliary.process(bam_file)
 

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -188,6 +188,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
                        'SNVs_profiled': not self.skip_SNV_profiling,
                        'SCVs_profiled': self.profile_SCVs,
                        'indels_profiled': self.profile_indels,
+                       'min_percent_identity': self.min_percent_identity or 0,
                        'min_coverage_for_variability': self.min_coverage_for_variability,
                        'report_variability_full': self.report_variability_full,
                        'contigs_db_hash': self.a_meta['contigs_db_hash'],
@@ -247,6 +248,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.run.info('skip_SNV_profiling', self.skip_SNV_profiling)
         self.run.info('profile_SCVs', self.profile_SCVs)
         self.run.info('profile_indels', self.profile_indels)
+        self.run.info('min_percent_identity', self.min_percent_identity)
         self.run.info('report_variability_full', self.report_variability_full)
 
         self.run.warning("Your minimum contig length is set to %s base pairs. So anvi'o will not take into "

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -155,6 +155,10 @@ variable_nts_table_name              = 'variable_nucleotides'
 variable_nts_table_structure         = ['entry_id', 'sample_id', 'split_name',   'pos'  , 'pos_in_contig', 'corresponding_gene_call', 'in_partial_gene_call', 'in_complete_gene_call', 'base_pos_in_codon', 'codon_order_in_gene', 'coverage', 'cov_outlier_in_split', 'cov_outlier_in_contig', 'departure_from_reference', 'competing_nts', 'reference'] + nucleotides
 variable_nts_table_types             = [ 'numeric',    'text'  ,    'text'   , 'numeric',    'numeric'   ,        'numeric'         ,       'numeric'       ,       'numeric'        ,       'numeric'    ,       'numeric'      , 'numeric' ,          'bool'       ,          'bool'        ,          'numeric'        ,      'text'    ,    'text'  ] + ['numeric'] * len(nucleotides)
 
+indels_table_name                    = 'indels'
+indels_table_structure               = ['entry_id', 'split_name', 'type', 'sequence', 'start_in_contig', 'end_in_contig', 'start_in_split', 'end_in_split', 'coverage']
+indels_table_types                   = ['numeric' , 'text   '   , 'text', 'text'    , 'numeric'        , 'numeric'      , 'numeric'       , 'numeric'     , 'numeric']
+
 views_table_name                     = 'views'
 views_table_structure                = ['view_id', 'target_table']
 views_table_types                    = [  'str'  ,      'str'    ]

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -156,8 +156,8 @@ variable_nts_table_structure         = ['entry_id', 'sample_id', 'split_name',  
 variable_nts_table_types             = [ 'numeric',    'text'  ,    'text'   , 'numeric',    'numeric'   ,        'numeric'         ,       'numeric'       ,       'numeric'        ,       'numeric'    ,       'numeric'      , 'numeric' ,          'bool'       ,          'bool'        ,          'numeric'        ,      'text'    ,    'text'  ] + ['numeric'] * len(nucleotides)
 
 indels_table_name                    = 'indels'
-indels_table_structure               = ['entry_id', 'split_name', 'type', 'sequence', 'start_in_contig', 'start_in_split', 'length' , 'coverage']
-indels_table_types                   = ['numeric' , 'text'      , 'text', 'text'    , 'numeric'        , 'numeric'       , 'numeric', 'numeric' ]
+indels_table_structure               = ['entry_id', 'sample_id', 'split_name', 'type', 'sequence', 'start_in_contig', 'start_in_split', 'length' , 'coverage']
+indels_table_types                   = ['numeric' , 'text'     , 'text'      , 'text', 'text'    , 'numeric'        , 'numeric'       , 'numeric', 'numeric' ]
 
 views_table_name                     = 'views'
 views_table_structure                = ['view_id', 'target_table']

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -14,7 +14,7 @@ __email__ = "a.murat.eren@gmail.com"
 
 
 contigs_db_version = "14"
-profile_db_version = "31"
+profile_db_version = "32"
 genes_db_version = "5"
 pan_db_version = "13"
 auxiliary_data_version = "2"

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -156,8 +156,8 @@ variable_nts_table_structure         = ['entry_id', 'sample_id', 'split_name',  
 variable_nts_table_types             = [ 'numeric',    'text'  ,    'text'   , 'numeric',    'numeric'   ,        'numeric'         ,       'numeric'       ,       'numeric'        ,       'numeric'    ,       'numeric'      , 'numeric' ,          'bool'       ,          'bool'        ,          'numeric'        ,      'text'    ,    'text'  ] + ['numeric'] * len(nucleotides)
 
 indels_table_name                    = 'indels'
-indels_table_structure               = ['entry_id', 'split_name', 'type', 'sequence', 'start_in_contig', 'end_in_contig', 'start_in_split', 'end_in_split', 'coverage']
-indels_table_types                   = ['numeric' , 'text'      , 'text', 'text'    , 'numeric'        , 'numeric'      , 'numeric'       , 'numeric'     , 'numeric' ]
+indels_table_structure               = ['entry_id', 'split_name', 'type', 'sequence', 'start_in_contig', 'start_in_split', 'length' , 'coverage']
+indels_table_types                   = ['numeric' , 'text'      , 'text', 'text'    , 'numeric'        , 'numeric'       , 'numeric', 'numeric' ]
 
 views_table_name                     = 'views'
 views_table_structure                = ['view_id', 'target_table']

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -157,7 +157,7 @@ variable_nts_table_types             = [ 'numeric',    'text'  ,    'text'   , '
 
 indels_table_name                    = 'indels'
 indels_table_structure               = ['entry_id', 'split_name', 'type', 'sequence', 'start_in_contig', 'end_in_contig', 'start_in_split', 'end_in_split', 'coverage']
-indels_table_types                   = ['numeric' , 'text   '   , 'text', 'text'    , 'numeric'        , 'numeric'      , 'numeric'       , 'numeric'     , 'numeric']
+indels_table_types                   = ['numeric' , 'text'      , 'text', 'text'    , 'numeric'        , 'numeric'      , 'numeric'       , 'numeric'     , 'numeric' ]
 
 views_table_name                     = 'views'
 views_table_structure                = ['view_id', 'target_table']

--- a/anvio/tables/codonfrequencies.py
+++ b/anvio/tables/codonfrequencies.py
@@ -48,7 +48,7 @@ class TableForCodonFrequencies(Table):
 
 
     def append(self, entry):
-        """Append a single entry based on a dictionary
+        """Append a single entry based on a sequence
 
         Parameters
         ==========

--- a/anvio/tables/indels.py
+++ b/anvio/tables/indels.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8
+# pylint: disable=line-too-long
+
+import anvio
+import anvio.db as db
+import anvio.tables as t
+import anvio.utils as utils
+import anvio.terminal as terminal
+
+from anvio.tables.tableops import Table
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "A. Murat Eren"
+__email__ = "a.murat.eren@gmail.com"
+__status__ = "Development"
+
+
+run = terminal.Run()
+progress = terminal.Progress()
+pp = terminal.pretty_print
+
+
+class TableForIndels(Table):
+    def __init__(self, db_path, run=run, progress=progress):
+        self.db_path = db_path
+        self.run = run
+        self.progress = progress
+
+        Table.__init__(self, self.db_path, utils.get_required_version_for_db(db_path), run=self.run, progress=self.progress)
+
+        self.num_entries = self.get_num_entries()
+        self.db_entries = []
+        self.set_next_available_id(t.indels_table_name)
+
+        # after getting an instance, we don't want things to keep accumulating
+        # in memory. the purpose of the following variable is to ensure whenever
+        # the number of entries in `self.db_entries` variable exceeds a certain
+        # value, it will be written to the database and the global variable
+        # `self.db_entries` will be emptied, saving significant memory space:
+        self.max_num_entries_in_storage_buffer = 50000
+
+
+    def get_num_entries(self):
+        database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
+        num_entries = database.get_row_counts_from_table(t.variable_nts_table_name)
+        database.disconnect()
+
+        return num_entries
+
+
+    def append_entry(self, entry):
+        """FIXME This needs documentation to explain difference between append and append_entry"""
+
+        self.db_entries.append(entry)
+
+        if len(self.db_entries) > self.max_num_entries_in_storage_buffer:
+            # everytime we are here, the contenst of self.db_entries will be stored in the
+            # database
+            self.store()
+
+
+    def append(self, entry):
+        """Append a single entry based on a sequence
+
+        Parameters
+        ==========
+        entry : sequence
+            values in order they are in the table, entry_id excluded (it will be appended in the
+            body of this function)
+        """
+
+        db_entry = (self.next_id(t.indels_table_name), *entry)
+        self.db_entries.append(db_entry)
+        self.num_entries += 1
+
+        if len(self.db_entries) >= self.max_num_entries_in_storage_buffer:
+            # everytime we are here, the contenst of self.db_entries will be stored in the
+            # database
+            self.store()
+
+
+    def store(self):
+        if not len(self.db_entries):
+            return
+
+        database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
+        database._exec_many('''INSERT INTO %s VALUES (?,?,?,?,?,?,?,?,?)''' % t.indels_table_name, self.db_entries)
+        database.disconnect()
+
+        if anvio.DEBUG:
+            run.info_single("INDELS: %d entries added to the indels table." % len(self.db_entries), mc="green")
+
+        self.db_entries = []

--- a/anvio/tables/indels.py
+++ b/anvio/tables/indels.py
@@ -15,9 +15,8 @@ __copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
 __credits__ = []
 __license__ = "GPL 3.0"
 __version__ = anvio.__version__
-__maintainer__ = "A. Murat Eren"
-__email__ = "a.murat.eren@gmail.com"
-__status__ = "Development"
+__maintainer__ = "Evan Kiefl"
+__email__ = "kiefl.evan@gmail.com"
 
 
 run = terminal.Run()

--- a/anvio/tables/variability.py
+++ b/anvio/tables/variability.py
@@ -65,7 +65,7 @@ class TableForVariability(Table):
 
 
     def append(self, entry):
-        """Append a single entry based on a dictionary
+        """Append a single entry based on a sequence
 
         Parameters
         ==========

--- a/anvio/tests/run_mini_test.sh
+++ b/anvio/tests/run_mini_test.sh
@@ -33,7 +33,12 @@ sqlite3 $output_dir/CONTIGS.db '.tables'
 for f in 01 02 03
 do
     INFO "Profiling sample SAMPLE-$f"
-    anvi-profile -i $output_dir/SAMPLE-$f.bam -o $output_dir/SAMPLE-$f -c $output_dir/CONTIGS.db --cluster --profile-SCVs
+    anvi-profile -i $output_dir/SAMPLE-$f.bam \
+                 -o $output_dir/SAMPLE-$f \
+                 -c $output_dir/CONTIGS.db \
+                 --cluster \
+                 --profile-SCVs \
+                 --profile-indels
 
     INFO "Importing short-read-level taxonomy for SAMPLE-$f"
     anvi-import-taxonomy-for-layers -p $output_dir/SAMPLE-$f/PROFILE.db \

--- a/bin/anvi-profile
+++ b/bin/anvi-profile
@@ -63,8 +63,8 @@ if __name__ == '__main__':
     groupM.add_argument(*anvio.A('sample-name'), **anvio.K('sample-name'))
     groupM.add_argument(*anvio.A('report-variability-full'), **anvio.K('report-variability-full'))
     groupM.add_argument(*anvio.A('skip-SNV-profiling'), **anvio.K('skip-SNV-profiling'))
+    groupM.add_argument(*anvio.A('skip-INDEL-profiling'), **anvio.K('skip-INDEL-profiling'))
     groupM.add_argument(*anvio.A('profile-SCVs'), **anvio.K('profile-SCVs'))
-    groupM.add_argument(*anvio.A('profile-indels'), **anvio.K('profile-indels'))
     groupM.add_argument(*anvio.A('min-percent-identity'), **anvio.K('min-percent-identity', {'help': 
                             'Ignore any reads with a percent identity to the reference less '
                             'than this number, e.g. 95. If not provided, all reads in the BAM '

--- a/bin/anvi-profile
+++ b/bin/anvi-profile
@@ -65,6 +65,10 @@ if __name__ == '__main__':
     groupM.add_argument(*anvio.A('skip-SNV-profiling'), **anvio.K('skip-SNV-profiling'))
     groupM.add_argument(*anvio.A('profile-SCVs'), **anvio.K('profile-SCVs'))
     groupM.add_argument(*anvio.A('profile-indels'), **anvio.K('profile-indels'))
+    groupM.add_argument(*anvio.A('min-percent-identity'), **anvio.K('min-percent-identity', {'help': 
+                            'Ignore any reads with a percent identity to the reference less '
+                            'than this number, e.g. 95. If not provided, all reads in the BAM '
+                            'file will be used (and things will run faster).', 'default': None}))
     groupM.add_argument(*anvio.A('description'), **anvio.K('description'))
     groupX.add_argument(*anvio.A('cluster-contigs'), **anvio.K('cluster-contigs'))
     groupX.add_argument(*anvio.A('skip-hierarchical-clustering'), **anvio.K('skip-hierarchical-clustering'))

--- a/bin/anvi-profile
+++ b/bin/anvi-profile
@@ -64,6 +64,7 @@ if __name__ == '__main__':
     groupM.add_argument(*anvio.A('report-variability-full'), **anvio.K('report-variability-full'))
     groupM.add_argument(*anvio.A('skip-SNV-profiling'), **anvio.K('skip-SNV-profiling'))
     groupM.add_argument(*anvio.A('profile-SCVs'), **anvio.K('profile-SCVs'))
+    groupM.add_argument(*anvio.A('profile-indels'), **anvio.K('profile-indels'))
     groupM.add_argument(*anvio.A('description'), **anvio.K('description'))
     groupX.add_argument(*anvio.A('cluster-contigs'), **anvio.K('cluster-contigs'))
     groupX.add_argument(*anvio.A('skip-hierarchical-clustering'), **anvio.K('skip-hierarchical-clustering'))

--- a/sandbox/anvi-script-get-coverage-from-bam
+++ b/sandbox/anvi-script-get-coverage-from-bam
@@ -36,7 +36,7 @@ class ComputeCoverage(object):
         self.sanity_check()
         self.f = self.init_output()
 
-        self.bam = pysam.Samfile(self.args.bam_file, 'rb')
+        self.bam = bamops.BAMFileObject(self.args.bam_file, 'rb')
 
         # lengths is {contig_name: contig_length} of each contig in the bam
         self.lengths = dict(zip(self.bam.references, self.bam.lengths))
@@ -123,11 +123,12 @@ class ComputeCoverage(object):
         ==========
         contig_name : str
         """
+
         self.progress.increment()
         self.progress.update('%s (%d/%d)' % (contig_name, self.progress.progress_current_item, self.progress.progress_total_items))
 
         cov = bamops.Coverage()
-        cov.run(self.bam, contig_name, skip_coverage_stats=True)
+        cov.run(self.bam, contig_name, read_iterator='fetch', skip_coverage_stats=True)
 
         return cov.c
 

--- a/sandbox/anvi-script-get-coverage-from-bam
+++ b/sandbox/anvi-script-get-coverage-from-bam
@@ -166,6 +166,7 @@ class ComputeCoverage(object):
             self.process_collection_txt()
 
         self.progress.end()
+        self.f.close()
         self.run.info_single('Output file %s has been written' % self.args.output, nl_before=1)
 
 


### PR DESCRIPTION
PR opens up several new doors into the anvi-profile world.

## indels can be stored in DB

With `--profile-indels`, one can store each indel. Here is the table structure:

![image](https://user-images.githubusercontent.com/8688665/78319783-81360280-752d-11ea-923e-c69eb1bc0e40.png)

## percentage ID filtering during anvi-profile

With `--min-percent-identity`, one can filter reads based on percentage identity.