### PR TITLE
Fix modules db bug

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2961,7 +2961,8 @@ class KeggModulesDatabase(KeggContext):
         data_types_to_split = ["ORTHOLOGY","REACTION"] # lines that fall under these categories need to have data_vals split on comma
         if current_data_name in data_types_to_split:
             # here we should NOT split on any commas within parentheses
-            for val in re.split(',(?!.*\))', data_vals):
+            vals = [x for x in re.split('\(|\)|,|\+|-', data_vals) if x]
+            for val in vals:
                 line_entries.append((current_data_name, val, data_def, line_num))
         else:
             line_entries.append((current_data_name, data_vals, data_def, line_num))

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -21,7 +21,7 @@ auxiliary_data_version = "2"
 structure_db_version = "2"
 genomes_storage_vesion = "7"
 workflow_config_version = "1"
-kegg_modules_db_version = "1"
+kegg_modules_db_version = "2"
 
 versions_for_db_types = {'contigs': contigs_db_version,
                          'profile': profile_db_version,


### PR DESCRIPTION
Briefly, this PR fixes a bug in the MODULES.db setup done in `anvi-setup-kegg-kofams`. Prior to this fix, some KOs that are components of enzyme complexes and on the same ORTHOLOGY line in a modules file were not separated when parsing the line. These KOs ended up in the same ORTHOLOGY row in the MODULES.db:
![image](https://user-images.githubusercontent.com/10360586/85097223-7ac63700-b1bc-11ea-8938-047ecb4461e1.png)

And since they were multiple KOs in the same ORTHOLOGY line, these KOs could not be found when searched for individually. 

After this fix, the KOs are separated so that they each get their own individual ORTHOLOGY line in the DB:
![image](https://user-images.githubusercontent.com/10360586/85096940-7d745c80-b1bb-11ea-9862-b6d5858f94b2.png)
So now searching works for these individual KOs, they get marked as present in their respective modules, and the module completion estimates are now correct.