### PR TITLE
Migrate modules db

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2441,7 +2441,7 @@ def set_version():
            t.auxiliary_data_version, \
            t.genomes_storage_vesion, \
            t.structure_db_version, \
-           t.kegg_modules_db_version
+           t.metabolic_modules_db_version
 
 
 def get_version_tuples():

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -3074,7 +3074,7 @@ class KeggModulesDatabase(KeggContext):
         self.db.set_meta_value('total_entries', mod_table.get_total_entries())
         self.db.set_meta_value('creation_date', time.time())
         self.db.set_meta_value('hash', self.get_db_content_hash())
-        self.db.set_meta_value('version', t.kegg_modules_db_version)
+        self.db.set_meta_value('version', t.metabolic_modules_db_version)
 
         self.db.disconnect()
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1684,9 +1684,10 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         else:
             meta_dict_for_bin[mod]["most_complete_paths"] = []
 
+        was_already_complete = meta_dict_for_bin[mod]["complete"]
         now_complete = True if meta_dict_for_bin[mod]["percent_complete"] >= self.module_completion_threshold else False
         meta_dict_for_bin[mod]["complete"] = now_complete
-        if now_complete:
+        if now_complete and not was_already_complete:
             meta_dict_for_bin["num_complete_modules"] += 1
 
         return now_complete

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -3073,6 +3073,7 @@ class KeggModulesDatabase(KeggContext):
         self.db.set_meta_value('total_entries', mod_table.get_total_entries())
         self.db.set_meta_value('creation_date', time.time())
         self.db.set_meta_value('hash', self.get_db_content_hash())
+        self.db.set_meta_value('version', t.kegg_modules_db_version)
 
         self.db.disconnect()
 

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -6,7 +6,6 @@ import argparse
 import re
 
 import anvio.db as db
-import anvio.tables as t
 import anvio.utils as utils
 import anvio.terminal as terminal
 

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -3,6 +3,7 @@
 
 import sys
 import argparse
+import re
 
 import anvio.db as db
 import anvio.tables as t
@@ -29,6 +30,37 @@ def migrate(db_path):
         modules_db.disconnect()
         raise ConfigError("Version of this modules database is not %s (hence, "
                           "this script cannot really do anything)." % current_version)
+
+    # split any orthology entries with multiple KOs into separate lines
+    where_clause = "data_name = 'ORTHOLOGY' AND (data_value LIKE '%+%' OR data_value LIKE '%-%')"
+    bad_rows = modules_db.get_some_rows_from_table(t.module_table_name, where_clause)
+
+    modules_db.remove_some_rows_from_table(t.module_table_name, where_clause)
+
+    good_rows = []
+    for mod, orth, kos, definition, line in bad_rows:
+        if orth != "ORTHOLOGY":
+            raise ConfigError("Serious SQL error here. We asked for ORTHOLOGY but we got %s" % orth)
+        split_kos = re.split('\+|\-', kos)
+        for ko in split_kos:
+            if len(ko) != 6 or ko[0] != 'K':
+                raise ConfigError("Uh oh. We split a KO that doesn't seem to have the right format. It looks like this: %s, "
+                                  "and the string that it came from is %s." % (ko, kos))
+            good_rows.append((mod, orth, ko, definition, line))
+
+    modules_db.insert_many(t.module_table_name, entries=good_rows)
+
+
+    prev_total_entries = modules_db.get_meta_value('total_entries')
+    modules_db.remove_meta_key_value_pair('total_entries')
+    modules_db.set_meta_value('total_entries', prev_total_entries - len(bad_rows) + len(good_rows))
+    modules_db.remove_meta_key_value_pair('version')
+    modules_db.set_version(next_version)
+    modules_db.disconnect()
+
+    run.info_single("Huzzah! Your modules db is now %s. This update fixed KOs that did not have individual "
+                    "entries in the modules table." % (next_version), nl_after=1, nl_before=1, mc='green')
+
 
 
 if __name__ == '__main__':

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -11,13 +11,25 @@ import anvio.terminal as terminal
 
 from anvio.errors import ConfigError
 
+current_version, next_version = [x[1:] for x in __name__.split('_to_')]
 
 run = terminal.Run()
 progress = terminal.Progress()
 
 
 def migrate(db_path):
-    pass
+    if db_path is None:
+        raise ConfigError("No database path is given.")
+
+    utils.is_modules_db(db_path)
+
+    # make sure the current version is 1
+    contigs_db = db.DB(db_path, None, ignore_version = True)
+    if str(contigs_db.get_version()) != current_version:
+        contigs_db.disconnect()
+        raise ConfigError("Version of this modules database is not %s (hence, "
+                          "this script cannot really do anything)." % current_version)
+    
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='A simple script to upgrade KEGG Modules database from version 1 to version 2')

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -24,12 +24,12 @@ def migrate(db_path):
     utils.is_modules_db(db_path)
 
     # make sure the current version is 1
-    contigs_db = db.DB(db_path, None, ignore_version = True)
-    if str(contigs_db.get_version()) != current_version:
-        contigs_db.disconnect()
+    modules_db = db.DB(db_path, None, ignore_version = True)
+    if str(modules_db.get_version()) != current_version:
+        modules_db.disconnect()
         raise ConfigError("Version of this modules database is not %s (hence, "
                           "this script cannot really do anything)." % current_version)
-    
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='A simple script to upgrade KEGG Modules database from version 1 to version 2')

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -33,9 +33,9 @@ def migrate(db_path):
 
     # split any orthology entries with multiple KOs into separate lines
     where_clause = "data_name = 'ORTHOLOGY' AND (data_value LIKE '%+%' OR data_value LIKE '%-%')"
-    bad_rows = modules_db.get_some_rows_from_table(t.module_table_name, where_clause)
+    bad_rows = modules_db.get_some_rows_from_table("kegg_modules", where_clause)
 
-    modules_db.remove_some_rows_from_table(t.module_table_name, where_clause)
+    modules_db.remove_some_rows_from_table("kegg_modules", where_clause)
 
     good_rows = []
     for mod, orth, kos, definition, line in bad_rows:
@@ -48,7 +48,7 @@ def migrate(db_path):
                                   "and the string that it came from is %s." % (ko, kos))
             good_rows.append((mod, orth, ko, definition, line))
 
-    modules_db.insert_many(t.module_table_name, entries=good_rows)
+    modules_db.insert_many("kegg_modules", entries=good_rows)
 
 
     prev_total_entries = modules_db.get_meta_value('total_entries')

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+import argparse
+
+import anvio.db as db
+import anvio.tables as t
+import anvio.utils as utils
+import anvio.terminal as terminal
+
+from anvio.errors import ConfigError
+
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+
+def migrate(db_path):
+    pass
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='A simple script to upgrade KEGG Modules database from version 1 to version 2')
+    parser.add_argument('modules_db', metavar = 'MODULES_DB', help = 'KEGG Modules database')
+    args, unknown = parser.parse_known_args()
+
+    try:
+        migrate(args.modules_db)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -21,7 +21,7 @@ auxiliary_data_version = "2"
 structure_db_version = "2"
 genomes_storage_vesion = "7"
 workflow_config_version = "1"
-kegg_modules_db_version = "2"
+metabolic_modules_db_version = "2"
 
 versions_for_db_types = {'contigs': contigs_db_version,
                          'profile': profile_db_version,
@@ -31,7 +31,7 @@ versions_for_db_types = {'contigs': contigs_db_version,
                          'genomestorage': genomes_storage_vesion,
                          'auxiliary data for coverages': auxiliary_data_version,
                          'config': workflow_config_version,
-                         'modules': kegg_modules_db_version}
+                         'modules': metabolic_modules_db_version}
 
 
 ####################################################################################################

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -30,7 +30,8 @@ versions_for_db_types = {'contigs': contigs_db_version,
                          'pan': pan_db_version,
                          'genomestorage': genomes_storage_vesion,
                          'auxiliary data for coverages': auxiliary_data_version,
-                         'config': workflow_config_version}
+                         'config': workflow_config_version,
+                         'modules': kegg_modules_db_version}
 
 
 ####################################################################################################

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3376,6 +3376,13 @@ def is_structure_db(db_path):
     return True
 
 
+def is_modules_db(db_path):
+    filesnpaths.is_file_exists(db_path)
+    if get_db_type(db_path) != 'modules':
+        raise ConfigError("'%s' is not an anvi'o modules database." % db_path)
+    return True
+
+
 def is_blank_profile(db_path):
     if get_db_type(db_path) != 'profile':
         return False

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -41,7 +41,7 @@ class Migrater(object):
                               "jeopardy.")
 
         if args.migrate_dbs_safely and args.migrate_dbs_quickly:
-            raise ConfigError("Please don't as anvi'o to migrate your databases both safely and quickly :/")
+            raise ConfigError("Please don't ask anvi'o to migrate your databases both safely and quickly :/")
 
         self.safe_mode = args.migrate_dbs_safely
 


### PR DESCRIPTION
This PR contains the very first migration script for a modules DB (which was rendered necessary by my last PR #1444 ). What the migration script does is fetch all the ORTHOLOGY entries that have multiple KOs, removes those entries, splits each multi-KO entry into entries with individual KOs, and adds those individual entries back into the modules table.

This PR also officially adds the 'version' metadata to the modules DB self table, and as an added bonus, there is a small bug fix in `anvi-estimate-metabolism` where before we were double-counting some modules as complete (we don't do that anymore).

## How to test
To test the migration script, this is what I did:
1) Set up an early version of the KEGG modules DB from an archive file (this particular archive file will be uploaded to figshare soon; if you want it before that happens I can send it to you)
```
anvi-setup-kegg-kofams --kegg-archive KEGG_build_2020-04-27.tar.gz --kegg-data-dir KEGG_ARCHIVE
```
2) Run the migration script 
```
anvi-migrate ./KEGG_ARCHIVE/MODULES.db --migrate-dbs-safely
```

Before the migration, this is what the self table looks like:
<img width="206" alt="Screen Shot 2020-06-23 at 00 45 05" src="https://user-images.githubusercontent.com/10360586/85367251-884a2c80-b4ee-11ea-8d0d-0534e4b39c3b.png">
And here is how it looks like when you manually search for multi-KO entries:
<img width="502" alt="Screen Shot 2020-06-23 at 00 45 30" src="https://user-images.githubusercontent.com/10360586/85367286-99933900-b4ee-11ea-842e-173645f0eba0.png">

After the migration, the self table looks like:
<img width="226" alt="Screen Shot 2020-06-23 at 00 46 25" src="https://user-images.githubusercontent.com/10360586/85367339-ac0d7280-b4ee-11ea-869d-f13378de1272.png">
And we can no longer find any multiple entries:
<img width="482" alt="Screen Shot 2020-06-23 at 00 46 16" src="https://user-images.githubusercontent.com/10360586/85367375-b891cb00-b4ee-11ea-86fd-c5d3a73278bc.png">
Plus, we can confirm that the KOs were split properly by looking at some examples from module M00567:
![image](https://user-images.githubusercontent.com/10360586/85367866-b54b0f00-b4ef-11ea-8eea-02a8a5749a44.png)

