### PR TITLE
dbops speed improvements

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -346,7 +346,7 @@ class BottleApplication(Bottle):
         if name == "init":
             bin_prefix = "Bin_"
             if self.interactive.mode == 'refine':
-                bin_prefix = list(self.interactive.bins)[0] + "_" if len(self.interactive.bins) == 1 else "Refined_",
+                bin_prefix = list(self.interactive.bin_names_of_interest)[0] + "_" if len(self.interactive.bin_names_of_interest) == 1 else "Refined_",
 
             default_view = self.interactive.default_view
             default_order = self.interactive.p_meta['default_item_order']

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -507,7 +507,14 @@ class ContigsSuperclass(object):
                                                                   error_if_no_data=False).values())
             self.gene_function_call_sources = requested_sources
         else:
-            hits = list(contigs_db.db.get_table_as_dict(t.gene_function_calls_table_name).values())
+            if self.split_names_of_interest:
+                gene_caller_ids_of_interest = set(self.genes_in_contigs_dict.keys())
+            else:
+                gene_caller_ids_of_interest = set([])
+
+            functions_dict = contigs_db.db.smart_get(t.gene_function_calls_table_name, 'gene_callers_id', gene_caller_ids_of_interest)
+            hits = list(functions_dict.values())
+
             self.gene_function_call_sources = gene_function_sources_in_db
 
         for hit in hits:

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -324,7 +324,10 @@ class ContigsSuperclass(object):
         return contigs_shorter_than_M
 
 
-    def init_split_sequences(self, min_contig_length=0, split_names_of_interest=[]):
+    def init_split_sequences(self, min_contig_length=0, split_names_of_interest=set([])):
+        if not len(split_names_of_interest):
+            split_names_of_interest = self.split_names_of_interest
+
         contigs_shorter_than_M = self.init_contig_sequences(min_contig_length)
 
         if not len(self.splits_basic_info):
@@ -390,7 +393,10 @@ class ContigsSuperclass(object):
         self.progress.end()
 
 
-    def init_non_singlecopy_gene_hmm_sources(self, split_names_of_interest=None, return_each_gene_as_a_layer=False):
+    def init_non_singlecopy_gene_hmm_sources(self, split_names_of_interest=set([]), return_each_gene_as_a_layer=False):
+        if not len(split_names_of_interest):
+            split_names_of_interest = self.split_names_of_interest
+
         if not self.contigs_db_path or not len(self.non_singlecopy_gene_hmm_sources):
             return
 

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2194,7 +2194,7 @@ class PanSuperclass(object):
         self.gene_clusters_initialized = True
 
 
-    def load_pan_views(self, splits_of_interest=None):
+    def load_pan_views(self, split_names_of_interest=None):
         pan_db = PanDatabase(self.pan_db_path)
 
         views_table = pan_db.db.get_table_as_dict(t.views_table_name)
@@ -2203,7 +2203,7 @@ class PanSuperclass(object):
             table_name = views_table[view]['target_table']
             self.views[view] = {'table_name': table_name,
                                 'header': pan_db.db.get_table_structure(table_name)[1:],
-                                'dict': pan_db.db.get_table_as_dict(table_name, keys_of_interest=splits_of_interest)}
+                                'dict': pan_db.db.get_table_as_dict(table_name, keys_of_interest=split_names_of_interest)}
 
         pan_db.disconnect()
 
@@ -2451,7 +2451,7 @@ class ProfileSuperclass(object):
         # Should we initialize the profile super for a specific list of splits? This is where we take care of that.
         # the user can initialize the profile super two ways: by providing split names of interest explicitly, or
         # by providing collection name and bin names in args.
-        self.split_names_of_interest = A('split_names_of_interest')
+        self.split_names_of_interest = A('split_names_of_interest') or set([])
         self.collection_name = A('collection_name')
 
         # figure out bin names, if there is one to figure out
@@ -2472,7 +2472,7 @@ class ProfileSuperclass(object):
             self.bin_names = None
 
         if self.split_names_of_interest and not isinstance(self.split_names_of_interest, type(set([]))):
-            raise ConfigError("ProfileSuper says the argument `splits_of_interest` must be of type set(). "
+            raise ConfigError("ProfileSuper says the argument `split_names_of_interest` must be of type set(). "
                               "Someone screwed up somewhere :/")
         elif self.split_names_of_interest and self.collection_name:
             raise ConfigError("ProfileSuper is initialized with args that contain both `split_names_of_interest`,\
@@ -3222,18 +3222,18 @@ class ProfileSuperclass(object):
         return collection, bins_info
 
 
-    def load_views(self, splits_of_interest=None, omit_parent_column=False):
+    def load_views(self, split_names_of_interest=None, omit_parent_column=False):
         profile_db = ProfileDatabase(self.profile_db_path)
 
         views_table = profile_db.db.get_table_as_dict(t.views_table_name)
 
-        self.progress.new('Loading views%s' % (' for %d items' % len(splits_of_interest) if splits_of_interest else ''))
+        self.progress.new('Loading views%s' % (' for %d items' % len(split_names_of_interest) if split_names_of_interest else ''))
         for view in views_table:
             self.progress.update('for %s' % view)
             table_name = views_table[view]['target_table']
             self.views[view] = {'table_name': table_name,
                                 'header': profile_db.db.get_table_structure(table_name)[1:],
-                                'dict': profile_db.db.get_table_as_dict(table_name, keys_of_interest=splits_of_interest, omit_parent_column=omit_parent_column)}
+                                'dict': profile_db.db.get_table_as_dict(table_name, keys_of_interest=split_names_of_interest, omit_parent_column=omit_parent_column)}
 
         self.progress.end()
         profile_db.disconnect()

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -91,6 +91,15 @@ class ContigsSuperclass(object):
         self.run = r
         self.progress = p
 
+        # if ContigsSuperclass is being used as a base class, then the class that inherits
+        # it may have set a `split_names_of_interest` variable. in which case we don't want to
+        # overwrite it, and use it for any task that requires a focus on a particular set of
+        # splits. But if there is non set by the class that inherits ContigsSuperclass, then
+        # we don't want functions that use/assume `split_names_of_interest` variable to throw
+        # errors because the variable is not set. so what we are doing here ensures that.
+        if not hasattr(self, 'split_names_of_interest'):
+            self.split_names_of_interest = set([])
+
         self.a_meta = {}
 
         self.splits_basic_info = {}

--- a/anvio/filesnpaths.py
+++ b/anvio/filesnpaths.py
@@ -139,6 +139,7 @@ def is_file_exists(file_path, dont_raise=False):
         if dont_raise:
             return False
         else:
+            Progress().reset()
             raise FilesNPathsError("No such file: '%s' :/" % file_path)
     return True
 

--- a/bin/anvi-refine
+++ b/bin/anvi-refine
@@ -130,6 +130,9 @@ if __name__ == '__main__':
         print(e)
         sys.exit(-3)
 
+    if args.dry_run:
+        run.info_single('Dry run, eh? Fine. Bai!', nl_after=1)
+        sys.exit()
 
     app = BottleApplication(d)
     app.run_application(args.ip_address, args.port_number)


### PR DESCRIPTION
This PR ameliorates one of the biggest bottlenecks in dbops that's been affecting all `anvi-refine` task.

When ContigsSuperclass was called even to work with a subset of contigs, it read all the data from multiple anvi'o tables, creating a huge burden on memory and adding significant amount of time before the interactive interface showed up.

After the changes in this PR, an `anvi-refine` call that took 1 minute in my test data took 17 seconds.