### PR TITLE
Pretty printing of long run info lines

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2006,7 +2006,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         self.run.info("Module completion threshold", self.module_completion_threshold)
         self.run.info("Number of complete modules", metabolism_dict_for_list_of_splits["num_complete_modules"])
         if complete_mods:
-            self.run.info("Complete modules", ", ".join(complete_mods))
+            self.run.info("Complete modules", ", ".join(complete_mods), align_long_values=True)
 
         return metabolism_dict_for_list_of_splits
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1348,7 +1348,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         run.warning(None, header="AVAILABLE OUTPUT MODES", lc="green")
 
         for mode, mode_meta in self.available_modes.items():
-            self.run.info(mode, mode_meta['description'], align_long_values=True)
+            self.run.info(mode, mode_meta['description'])
 
 
     def list_output_headers(self):
@@ -1359,7 +1359,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             desc_str = header_meta['description']
             type_str = header_meta['mode_type']
             mode_str = "output modes" if header_meta['mode_type'] == 'all' else "output mode"
-            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]", align_long_values=True)
+            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]")
 
 
     def init_hits_and_splits(self):
@@ -2006,7 +2006,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         self.run.info("Module completion threshold", self.module_completion_threshold)
         self.run.info("Number of complete modules", metabolism_dict_for_list_of_splits["num_complete_modules"])
         if complete_mods:
-            self.run.info("Complete modules", ", ".join(complete_mods), align_long_values=True)
+            self.run.info("Complete modules", ", ".join(complete_mods))
 
         return metabolism_dict_for_list_of_splits
 
@@ -2635,7 +2635,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
         run.warning(None, header="AVAILABLE OUTPUT MODES", lc="green")
 
         for mode, mode_meta in self.available_modes.items():
-            self.run.info(mode, mode_meta['description'], align_long_values=True)
+            self.run.info(mode, mode_meta['description'])
 
     def update_available_headers_for_multi(self):
         """This function updates the available headers dictionary to reflect all possibilities in the multiple DB case."""
@@ -2678,7 +2678,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
             desc_str = header_meta['description']
             type_str = header_meta['mode_type']
             mode_str = "output modes" if header_meta['mode_type'] == 'all' else "output mode"
-            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]", align_long_values=True)
+            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]")
 
 
     def init_metagenomes(self):

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1348,7 +1348,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         run.warning(None, header="AVAILABLE OUTPUT MODES", lc="green")
 
         for mode, mode_meta in self.available_modes.items():
-            self.run.info(mode, mode_meta['description'])
+            self.run.info(mode, mode_meta['description'], align_long_values=True)
 
 
     def list_output_headers(self):
@@ -1359,7 +1359,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             desc_str = header_meta['description']
             type_str = header_meta['mode_type']
             mode_str = "output modes" if header_meta['mode_type'] == 'all' else "output mode"
-            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]")
+            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]", align_long_values=True)
 
 
     def init_hits_and_splits(self):
@@ -2635,7 +2635,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
         run.warning(None, header="AVAILABLE OUTPUT MODES", lc="green")
 
         for mode, mode_meta in self.available_modes.items():
-            self.run.info(mode, mode_meta['description'])
+            self.run.info(mode, mode_meta['description'], align_long_values=True)
 
     def update_available_headers_for_multi(self):
         """This function updates the available headers dictionary to reflect all possibilities in the multiple DB case."""
@@ -2678,7 +2678,7 @@ class KeggMetabolismEstimatorMulti(KeggContext, KeggEstimatorArgs):
             desc_str = header_meta['description']
             type_str = header_meta['mode_type']
             mode_str = "output modes" if header_meta['mode_type'] == 'all' else "output mode"
-            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]")
+            self.run.info(header, f"{desc_str} [{type_str} {mode_str}]", align_long_values=True)
 
 
     def init_metagenomes(self):

--- a/anvio/merger.py
+++ b/anvio/merger.py
@@ -540,7 +540,7 @@ class MultipleRuns:
         self.run.info('merged_sample_ids', sample_ids_list)
         self.run.info("Common layer additional data keys", ', '.join(self.layer_additional_data_keys))
         self.run.info('total_reads_mapped', total_reads_mapped_list)
-        self.run.info('cmd_line', utils.get_cmd_line())
+        self.run.info('cmd_line', utils.get_cmd_line(), align_long_values=False)
         self.run.info('clustering_performed', not self.skip_hierarchical_clustering)
 
         self.merge_split_coverage_data()

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -237,7 +237,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.run.info('profile_db', self.profile_db_path, display_only=True)
         self.run.info('contigs_db', True if self.contigs_db_path else False)
         self.run.info('contigs_db_hash', self.a_meta['contigs_db_hash'])
-        self.run.info('cmd_line', utils.get_cmd_line())
+        self.run.info('cmd_line', utils.get_cmd_line(), align_long_values=False)
         self.run.info('merged', False)
         self.run.info('blank', self.blank)
         self.run.info('split_length', self.a_meta['split_length'])

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -385,7 +385,7 @@ class Run:
                                          '.' * (self.width - len(label)),
                                          c(str(value), mc), '\n' * nl_after)
         if align_long_values:
-            terminal_width = os.get_terminal_size()[0]
+            terminal_width = get_terminal_size()[0]
             wrap_width = terminal_width - self.width - 3
             wrapped_value_lines = textwrap.wrap(value, width=wrap_width, break_long_words=False, break_on_hyphens=False)
             aligned_value_str = wrapped_value_lines[0]

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -336,7 +336,7 @@ class Run:
 
 
     def info(self, key, value, quiet=False, display_only=False, overwrite_verbose=False, nl_before=0, nl_after=0, lc='cyan',
-             mc='yellow', progress=None, align_long_values=False):
+             mc='yellow', progress=None, align_long_values=True):
         """
         This function prints information nicely to the terminal in the form:
         key ........: value

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -382,6 +382,17 @@ class Run:
         info_line = "%s%s %s: %s\n%s" % ('\n' * nl_before, c(label, lc),
                                          '.' * (self.width - len(label)),
                                          c(str(value), mc), '\n' * nl_after)
+        if align_long_values:
+            terminal_width = os.get_terminal_size()[0]
+            wrap_width = terminal_width - self.width - 3
+            wrapped_value_lines = textwrap.wrap(value, width=wrap_width)
+            aligned_value_str = wrapped_value_lines[0]
+            for line in wrapped_value_lines[1:]:
+                aligned_value_str += "\n %s  %s" % (' ' * self.width, line)
+
+            info_line = "%s%s %s: %s\n%s" % ('\n' * nl_before, c(label, lc),
+                                             '.' * (self.width - len(label)),
+                                             c(str(aligned_value_str), mc), '\n' * nl_after)
 
         if progress:
             progress.clear()

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -372,7 +372,7 @@ class Run:
 
         if value is None:
             value = "None"
-        elif isinstance(value, bool) or isinstance(value, float):
+        elif isinstance(value, bool) or isinstance(value, float) or isinstance(value, list):
             value = "%s" % value
         elif isinstance(value, str):
             value = remove_spaces(value)
@@ -388,9 +388,12 @@ class Run:
             terminal_width = get_terminal_size()[0]
             wrap_width = terminal_width - self.width - 3
             wrapped_value_lines = textwrap.wrap(value, width=wrap_width, break_long_words=False, break_on_hyphens=False)
-            aligned_value_str = wrapped_value_lines[0]
-            for line in wrapped_value_lines[1:]:
-                aligned_value_str += "\n %s  %s" % (' ' * self.width, line)
+            if len(wrapped_value_lines) == 0:
+                aligned_value_str = value
+            else:
+                aligned_value_str = wrapped_value_lines[0]
+                for line in wrapped_value_lines[1:]:
+                    aligned_value_str += "\n %s  %s" % (' ' * self.width, line)
 
             info_line = "%s%s %s: %s\n%s" % ('\n' * nl_before, c(label, lc),
                                              '.' * (self.width - len(label)),

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -370,7 +370,9 @@ class Run:
         if not display_only:
             self.info_dict[key] = value
 
-        if isinstance(value, bool):
+        if value is None:
+            value = "None"
+        elif isinstance(value, bool):
             value = "%s" % value
         elif isinstance(value, str):
             value = remove_spaces(value)

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -387,7 +387,7 @@ class Run:
         if align_long_values:
             terminal_width = os.get_terminal_size()[0]
             wrap_width = terminal_width - self.width - 3
-            wrapped_value_lines = textwrap.wrap(value, width=wrap_width)
+            wrapped_value_lines = textwrap.wrap(value, width=wrap_width, break_long_words=False, break_on_hyphens=False)
             aligned_value_str = wrapped_value_lines[0]
             for line in wrapped_value_lines[1:]:
                 aligned_value_str += "\n %s  %s" % (' ' * self.width, line)

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -371,7 +371,7 @@ class Run:
             self.info_dict[key] = value
 
         if isinstance(value, bool):
-            pass
+            value = "%s" % value
         elif isinstance(value, str):
             value = remove_spaces(value)
         elif isinstance(value, int):

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -335,7 +335,38 @@ class Run:
                 sys.stderr.write(line.encode('utf-8'))
 
 
-    def info(self, key, value, quiet=False, display_only=False, overwrite_verbose=False, nl_before=0, nl_after=0, lc='cyan', mc='yellow', progress=None):
+    def info(self, key, value, quiet=False, display_only=False, overwrite_verbose=False, nl_before=0, nl_after=0, lc='cyan',
+             mc='yellow', progress=None, align_long_values=False):
+        """
+        This function prints information nicely to the terminal in the form:
+        key ........: value
+
+        PARAMETERS
+        ==========
+        key : str
+            what to print before the dots
+        value : str
+            what to print after the dots
+        quiet : boolean
+            the standard anvi'o quiet parameter which, if True, suppresses some output
+        display_only : boolean
+            if False, the key value pair is also stored in the info dictionary
+        overwrite_verbose : boolean
+            if True, downstream quiet parameters (though not the global --quiet) are ignored to produce more verbose output
+        nl_before : int
+            number of lines to print before the key-value line
+        nl_after : int
+            number of lines to print after the key-value line
+        lc : color str
+            the color of the label (key)
+        mc : color str
+            the color of the value
+        progress : Progress instance
+            provides the Progress bar to use
+        align_long_values : boolean
+            if True, values that are longer than the terminal width will be broken up into different lines that
+            align nicely
+        """
         if not display_only:
             self.info_dict[key] = value
 

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -372,7 +372,7 @@ class Run:
 
         if value is None:
             value = "None"
-        elif isinstance(value, bool):
+        elif isinstance(value, bool) or isinstance(value, float):
             value = "%s" % value
         elif isinstance(value, str):
             value = remove_spaces(value)


### PR DESCRIPTION
This PR introduces a small change to the prevalent `run.info` method allowing longer info text to be broken up and nicely aligned across different lines in the terminal. **This feature is now the default behavior of `run.info`, meaning that if you don't want lines to be broken up, you must explicitly turn the `align_long_values` flag off.**

To demonstrate, this is what the run info lines for `anvi-estimate-metabolism` output headers looked like before this change:
![image](https://user-images.githubusercontent.com/10360586/89848057-30718e80-db4b-11ea-93c9-26bc6e944caa.png)

And this is what they look like afterwards:
![image](https://user-images.githubusercontent.com/10360586/89848019-1172fc80-db4b-11ea-860c-b345dc562844.png)

A couple of notes:
- I turned off the `break_long_words` and `break_on_hyphens` flags so that file paths would not be broken across different lines (for convenient copy-paste)
- I also explicitly turned off this behavior for the run info lines with terminal commands for the same reason