### PR TITLE
SCG taxonomy versioning

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3956,6 +3956,7 @@ class ContigsDatabase:
         self.db.set_meta_value('skip_predict_frame', True if skip_predict_frame else False)
         self.db.set_meta_value('splits_consider_gene_calls', (not skip_mindful_splitting))
         self.db.set_meta_value('scg_taxonomy_was_run', False)
+        self.db.set_meta_value('scg_taxonomy_database_version', None)
         self.db.set_meta_value('creation_date', self.get_date())
         self.disconnect()
 

--- a/anvio/migrations/contigs/v17_to_v18.py
+++ b/anvio/migrations/contigs/v17_to_v18.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+import argparse
+
+import anvio.db as db
+import anvio.utils as utils
+import anvio.terminal as terminal
+
+from anvio.errors import ConfigError
+
+current_version, next_version = [x[1:] for x in __name__.split('_to_')]
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+def migrate(db_path):
+    if db_path is None:
+        raise ConfigError("No database path is given.")
+
+    utils.is_contigs_db(db_path)
+
+    contigs_db = db.DB(db_path, None, ignore_version = True)
+    if str(contigs_db.get_version()) != current_version:
+        raise ConfigError("Version of this contigs database is not %s (hence, this script cannot really do anything)." % current_version)
+
+    progress.new("Updating the self table")
+    progress.update("...")
+
+    scg_taxonomy_was_run = contigs_db.get_meta_value('scg_taxonomy_was_run')
+    if scg_taxonomy_was_run:
+        contigs_db.set_meta_value('scg_taxonomy_database_version', 'v89')
+    else:
+        contigs_db.set_meta_value('scg_taxonomy_database_version', None)
+
+    progress.update("Updating version")
+    contigs_db.remove_meta_key_value_pair('version')
+    contigs_db.set_version(next_version)
+
+    progress.update("Committing changes")
+    contigs_db.disconnect()
+
+    progress.end()
+    run.info_single("The contigs database is now %s. We just updated the self table of the contigs database with a small "
+                    "bit of information to be able to track SCG taxonomy version changes more accurately going forward" % \
+                                    (next_version), nl_after=1, nl_before=1, mc='green')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='A simple script to upgrade CONTIGS.db from version %s to version %s' % (current_version, next_version))
+    parser.add_argument('contigs_db', metavar = 'CONTIGS_DB', help = 'Contigs database at version %s' % current_version)
+    args, unknown = parser.parse_known_args()
+
+    try:
+        migrate(args.contigs_db)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)

--- a/anvio/scgtaxonomyops.py
+++ b/anvio/scgtaxonomyops.py
@@ -300,11 +300,11 @@ class SanityCheck(object):
                                       "is easy to fix that. Please see the program `anvi-run-scg-taxonomy`.")
 
                 if scg_taxonomy_database_version != self.ctx.scg_taxonomy_database_version:
-                    raise ConfigError("The SCG taxonomy database on your computer has a different version (%s) than the SCG taxonomy information "
-                                      "stored in your contigs database (%s). Sadly, you will need to re-run SCG taxonomy on this contigs database "
-                                      "to make sure nothing funky is going on with your estimations :( If you are still here and willing to redo "
-                                      "this, the program you need is `anvi-run-scg-taxonomy`." % \
-                                                (self.ctx.scg_taxonomy_database_version, scg_taxonomy_database_version))
+                    self.progress.reset()
+                    self.run.warning("The SCG taxonomy database on your computer has a different version (%s) than the SCG taxonomy information "
+                                     "stored in your contigs database (%s). This is not a problem and things will most likely continue to work "
+                                     "fine, but we wanted to let you know. You can get rid of this warning by re-running `anvi-run-scg-taxonomy` "
+                                     "on your database." % (self.ctx.scg_taxonomy_database_version, scg_taxonomy_database_version))
 
                 if self.profile_db_path:
                     utils.is_profile_db_and_contigs_db_compatible(self.profile_db_path, self.contigs_db_path)
@@ -472,18 +472,23 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
         # with each other and with the installed version of SCG taxonomy database
         scg_taxonomy_database_versions_in_metagenomes = [g.metagenomes[m]['scg_taxonomy_database_version'] for m in g.metagenomes]
         if len(set(scg_taxonomy_database_versions_in_metagenomes)) > 1:
-            raise ConfigError("Not all SCG taxonomy database versions across your metagenomes are identical :( It means "
-                              "the program `anvi-run-scg-taxonomy` was run on these database across different versions of "
-                              "the source database. Before you continue, you must make sure that they all agree. Which may "
-                              "require you to re-run `anvi-run-scg-taxonomy` on the ones that do have a different version "
-                              "than what is installed on your system, which is '%s' (if you run `anvi-db-info` on any contigs "
-                              "database you can learn the SCG database version of it). Anvi'o found these versions across your "
-                              "metagenomes: '%s'." % (self.ctx.scg_taxonomy_database_version, ', '.join(list(set(scg_taxonomy_database_versions_in_metagenomes)))))
+            self.progress.reset()
+            self.run.warning("Please note that not all SCG taxonomy database versions across your metagenomes are identical. "
+                             "This means the program `anvi-run-scg-taxonomy` was run on these database across different versions of "
+                             "the source SCG taxonomy database. This is OK and things will continue to work, but you should consider "
+                             "the fact that taxonomy estimations coming from different versions of the database may not be comparable "
+                             "anymore depending on what has changed between different versions of the database. If your purpose is not "
+                             "to compare different versions of the database, and if you would like to ensure consistency, you can re-run "
+                             "`anvi-run-scg-taxonomy` on contigs databases that have a different version than what is installed on your "
+                             "system, which is '%s' (if you run `anvi-db-info` on any contigs database you can learn the SCG database "
+                             "version of it). Anvi'o found these versions across your metagenomes: '%s'." % \
+                                        (self.ctx.scg_taxonomy_database_version, ', '.join(list(set(scg_taxonomy_database_versions_in_metagenomes)))))
         elif scg_taxonomy_database_versions_in_metagenomes[0] != self.ctx.scg_taxonomy_database_version:
-            raise ConfigError("While all of your metagenomes agree with each other and have the SCG taxonomy database version of %s "
-                              "unfortunately it differs from what is installed on your system, which is %s :/ To fix this, you will "
-                              "to re-run the program `anvi-run-scg-taxonomy` on each one of them. We can almost feel all the way "
-                              "from here the frustration brewing over there 😬" % \
+            self.progress.reset()
+            self.run.warning("While all of your metagenomes agree with each other and have the SCG taxonomy database version of %s, "
+                              "this version differs from what is installed on your system, which is %s. If you don't do anything, "
+                              "things will continue to work. But if you would like to get rid of this warning you will need to "
+                              "re-run the program `anvi-run-scg-taxonomy` on each one of them 😬" % \
                                         (scg_taxonomy_database_versions_in_metagenomes[0], self.ctx.scg_taxonomy_database_version))
 
         self.metagenomes = copy.deepcopy(g.metagenomes)

--- a/anvio/scgtaxonomyops.py
+++ b/anvio/scgtaxonomyops.py
@@ -2132,7 +2132,7 @@ class PopulateContigsDatabaseWithSCGTaxonomy(SCGTaxonomyArgs, SanityCheck):
             # even if there are no SCGs to use for taxonomy later, we did attempt ot populate the
             # contigs database, so we shall note that in the self table to make sure the error from
             # `anvi-estimate-genome-taxonomy` is not "you seem to have not run taxonomy".
-            self.tables_for_taxonomy.update_self_value()
+            self.tables_for_taxonomy.update_db_self_table_values(taxonomy_was_run=True, database_version=self.ctx.scg_taxonomy_database_version)
 
             # return empty handed like a goose in the job market in 2020
             return None
@@ -2151,8 +2151,8 @@ class PopulateContigsDatabaseWithSCGTaxonomy(SCGTaxonomyArgs, SanityCheck):
         self.run.info('Num CPUs per aligment task', self.num_threads)
         self.run.info('Log file path', log_file_path)
 
-        self.tables_for_taxonomy.delete_contents_of_table(t.scg_taxonomy_table_name)
-        self.tables_for_taxonomy.update_self_value(value=False)
+        self.tables_for_taxonomy.delete_contents_of_table(t.scg_taxonomy_table_name, warning=False)
+        self.tables_for_taxonomy.update_db_self_table_values(taxonomy_was_run=False, database_version=None)
 
         total_num_processes = len(scg_sequences_dict)
 
@@ -2232,7 +2232,7 @@ class PopulateContigsDatabaseWithSCGTaxonomy(SCGTaxonomyArgs, SanityCheck):
         self.tables_for_taxonomy.add(blastp_search_output)
 
         # time to update the self table:
-        self.tables_for_taxonomy.update_self_value()
+        self.tables_for_taxonomy.update_db_self_table_values(taxonomy_was_run=True, database_version=self.ctx.scg_taxonomy_database_version)
 
         self.progress.end()
 

--- a/anvio/scgtaxonomyops.py
+++ b/anvio/scgtaxonomyops.py
@@ -129,6 +129,7 @@ class SCGTaxonomyContext(object):
         self.SCGs_taxonomy_data_dir = (os.path.abspath(scgs_taxonomy_data_dir) if scgs_taxonomy_data_dir else None) or (os.path.join(self.default_scgs_taxonomy_data_dir, self.target_database))
         self.msa_individual_genes_dir_path = os.path.join(self.SCGs_taxonomy_data_dir, 'MSA_OF_INDIVIDUAL_SCGs')
         self.accession_to_taxonomy_file_path = os.path.join(self.SCGs_taxonomy_data_dir, 'ACCESSION_TO_TAXONOMY.txt.gz')
+        self.database_version_file_path = os.path.join(self.SCGs_taxonomy_data_dir, 'VERSION')
         self.search_databases_dir_path = os.path.join(self.SCGs_taxonomy_data_dir, 'SCG_SEARCH_DATABASES')
         self.target_database_URL = scgs_taxonomy_remote_database_url or self.target_database_URL
 
@@ -139,6 +140,12 @@ class SCGTaxonomyContext(object):
         self.SCGs = dict([(SCG, {'db': os.path.join(self.search_databases_dir_path, SCG + '.dmnd'), 'fasta': os.path.join(self.search_databases_dir_path, SCG)}) for SCG in self.default_scgs_for_taxonomy])
 
         self.letter_to_level = dict([(l.split('_')[1][0], l) for l in self.levels_of_taxonomy])
+
+        # set version for ctx, so we know what version of the databases are on disk
+        if os.path.exists(self.database_version_file_path):
+            self.scg_taxonomy_database_version = open(self.database_version_file_path).readline().strip()
+        else:
+            self.scg_taxonomy_database_version = None
 
         self.accession_to_taxonomy_dict = None
         if os.path.exists(self.accession_to_taxonomy_file_path):

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -13,7 +13,7 @@ __maintainer__ = "A. Murat Eren"
 __email__ = "a.murat.eren@gmail.com"
 
 
-contigs_db_version = "17"
+contigs_db_version = "18"
 profile_db_version = "34"
 genes_db_version = "6"
 pan_db_version = "14"

--- a/anvio/tables/scgtaxonomy.py
+++ b/anvio/tables/scgtaxonomy.py
@@ -39,7 +39,7 @@ class TableForSCGTaxonomy(Table):
     def add(self, blastp_search_output):
         """Incrementally adds new hits to a contigs database.
 
-           It is essential to run the member function `update_self_value` once adding new hits are complete.
+           It is essential to run the member function `update_db_self_table_values` once adding new hits are complete.
            At the time of writing this class w couldn't find a better way to do it.
         """
 
@@ -58,11 +58,24 @@ class TableForSCGTaxonomy(Table):
         self.database.disconnect()
 
 
-    def update_self_value(self, value=True):
-        """Updates the self table in contigs db to clarify that scg taxonomy were run"""
+    def update_db_self_table_values(self, taxonomy_was_run=False, database_version=None):
+        """Updates the self table in contigs db.
+
+        The purpose of this function is to clarify whether scg taxonomy was run for a contigs
+        database, and if yes, which version of the local database was used to keep track of
+        versions.
+
+        Paremeters
+        ==========
+        taxonomy_was_run: bool, False
+            Set True if taxonomy was run successfuly.
+        database_version: str, None
+            This sould be read from the ctx.scg_taxonomy_database_version in taxonomyops.
+        """
 
         self.database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
-        self.database.update_meta_value("scg_taxonomy_was_run", value)
+        self.database.update_meta_value("scg_taxonomy_was_run", taxonomy_was_run)
+        self.database.update_meta_value("scg_taxonomy_database_version", database_version)
         self.database.disconnect()
 
 


### PR DESCRIPTION
Getting ready for tRNA taxonomy, I realized that we are not keeping track of SCG taxonomy versioning.

Things will work well even if the database files that were used to store SCG taxonomy in a given contigs database AND the database files that exist in the current system to estimate SCG taxonomy does not match to each other.

But with this PR,

- We now store the key SCG taxonomy database information in contigs databases,
- and keep users posted about what is going on so they can figure out inconsistencies if they occur.