### PR TITLE
Prevent naughty characters from ever entering contigs database

### DIFF
--- a/bin/anvi-gen-contigs-database
+++ b/bin/anvi-gen-contigs-database
@@ -26,6 +26,12 @@ run = terminal.Run()
 progress = terminal.Progress()
 
 
+@terminal.time_program
+def main(args):
+    a = dbops.ContigsDatabase(args.output_db_path, run, progress, quiet=False, skip_init = True)
+    a.create(args)
+
+
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description=__description__)
@@ -54,8 +60,7 @@ if __name__ == '__main__':
     args = anvio.get_args(parser)
 
     try:
-        a = dbops.ContigsDatabase(args.output_db_path, run, progress, quiet=False, skip_init = True)
-        a.create(args)
+        main(args)
     except ConfigError as e:
         print(e)
         sys.exit(-1)

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -78,6 +78,7 @@ def reformat_FASTA(args):
     total_num_nucleotides = 0
     total_num_contigs = 0
     total_num_nucleotides_removed = 0
+    total_num_nucleotides_modified = 0
     total_num_contigs_removed = 0
 
     while next(fasta):
@@ -92,6 +93,7 @@ def reformat_FASTA(args):
             for char in fasta.seq:
                 if char not in acceptable_chars:
                     seq.append(replacement)
+                    total_num_nucleotides_modified += 1
                 else:
                     seq.append(char)
             fasta.seq = ''.join(seq)
@@ -141,6 +143,7 @@ def reformat_FASTA(args):
     run.info('Total num nucleotides', total_num_nucleotides)
     run.info('Contigs removed', '%d (%.2f%% of all)' % (total_num_contigs_removed, total_num_contigs_removed * 100.0 / total_num_contigs), mc='green')
     run.info('Nucleotides removed', '%d (%.2f%% of all)' % (total_num_nucleotides_removed, total_num_nucleotides_removed * 100.0 / total_num_nucleotides), mc='green')
+    run.info('Nucleotides modified', '%d (%.2f%% of all)' % (total_num_nucleotides_modified, total_num_nucleotides_modified * 100.0 / total_num_nucleotides), mc='green')
     run.info('Deflines simplified', args.simplify_names, mc='green')
 
 

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -7,6 +7,7 @@ import anvio
 import anvio.fastalib as u
 import anvio.utils as utils
 import anvio.terminal as terminal
+import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import ConfigError, FilesNPathsError
@@ -55,6 +56,16 @@ def reformat_FASTA(args):
     else:
         keep_ids = set([])
 
+    if args.seq_type is not None:
+        replace_chars = True
+        if args.seq_type == 'AA':
+            acceptable_chars = set(constants.amino_acids)
+            replacement = 'X'
+        else:
+            acceptable_chars = set(constants.nucleotides)
+            replacement = 'N'
+    else:
+        replace_chars = False
 
     output = u.FastaOutput(args.output_file)
     fasta = u.SequenceSource(args.contigs_fasta)
@@ -75,6 +86,15 @@ def reformat_FASTA(args):
 
         total_num_nucleotides += l
         total_num_contigs += 1
+
+        if replace_chars:
+            seq = []
+            for char in fasta.seq:
+                if char not in acceptable_chars:
+                    seq.append(replacement)
+                else:
+                    seq.append(char)
+            fasta.seq = ''.join(seq)
 
         if keep_ids and fasta.id.split()[0] not in keep_ids:
             total_num_nucleotides_removed += l
@@ -153,6 +173,11 @@ if __name__ == '__main__':
                         help="Use this parameter if you would like to add a prefix to your contig\
                               names while simplifying them. The prefix must be a single word (you\
                               can use underscor character, but nothing more!).")
+    parser.add_argument('--seq-type', default=None, metavar="SEQ TYPE", choices={'AA', 'NT'},
+                        help=("Supply either 'NT' or 'AA' (if you want). If 'NT', any characters besides {A,C,T,G} will "
+                              "by replaced with 'N'. If 'AA', any characters that are not 1-letter amino acid "
+                              "characters will be replaced with 'X'. If you don't supply anything, no charaters will be "
+                              "modified."))
     parser.add_argument('-r', '--report-file', required=False, metavar='REPORT FILE',
                         help="Report file path. When you run this program with `--simplify-names`\
                               flag, all changes to deflines will be reported in this file\


### PR DESCRIPTION
- Prevents database generation what incoming contigs fasta contains characters that are not A, C, T, G, N, a, c, t, g, or n.
- Adds new `--seq-type` parameter to `anvi-script-reformat-fasta` which fixes contig fastas that suffer from this ailment