### PR TITLE
KOfam-oriented output from metabolism estimation

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2117,9 +2117,12 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         =======
         kegg_metabolism_superdict : dictionary of dictionaries of dictionaries
             a complex data structure containing the metabolism estimation data for each genome/bin in the contigs DB
+        kofam_hits_superdict : dictionary of dictionaries of dictionaries
+            a complex data structure containing the KOfam hits information for each genome/bin in the contigs DB
         """
 
         kegg_metabolism_superdict = {}
+        kofam_hits_superdict = {}
 
         self.kegg_modules_db = KeggModulesDatabase(self.kegg_modules_db_path, args=self.args, run=run_quiet, quiet=self.quiet)
 
@@ -2130,11 +2133,11 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             kofam_hits_info = self.init_hits_and_splits()
 
             if self.profile_db_path and not self.metagenome_mode:
-                kegg_metabolism_superdict = self.estimate_for_bins_in_collection(kofam_hits_info)
+                kegg_metabolism_superdict, kofam_hits_superdict = self.estimate_for_bins_in_collection(kofam_hits_info)
             elif not self.profile_db_path and not self.metagenome_mode:
-                kegg_metabolism_superdict = self.estimate_for_genome(kofam_hits_info)
+                kegg_metabolism_superdict, kofam_hits_superdict = self.estimate_for_genome(kofam_hits_info)
             elif self.metagenome_mode:
-                kegg_metabolism_superdict = self.estimate_for_contigs_db_for_metagenome(kofam_hits_info)
+                kegg_metabolism_superdict, kofam_hits_superdict = self.estimate_for_contigs_db_for_metagenome(kofam_hits_info)
             else:
                 raise ConfigError("This class doesn't know how to deal with that yet :/")
 
@@ -2145,7 +2148,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         if self.write_dict_to_json:
             self.store_metabolism_superdict_as_json(kegg_metabolism_superdict, self.json_output_file_path + ".json")
 
-        return kegg_metabolism_superdict
+        return kegg_metabolism_superdict, kofam_hits_superdict
 
 
     def generate_output_dict(self, kegg_superdict, headers_to_include=None, only_complete_modules=False):

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -87,7 +87,7 @@ OUTPUT_MODES = {'kofam_hits_in_modules': {
                     },
                 }
 # dict containing matrix headers of information that we can output in custom mode
-# key corresponds to the header's key in output dictionary (returned from generate_output_dict() function)
+# key corresponds to the header's key in output dictionary (returned from generate_output_dict_for_modules() function)
 # cdict_key is the header's key in module-level completion dictionary (if any)
 # mode_type indicates which category of output modes (modules or kofams) this header can be used for. If both, this is 'all'
 # description is printed when --list-available-output-headers parameter is used
@@ -2184,14 +2184,14 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         self.kegg_modules_db.disconnect()
 
         if not self.store_json_without_estimation and not skip_storing_data:
-            self.store_kegg_metabolism_superdict(kegg_metabolism_superdict)
+            self.store_kegg_metabolism_superdicts(kegg_metabolism_superdict, kofam_hits_superdict)
         if self.write_dict_to_json:
             self.store_metabolism_superdict_as_json(kegg_metabolism_superdict, self.json_output_file_path + ".json")
 
         return kegg_metabolism_superdict, kofam_hits_superdict
 
 
-    def generate_output_dict(self, kegg_superdict, headers_to_include=None, only_complete_modules=False):
+    def generate_output_dict_for_modules(self, kegg_superdict, headers_to_include=None, only_complete_modules=False):
         """This dictionary converts the metabolism superdict to a two-level dict containing desired headers for output.
 
         The metabolism superdict is a three-to-four-level dictionary. The first three levels are: genomes/metagenomes/bins, modules, and module completion information.
@@ -2392,8 +2392,8 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         return d
 
 
-    def store_kegg_metabolism_superdict(self, kegg_superdict):
-        """This function writes the metabolism superdict to tab-delimited files depending on which output the user requested.
+    def store_kegg_metabolism_superdicts(self, module_superdict, ko_superdict):
+        """This function writes the metabolism superdicts to tab-delimited files depending on which output the user requested.
 
         The user can request a variety of output 'modes', and for each of these modes we look up the details on the output
         format which are stored in self.available_modes, use that information to generate a dictionary of dictionaries,
@@ -2407,7 +2407,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
                 raise ConfigError("Oh, dear. You've come all this way only to realize that we don't know which headers to use "
                                   "for the %s output mode. Something is terribly wrong, and it is probably a developer's fault. :("
                                   % (mode))
-            output_dict = self.generate_output_dict(kegg_superdict, headers_to_include=header_list, only_complete_modules=self.available_modes[mode]["only_complete"])
+            output_dict = self.generate_output_dict_for_modules(module_superdict, headers_to_include=header_list, only_complete_modules=self.available_modes[mode]["only_complete"])
             utils.store_dict_as_TAB_delimited_file(output_dict, output_path, key_header="unique_id", headers=header_list)
             self.run.info("%s output file" % mode, output_path, nl_before=1)
 
@@ -2702,7 +2702,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
                                   "for the %s output mode. Something is terribly wrong. Perhaps you should try telling us what "
                                   "headers to use with the --custom-output-headers flag. If that doesn't work, contact the developers. :)"
                                   % (output_mode))
-            single_dict = single_estimator.generate_output_dict(kegg_superdict_multi[metagenome_name], headers_to_include=header_list, only_complete_modules=self.available_modes[output_mode]["only_complete"])
+            single_dict = single_estimator.generate_output_dict_for_modules(kegg_superdict_multi[metagenome_name], headers_to_include=header_list, only_complete_modules=self.available_modes[output_mode]["only_complete"])
 
             kegg_metabolism_superdict_multi_output_version[metagenome_name] = single_dict
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -76,7 +76,7 @@ OUTPUT_MODES = {'kofam_hits_in_modules': {
                     'data_dict': "modules",
                     'headers': None,
                     'only_complete': False,
-                    'description': "A custom tab-delimited output file where you choose the included data using --custom-output-headers"
+                    'description': "A custom tab-delimited output file where you choose the included KEGG modules data using --custom-output-headers"
                     },
                 'kofam_hits': {
                     'output_suffix': "kofam_hits.txt",
@@ -89,11 +89,11 @@ OUTPUT_MODES = {'kofam_hits_in_modules': {
 # dict containing matrix headers of information that we can output in custom mode
 # key corresponds to the header's key in output dictionary (returned from generate_output_dict() function)
 # cdict_key is the header's key in module-level completion dictionary (if any)
-# mode_type indicates which category of output modes (modules or kofams) this header can be used for. If both, this is 'shared'
+# mode_type indicates which category of output modes (modules or kofams) this header can be used for. If both, this is 'all'
 # description is printed when --list-available-output-headers parameter is used
 OUTPUT_HEADERS = {'unique_id' : {
                         'cdict_key': None,
-                        'mode_type': 'shared',
+                        'mode_type': 'all',
                         'description': "Just an integer that keeps our data organized. No real meaning here. Always included in output, so no need to specify it on the command line"
                         },
                   'kegg_module' : {
@@ -144,7 +144,7 @@ OUTPUT_HEADERS = {'unique_id' : {
                         },
                   'gene_caller_id': {
                         'cdict_key': None,
-                        'mode_type': 'shared',
+                        'mode_type': 'all',
                         'description': "Gene caller ID of a single KOfam hit in the contigs DB. If you choose this header, each "
                                        "line in the output file will be a KOfam hit"
                         },
@@ -161,7 +161,7 @@ OUTPUT_HEADERS = {'unique_id' : {
                         },
                   'contig' : {
                         'cdict_key': 'genes_to_contigs',
-                        'mode_type': 'shared',
+                        'mode_type': 'all',
                         'description': "Contig that a KOfam hit is found on. If you choose this header, each line in the output "
                                        "file will be a KOfam hit"
                         },
@@ -1205,10 +1205,11 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
 
         # update available modes and headers with appropriate genome/bin/metagenome identifier
         for m in self.available_modes:
-            if m != 'custom':
+            if m != 'modules_custom':
                 self.available_modes[m]['headers'].insert(1, self.name_header)
         self.available_headers[self.name_header] = {
                                         'cdict_key': None,
+                                        'mode_type' : 'all',
                                         'description': "Name of genome/bin/metagenome in which we find KOfam hits and/or KEGG modules"
                                         }
 
@@ -1255,11 +1256,11 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             raise ConfigError("You have requested some output modes that we cannot handle. The offending modes "
                               "are: %s. Please use the flag --list-available-modes to see which ones are acceptable."
                               % (", ".join(illegal_modes)))
-        if self.custom_output_headers and "custom" not in self.output_modes:
-            raise ConfigError("You seem to have provided a list of custom headers without actually requesting the 'custom' output "
+        if self.custom_output_headers and "modules_custom" not in self.output_modes:
+            raise ConfigError("You seem to have provided a list of custom headers without actually requesting a 'custom' output "
                               "mode. We think perhaps you missed something, so we are stopping you right there.")
-        if "custom" in self.output_modes and not self.custom_output_headers:
-            raise ConfigError("You have requested 'custom' output mode, but haven't told us what headers to include in that output. "
+        if "modules_custom" in self.output_modes and not self.custom_output_headers:
+            raise ConfigError("You have requested a 'custom' output mode, but haven't told us what headers to include in that output. "
                               "You should be using the --custom-output-headers flag to do this.")
         if self.custom_output_headers:
             if anvio.DEBUG:
@@ -1330,7 +1331,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         run.warning(None, header="AVAILABLE OUTPUT HEADERS", lc="green")
 
         for header, header_meta in self.available_headers.items():
-            self.run.info(header, header_meta['description'])
+            self.run.info(header, "%s [%s output modes]" %(header_meta['description'], header_meta['mode_type']))
 
 
     def init_hits_and_splits(self):

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1510,7 +1510,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
                                            "contigs_to_genes" : {}
                                           }
         for knum in all_kos:
-            bin_level_ko_dict[ko] = {"gene_caller_ids" : set(),
+            bin_level_ko_dict[knum] = {"gene_caller_ids" : set(),
                                      "modules" : None,
                                      "genes_to_contigs" : {},
                                      "contigs_to_genes" : {}
@@ -1521,6 +1521,12 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             present_in_mods = self.kegg_modules_db.get_modules_for_knum(ko)
             if not present_in_mods:
                 kos_not_in_modules.append(ko)
+                # KOs that are not in modules will not be initialized above in the ko hit dictionary, so we add them here
+                bin_level_ko_dict[ko] = {"gene_caller_ids" : set(),
+                                         "modules" : None,
+                                         "genes_to_contigs" : {},
+                                         "contigs_to_genes" : {}
+                                         }
             else:
                 bin_level_ko_dict[ko]["modules"] = present_in_mods
             for m in present_in_mods:

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2517,7 +2517,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         # add keys to this list to include the data in the visualization dictionary
         module_data_keys_for_visualization = ['percent_complete']
 
-        metabolism_dict = self.estimate_metabolism(skip_storing_data=True)
+        metabolism_dict, ko_hit_dict = self.estimate_metabolism(skip_storing_data=True)
         data_for_visualization = {}
 
         for bin, mod_dict in metabolism_dict.items():
@@ -2704,6 +2704,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
         """The function that calls metabolism on each individual contigs db and aggregates the results into one dictionary."""
 
         metabolism_super_dict = {}
+        ko_hits_super_dict = {}
 
         total_num_metagenomes = len(self.database_names)
         self.progress.new("Estimating metabolism for contigs DBs", progress_total_items=total_num_metagenomes)
@@ -2711,14 +2712,14 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
         for metagenome_name in self.database_names:
             args = self.get_args_for_single_estimator(metagenome_name)
             self.progress.update("[%d of %d] %s" % (self.progress.progress_current_item + 1, total_num_metagenomes, metagenome_name))
-            metabolism_super_dict[metagenome_name] = KeggMetabolismEstimator(args, progress=progress_quiet, run=run_quiet).estimate_metabolism(skip_storing_data=True)
+            metabolism_super_dict[metagenome_name], ko_hits_super_dict[metagenome_name] = KeggMetabolismEstimator(args, progress=progress_quiet, run=run_quiet).estimate_metabolism(skip_storing_data=True)
 
             self.progress.increment()
             self.progress.reset()
 
         self.progress.end()
 
-        return metabolism_super_dict
+        return metabolism_super_dict, ko_hits_super_dict
 
 
     def get_metabolism_superdict_multi_as_data_frame(self, kegg_superdict_multi_output_version):
@@ -2874,7 +2875,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
             self.run.info("Num Contigs DBs in file", len(self.database_names))
             self.run.info('Metagenome Mode', self.metagenome_mode)
 
-        kegg_metabolism_superdict_multi = self.get_metabolism_superdict_multi()
+        kegg_metabolism_superdict_multi, ko_hits_superdict_multi = self.get_metabolism_superdict_multi()
 
         self.store_metabolism_superdict_multi(kegg_metabolism_superdict_multi)
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -81,7 +81,7 @@ OUTPUT_MODES = {'kofam_hits_in_modules': {
                 'kofam_hits': {
                     'output_suffix': "kofam_hits.txt",
                     'data_dict': "kofams",
-                    'headers': ["unique_id", "ko", "gene_caller_id", "contig", "modules"],
+                    'headers': ["unique_id", "ko", "gene_caller_id", "contig", "modules_with_ko"],
                     'only_complete': False,
                     'description': "Information on all KOfam hits in the contigs DB, regardless of KEGG module membership"
                     },

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -48,112 +48,151 @@ pp = terminal.pretty_print
 """Some critical constants for metabolism estimation output formatting."""
 # dict containing possible output modes
 # output_suffix should be unique to a mode so that multiple output modes can be used at once
+# data_dict indicates which data dictionary is used for generating the output (modules or kofams)
 # headers list describes which information to include in the output file; see OUTPUT_HEADERS dict below for more info
 # only_complete flag indicates whether to only include modules over completeness threshold in the output file
 # description is what is printed when --list-available-modes parameter is used
-OUTPUT_MODES = {'kofam_hits': {
-                    'output_suffix': "kofam_hits.txt",
+OUTPUT_MODES = {'kofam_hits_in_modules': {
+                    'output_suffix': "kofam_hits_in_modules.txt",
+                    'data_dict': "modules",
                     'headers': ["unique_id", "kegg_module", "module_is_complete",
                                 "module_completeness", "path_id", "path", "path_completeness",
                                 "kofam_hit", "gene_caller_id", "contig"],
                     'only_complete': False,
-                    'description': "Information on each KOfam hit in the contigs DB"
+                    'description': "Information on each KOfam hit that belongs to a KEGG module"
                     },
                 'modules': {
                     'output_suffix': "modules.txt",
+                    'data_dict': "modules",
                     'headers': ["unique_id", "kegg_module", "module_name", "module_class", "module_category",
                                 "module_subcategory", "module_definition", "module_completeness", "module_is_complete",
                                 "kofam_hits_in_module", "gene_caller_ids_in_module"],
                     'only_complete': True,
-                    'description': "Completeness information on KEGG modules. Only modules whose completeness is above the "
+                    'description': "Information on complete KEGG modules. Only modules whose completeness is above the "
                                    "threshold will be included, but you include all modules by running with --module-completion-threshold 0"
                     },
-                'custom': {
-                    'output_suffix': "custom.txt",
+                'modules_custom': {
+                    'output_suffix': "modules_custom.txt",
+                    'data_dict': "modules",
                     'headers': None,
                     'only_complete': False,
                     'description': "A custom tab-delimited output file where you choose the included data using --custom-output-headers"
-                    }
+                    },
+                'kofam_hits': {
+                    'output_suffix': "kofam_hits.txt",
+                    'data_dict': "kofams",
+                    'headers': ["unique_id", "ko", "gene_caller_id", "contig", "modules"],
+                    'only_complete': False,
+                    'description': "Information on all KOfam hits in the contigs DB, regardless of KEGG module membership"
+                    },
                 }
 # dict containing matrix headers of information that we can output in custom mode
 # key corresponds to the header's key in output dictionary (returned from generate_output_dict() function)
 # cdict_key is the header's key in module-level completion dictionary (if any)
+# mode_type indicates which category of output modes (modules or kofams) this header can be used for. If both, this is 'shared'
 # description is printed when --list-available-output-headers parameter is used
 OUTPUT_HEADERS = {'unique_id' : {
                         'cdict_key': None,
+                        'mode_type': 'shared',
                         'description': "Just an integer that keeps our data organized. No real meaning here. Always included in output, so no need to specify it on the command line"
                         },
                   'kegg_module' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "KEGG module number"
                         },
                   'module_is_complete' : {
                         'cdict_key': 'complete',
+                        'mode_type': 'modules',
                         'description': "Whether a KEGG module is considered complete or not based on its percent completeness and the completeness threshold"
                         },
                   'module_completeness' : {
                         'cdict_key': 'percent_complete',
+                        'mode_type': 'modules',
                         'description': "Percent completeness of a KEGG module"
                         },
                   'module_name' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "English name/description of a KEGG module"
                         },
                   'module_class' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "Metabolism class of a KEGG module"
                         },
                   'module_category' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "Metabolism category of a KEGG module"
                         },
                   'module_subcategory' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "Metabolism subcategory of a KEGG module"
                         },
                   'module_definition' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "KEGG-formatted definition of a KEGG module. Describes the metabolic pathway "
                                        "in terms of the KOS that belong to the module"
                         },
                   'gene_caller_ids_in_module': {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "Comma-separated list of gene caller IDs of KOfam hits in a module"
                         },
                   'gene_caller_id': {
                         'cdict_key': None,
+                        'mode_type': 'shared',
                         'description': "Gene caller ID of a single KOfam hit in the contigs DB. If you choose this header, each "
                                        "line in the output file will be a KOfam hit"
                         },
                   'kofam_hits_in_module' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "Comma-separated list of KOfam hits in a module"
                         },
                   'kofam_hit' : {
                         'cdict_key': 'kofam_hits',
+                        'mode_type': 'modules',
                         'description': "KO number of a single KOfam hit. If you choose this header, each line in the output file "
                                        "will be a KOfam hit"
                         },
                   'contig' : {
                         'cdict_key': 'genes_to_contigs',
+                        'mode_type': 'shared',
                         'description': "Contig that a KOfam hit is found on. If you choose this header, each line in the output "
                                        "file will be a KOfam hit"
                         },
                   'path_id' : {
                         'cdict_key': None,
+                        'mode_type': 'modules',
                         'description': "Integer ID for a path through a KEGG module. No real meaning and just for data organization. "
                                        "If you choose this header, each line in the output file will be a KOfam hit"
                         },
                   'path' : {
                         'cdict_key': 'paths',
+                        'mode_type': 'modules',
                         'description': "A path through a KEGG module (a linear sequence of KOs that together represent each metabolic step "
                                        "in the module. Most modules have several of these due to KO redundancy). If you choose this header, "
                                        "each line in the output file will be a KOfam hit"
                         },
                   'path_completeness' : {
                         'cdict_key': 'pathway_completeness',
+                        'mode_type': 'modules',
                         'description': "Percent completeness of a particular path through a KEGG module. If you choose this header, each line "
                                        "in the output file will be a KOfam hit"
+                        },
+                  'ko' : {
+                        'cdict_key': None,
+                        'mode_type': 'kofams',
+                        'description': 'KEGG Orthology (KO) number of a KOfam hit'
+                        },
+                  'modules_with_ko': {
+                        'cdict_key': 'modules',
+                        'mode_type': 'kofams',
+                        'description': 'A comma-separated list of modules that the KO belongs to'
                         },
                   }
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2818,7 +2818,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
     def store_metabolism_superdict_multi_matrix_format(self, kegg_superdict_multi, ko_superdict_multi):
         """Stores the multi-contigs DB metabolism data in several matrices.
 
-        Contigs DBs are arranged in columns and KEGG modules are arranged in rows.
+        Contigs DBs are arranged in columns and KEGG modules/KOs are arranged in rows.
         Each module statistic (ie, completeness, presence/absence) will be in a different file.
         """
 
@@ -2845,6 +2845,14 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
                     output.write('\t'.join([rows[i]] + ['%.2f' % c for c in matrix[i]]) + '\n')
 
             self.run.info('Output matrix for "%s"' % stat, output_file_path)
+
+        # now we make a KO hit count matrix
+        df = self.get_metabolism_superdict_multi_for_output(kegg_superdict_multi, ko_superdict_multi, output_mode="kofam_hits", as_data_frame=True)
+        df.set_index(['db_name'], inplace=True)
+        ko_counts = df.groupby(['ko','db_name']).size().unstack(fill_value=0)
+        output_file_path = '%s-ko_hits-MATRIX.txt' % (self.output_file_prefix)
+        ko_counts.to_csv(output_file_path, sep='\t')
+        self.run.info('Output matrix for "%s"' % 'ko_hits', output_file_path)
 
 
     def store_metabolism_superdict_multi(self, kegg_superdict_multi, ko_superdict_multi):


### PR DESCRIPTION
One of the biggest shortcomings of the metabolism estimation output so far is that it does not contain information about all KOfam hits. Only KOs that belonged to KEGG modules are included. This PR aims to fix that. 

The additions in this PR include:
- a dictionary of all KOfam hits (regardless of module membership) that is passed around to enable output generation
- a new `kofam_hits` output mode which contains one line for every KOfam hit in the input database(s)
  - please note that some modules-oriented output modes have been renamed to accommodate this change ('custom' is now 'modules_custom' and the modules-oriented 'kofam_hits' is now 'kofam_hits_in_modules')
- an output matrix of KO counts

You can see example outputs below.

Kofam Hits output mode:
```
$ anvi-estimate-metabolism -e external_genomes.txt --kegg-output-modes kofam_hits
[....]
Long-format output ...........................: kegg-metabolism_kofam_hits.txt

✓ anvi-estimate-metabolism took 0:00:10.319506
(anvio-master) mithrandir:~/Lab/test-kegg iva$ head kegg-metabolism_kofam_hits.txt
unique_id	db_name	genome_name	ko	gene_caller_id	contig	modules_with_ko
0	E_faecalis_6240	Enterococcus_faecalis_6240	K00845	1608	Enterococcus_faecalis_6240_contig_00003_chromosome	M00001,M00549,M00892,M00909
1	E_faecalis_6240	Enterococcus_faecalis_6240	K01810	600	Enterococcus_faecalis_6240_contig_00003_chromosome	M00001,M00004,M00114,M00892,M00909
2	E_faecalis_6240	Enterococcus_faecalis_6240	K00850	225	Enterococcus_faecalis_6240_contig_00003_chromosome	M00001,M00345
3	E_faecalis_6240	Enterococcus_faecalis_6240	K01624	348	Enterococcus_faecalis_6240_contig_00003_chromosome	M00001,M00003,M00165,M00167,M00345,M00344,M00611,M00612
4	E_faecalis_6240	Enterococcus_faecalis_6240	K01803	1042	Enterococcus_faecalis_6240_contig_00003_chromosome	M00001,M00002,M00003
```

KO Count matrix:
```
$ anvi-estimate-metabolism -e external_genomes.txt --matrix-format
[...]
Output matrix for "completeness" .............: kegg-metabolism-completeness-MATRIX.txt
Output matrix for "presence" .................: kegg-metabolism-presence-MATRIX.txt
Output matrix for "ko_hits" ..................: kegg-metabolism-ko_hits-MATRIX.txt

✓ anvi-estimate-metabolism took 0:00:05.476662
$ head kegg-metabolism-ko_hits-MATRIX.txt
ko	E_faecalis_6240	isolate	test_2
K00003	1	1	1
K00005	1	0	0
K00009	1	0	0
K00013	0	1	1
K00014	1	1	1
K00016	1	1	1
K00020	1	0	0
```