### PR TITLE
A way to ask anvi'o skip checking genome hashes

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -297,6 +297,16 @@ D = {
                      "'collection_id', 'profile_db_path', 'contigs_db_path'. Each line should list a single entry, where 'name' "
                      "can be any name to describe the anvi'o bin identified as 'bin_id' that is stored in a collection."}
                 ),
+    'skip-checking-genome-hashes': (
+            ['--skip-checking-genome-hashes'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Use this flag if you would like anvi'o to skip checking genome hashes. This is only relevant if you may have "
+                     "genomes in your internal or external genomes files that have identical sequences with different names AND if "
+                     "you are OK with it. You may be OK with it, for instance, if you are using `anvi-dereplicate-genomes` program "
+                     "to dereplicate genomes desribed in multiple collections in an anvi'o profile database that may be describing "
+                     "the same genome multiple times (see https://github.com/merenlab/anvio/issues/1397 for a case)."}
+                ),
     'metagenomes': (
             ['-M', '--metagenomes'],
             {'metavar': 'FILE_PATH',

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -290,7 +290,7 @@ class Run:
                 sys.stderr.write(line.encode('utf-8'))
 
 
-    def info(self, key, value, quiet=False, display_only=False, nl_before=0, nl_after=0, lc='cyan', mc='yellow', progress=None):
+    def info(self, key, value, quiet=False, display_only=False, overwrite_verbose=False, nl_before=0, nl_after=0, lc='cyan', mc='yellow', progress=None):
         if not display_only:
             self.info_dict[key] = value
 
@@ -309,14 +309,13 @@ class Run:
 
         if progress:
             progress.clear()
-            self.write(info_line, quiet=quiet)
+            self.write(info_line, overwrite_verbose=False, quiet=quiet)
             progress.update(progress.msg)
-
         else:
-            self.write(info_line, quiet=quiet)
+            self.write(info_line, quiet=quiet, overwrite_verbose=overwrite_verbose)
 
 
-    def info_single(self, message, mc='yellow', nl_before=0, nl_after=0, cut_after=80, level=1, progress=None):
+    def info_single(self, message, overwrite_verbose=False, mc='yellow', nl_before=0, nl_after=0, cut_after=80, level=1, progress=None):
         if isinstance(message, str):
             message = remove_spaces(message)
 
@@ -332,11 +331,10 @@ class Run:
 
         if progress:
             progress.clear()
-            self.write(message_line)
+            self.write(message_line, overwrite_verbose=False)
             progress.update(progress.msg)
-
         else:
-            self.write(message_line)
+            self.write(message_line, overwrite_verbose=False)
 
 
     def warning(self, message, header='WARNING', lc='red', raw=False, overwrite_verbose=False, nl_before=0, nl_after=0):

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -283,7 +283,7 @@ class Run:
         if self.log_file_path:
             self.log(line)
 
-        if (self.verbose and not quiet) or overwrite_verbose:
+        if (self.verbose and not quiet) or (overwrite_verbose and not anvio.QUIET):
             try:
                 sys.stderr.write(line)
             except:

--- a/bin/anvi-dereplicate-genomes
+++ b/bin/anvi-dereplicate-genomes
@@ -108,6 +108,7 @@ if __name__ == '__main__':
     groupH = parser.add_argument_group('OTHER IMPORTANT STUFF', "Yes. You're almost done.")
     groupH.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
     groupH.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
+    groupH.add_argument(*anvio.A('skip-checking-genome-hashes'), **anvio.K('skip-checking-genome-hashes'))
     groupH.add_argument(*anvio.A('log-file'), **anvio.K('log-file'))
 
     args = anvio.get_args(parser)


### PR DESCRIPTION
This PR addresses #1397. So the user can instruct anvi'o to skip checking genome hashes.

This is a risky flag, but testing it with `anvi-dereplicate-genomes` seemed to be working well.