### PR TITLE
init commit

### DIFF
--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -119,7 +119,7 @@ def reformat_FASTA(args):
 
         num_gaps = fasta.seq.count('-')
         if args.export_gap_counts_table:
-            gaps_info_list.append([fasta.id, num_gaps, fasta.seq])
+            gaps_info_list.append([fasta.id, num_gaps])
 
         percentage_of_gaps = num_gaps * 100.0 / l
         if percentage_of_gaps >= args.max_percentage_gaps:
@@ -147,7 +147,7 @@ def reformat_FASTA(args):
             output.store(fasta, split = False)
 
     if args.export_gap_counts_table:
-        df = pd.DataFrame(gaps_info_list, columns=["header", "num_gaps", "sequence"])
+        df = pd.DataFrame(gaps_info_list, columns=["header", "num_gaps"])
         df.to_csv(args.export_gap_counts_table + ".tsv", sep='\t', index=False)
 
     if report_file:

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -10,6 +10,8 @@ import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
 
+import statistics
+
 from anvio.errors import ConfigError, FilesNPathsError
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
@@ -81,8 +83,20 @@ def reformat_FASTA(args):
     total_num_nucleotides_modified = 0
     total_num_contigs_removed = 0
 
+    # Get stats for arg.filter_third_quartile
+    percent_of_gaps_list = []
     while next(fasta):
+        l = len(fasta.seq)
+        percentage_of_gaps = fasta.seq.count('-') * 100.0 / l
+        percent_of_gaps_list.append(percentage_of_gaps)
+    standard_deviation = statistics.pstdev(percent_of_gaps_list)
+    average = statistics.mean(percent_of_gaps_list)
+    third_quartile = average + standard_deviation
 
+    # Reopen fasta
+    fasta = u.SequenceSource(args.contigs_fasta)
+
+    while next(fasta):
         l = len(fasta.seq)
 
         total_num_nucleotides += l
@@ -118,6 +132,12 @@ def reformat_FASTA(args):
             total_num_nucleotides_removed += l
             total_num_contigs_removed += 1
             continue
+
+        if args.filter_third_quartile_gaps == True:
+            if percentage_of_gaps >= third_quartile:
+                total_num_nucleotides_removed += l
+                total_num_contigs_removed += 1
+                continue
 
         if args.simplify_names:
             if prefix:
@@ -160,6 +180,10 @@ if __name__ == '__main__':
                         help="Maximum fraction of gaps in a sequence (any sequence with \
                               more gaps will be removed from the output FASTA file). The \
                               default is %(default)f.")
+    parser.add_argument('--filter-third-quartile-gaps', type=bool, default=False, metavar='PERCENTAGE',
+                        help="Sequences with a percentage of gaps greater than the third  \
+                              quartile of the gap percentage distribution will be removed \
+                              more gaps will be removed from the output FASTA file (Boolean).")
     parser.add_argument('-i', '--exclude-ids', required=False, metavar='TXT FILE',
                         help="IDs to remove from the FASTA file. You cannot provide both\
                               --keep-ids and --exclude-ids.")

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -3,7 +3,7 @@
 
 import sys
 
-import numpy as np
+import pandas as pd
 
 import anvio
 import anvio.fastalib as u
@@ -83,17 +83,7 @@ def reformat_FASTA(args):
     total_num_nucleotides_modified = 0
     total_num_contigs_removed = 0
 
-    # Get stats for arg.filter_third_quartile
-    if args.filter_third_quartile_gaps == True:
-        percent_of_gaps_list = []
-        while next(fasta):
-            l = len(fasta.seq)
-            percentage_of_gaps = fasta.seq.count('-') * 100.0 / l
-            percent_of_gaps_list.append(percentage_of_gaps)
-        cutoff_percentile = np.percentile(percent_of_gaps_list, 75)
-
-    # Reopen fasta
-    fasta = u.SequenceSource(args.contigs_fasta)
+    num_gaps_list = []
 
     while next(fasta):
         l = len(fasta.seq)
@@ -126,17 +116,20 @@ def reformat_FASTA(args):
             total_num_contigs_removed += 1
             continue
 
-        percentage_of_gaps = fasta.seq.count('-') * 100.0 / l
+        num_gaps = fasta.seq.count('-')
+        sequence_num_gaps_list = [fasta.id, num_gaps, fasta.seq]
+        num_gaps_list.append(sequence_num_gaps_list)
+        percentage_of_gaps = num_gaps * 100.0 / l
+
         if percentage_of_gaps >= args.max_percentage_gaps:
             total_num_nucleotides_removed += l
             total_num_contigs_removed += 1
             continue
 
-        if args.filter_third_quartile_gaps == True:
-            if percentage_of_gaps >= cutoff_percentile:
-                total_num_nucleotides_removed += l
-                total_num_contigs_removed += 1
-                continue
+        if num_gaps >= args.max_gaps:
+            total_num_nucleotides_removed += l
+            total_num_contigs_removed += 1
+            continue
 
         if args.simplify_names:
             if prefix:
@@ -151,6 +144,10 @@ def reformat_FASTA(args):
                 report_file.write('%s\t%s\n' % (defline, fasta.id))
         else:
             output.store(fasta, split = False)
+
+    if args.export_gap_counts_table:
+        df = pd.DataFrame(num_gaps_list, columns=["header", "num_gaps", "sequence"])
+        df.to_csv(args.export_gap_counts_table + ".tsv", sep='\t', index=False)
 
     if report_file:
         report_file.close()
@@ -179,14 +176,15 @@ if __name__ == '__main__':
                         help="Maximum fraction of gaps in a sequence (any sequence with \
                               more gaps will be removed from the output FASTA file). The \
                               default is %(default)f.")
-    parser.add_argument('--filter-third-quartile-gaps', type=bool, default=False, metavar='PERCENTAGE',
-                        help="Sequences with a percentage of gaps greater than the third  \
-                              quartile of the gap percentage distribution will be removed \
-                              more gaps will be removed from the output FASTA file (Boolean).")
+    parser.add_argument('-M','--max-gaps', type=float, default=1000000,
+                        help="Maximum amount of gaps allowed per sequence in the alignment.")
     parser.add_argument('-i', '--exclude-ids', required=False, metavar='TXT FILE',
                         help="IDs to remove from the FASTA file. You cannot provide both\
                               --keep-ids and --exclude-ids.")
-    parser.add_argument('-I', '--keep-ids', required=False, metavar='TXT FILE',
+    parser.add_argument('--export-gap-counts-table', required=False, metavar='TSV FILE',
+                        help="Export a table with the number of gaps per sequence. \
+                              Please provide a prefix to name the file.")
+    parser.add_argument('-I', '--keep-ids', type=str, required=False, metavar='TXT FILE',
                         help="If provided, all IDs not in this file will be excluded from the\
                               reformatted FASTA file. Any additional filters (such as --min-len)\
                               will still be applied to the IDs in this file. You cannot provide both\

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -83,7 +83,8 @@ def reformat_FASTA(args):
     total_num_nucleotides_modified = 0
     total_num_contigs_removed = 0
 
-    num_gaps_list = []
+    if args.export_gap_counts_table:
+        gaps_info_list = []
 
     while next(fasta):
         l = len(fasta.seq)
@@ -117,10 +118,10 @@ def reformat_FASTA(args):
             continue
 
         num_gaps = fasta.seq.count('-')
-        sequence_num_gaps_list = [fasta.id, num_gaps, fasta.seq]
-        num_gaps_list.append(sequence_num_gaps_list)
-        percentage_of_gaps = num_gaps * 100.0 / l
+        if args.export_gap_counts_table:
+            gaps_info_list.append([fasta.id, num_gaps, fasta.seq])
 
+        percentage_of_gaps = num_gaps * 100.0 / l
         if percentage_of_gaps >= args.max_percentage_gaps:
             total_num_nucleotides_removed += l
             total_num_contigs_removed += 1
@@ -146,7 +147,7 @@ def reformat_FASTA(args):
             output.store(fasta, split = False)
 
     if args.export_gap_counts_table:
-        df = pd.DataFrame(num_gaps_list, columns=["header", "num_gaps", "sequence"])
+        df = pd.DataFrame(gaps_info_list, columns=["header", "num_gaps", "sequence"])
         df.to_csv(args.export_gap_counts_table + ".tsv", sep='\t', index=False)
 
     if report_file:

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -69,6 +69,9 @@ def reformat_FASTA(args):
     else:
         replace_chars = False
 
+    if args.export_gap_counts_table:
+        gaps_info_list = []
+
     output = u.FastaOutput(args.output_file)
     fasta = u.SequenceSource(args.contigs_fasta)
 
@@ -82,9 +85,6 @@ def reformat_FASTA(args):
     total_num_nucleotides_removed = 0
     total_num_nucleotides_modified = 0
     total_num_contigs_removed = 0
-
-    if args.export_gap_counts_table:
-        gaps_info_list = []
 
     while next(fasta):
         l = len(fasta.seq)
@@ -178,7 +178,9 @@ if __name__ == '__main__':
                               more gaps will be removed from the output FASTA file). The \
                               default is %(default)f.")
     parser.add_argument('-M','--max-gaps', type=float, default=1000000,
-                        help="Maximum amount of gaps allowed per sequence in the alignment.")
+                        help="Maximum amount of gaps allowed per sequence in the alignment. \
+                              Don't know which threshold to pick? Use --export-gap-counts-table \
+                              to explore the gap counts per sequence distribution!")
     parser.add_argument('-i', '--exclude-ids', required=False, metavar='TXT FILE',
                         help="IDs to remove from the FASTA file. You cannot provide both\
                               --keep-ids and --exclude-ids.")

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -84,14 +84,15 @@ def reformat_FASTA(args):
     total_num_contigs_removed = 0
 
     # Get stats for arg.filter_third_quartile
-    percent_of_gaps_list = []
-    while next(fasta):
-        l = len(fasta.seq)
-        percentage_of_gaps = fasta.seq.count('-') * 100.0 / l
-        percent_of_gaps_list.append(percentage_of_gaps)
-    standard_deviation = statistics.pstdev(percent_of_gaps_list)
-    average = statistics.mean(percent_of_gaps_list)
-    third_quartile = average + standard_deviation
+    if args.filter_third_quartile_gaps == True:
+        percent_of_gaps_list = []
+        while next(fasta):
+            l = len(fasta.seq)
+            percentage_of_gaps = fasta.seq.count('-') * 100.0 / l
+            percent_of_gaps_list.append(percentage_of_gaps)
+        standard_deviation = statistics.pstdev(percent_of_gaps_list)
+        average = statistics.mean(percent_of_gaps_list)
+        third_quartile = average + standard_deviation
 
     # Reopen fasta
     fasta = u.SequenceSource(args.contigs_fasta)

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -3,14 +3,14 @@
 
 import sys
 
+import numpy as np
+
 import anvio
 import anvio.fastalib as u
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
-import statistics
 
 from anvio.errors import ConfigError, FilesNPathsError
 
@@ -90,9 +90,7 @@ def reformat_FASTA(args):
             l = len(fasta.seq)
             percentage_of_gaps = fasta.seq.count('-') * 100.0 / l
             percent_of_gaps_list.append(percentage_of_gaps)
-        standard_deviation = statistics.pstdev(percent_of_gaps_list)
-        average = statistics.mean(percent_of_gaps_list)
-        third_quartile = average + standard_deviation
+        cutoff_percentile = np.percentile(percent_of_gaps_list, 75)
 
     # Reopen fasta
     fasta = u.SequenceSource(args.contigs_fasta)
@@ -135,7 +133,7 @@ def reformat_FASTA(args):
             continue
 
         if args.filter_third_quartile_gaps == True:
-            if percentage_of_gaps >= third_quartile:
+            if percentage_of_gaps >= cutoff_percentile:
                 total_num_nucleotides_removed += l
                 total_num_contigs_removed += 1
                 continue


### PR DESCRIPTION
Hi Meren, 

I added a flag to `anvi-script-reformat-fasta` that will allow a user to filter out sequences with a gaps percentage greater than the 3rd quartile of the percent gap distribution in an alignment. I unfortunately could not find another way than to load the fasta file twice which is probably not best practice. Please let me know if there is a better approach.

Cheers,
Matt