### PR TITLE
Patch news page for Mac OS Catalina

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1541,6 +1541,12 @@ D = {
              'action': 'store_true',
              'help': "For debugging purposes. You should never really need it."}
                 ),
+    'skip-news': (
+            ['--skip-news'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Don't try to read news content from upstream."}
+                ),
     'experimental-org-input-dir': (
             ['-i', '--input-directory'],
             {'metavar': 'DIR_PATH',

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -304,7 +304,7 @@ class BottleApplication(Bottle):
     def get_news(self):
         ret = []
         try:
-            news_markdown = requests.get('https://raw.githubusercontent.com/merenlab/anvio/master/NEWS.md')
+            news_markdown = requests.get('https://raw.githubusercontent.com/merenlab/anvio/master/NEWS.md', timeout=3)
             news_items = news_markdown.text.split("***")
 
             """ FORMAT
@@ -327,6 +327,8 @@ class BottleApplication(Bottle):
                         'title': news_item.split("#")[1].split("(")[0].strip(),
                         'content': news_item.split("#\n")[1].strip()
                     })
+        except requests.exceptions.Timeout as e:
+            print e
         except:
             ret.append({
                     'date': '',

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -328,7 +328,7 @@ class BottleApplication(Bottle):
                         'content': news_item.split("#\n")[1].strip()
                     })
         except requests.exceptions.Timeout as e:
-            print e
+            print(e)
         except:
             ret.append({
                     'date': '',

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -328,6 +328,11 @@ class BottleApplication(Bottle):
                         'content': news_item.split("#\n")[1].strip()
                     })
         except requests.exceptions.Timeout as e:
+            ret.append({
+                    'date': '',
+                    'title': 'News not found',
+                    'content': 'Anvi\'o failed to retrieve any news for you, but see the news page [here]()'
+                })
             print(e)
         except:
             ret.append({

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -35,6 +35,7 @@ import anvio.dbops as dbops
 import anvio.utils as utils
 import anvio.drivers as drivers
 import anvio.terminal as terminal
+import anvio.constants as constants
 import anvio.summarizer as summarizer
 import anvio.filesnpaths as filesnpaths
 import anvio.scgtaxonomyops as scgtaxonomyops
@@ -302,46 +303,12 @@ class BottleApplication(Bottle):
 
 
     def get_news(self):
-        ret = []
-        try:
-            news_markdown = requests.get('https://raw.githubusercontent.com/merenlab/anvio/master/NEWS.md', timeout=3)
-            news_items = news_markdown.text.split("***")
-
-            """ FORMAT
-            # Title with spaces (01.01.1970) #
-            Lorem ipsum, dolor sit amet
-            ***
-            # Title with spaces (01.01.1970) #
-            Lorem ipsum, dolor sit amet
-            ***
-            # Title with spaces (01.01.1970) #
-            Lorem ipsum, dolor sit amet
-            """
-            for news_item in news_items:
-                if len(news_item) < 5:
-                    # too short to parse, just skip it
-                    continue
-
-                ret.append({
-                        'date': news_item.split("(")[1].split(")")[0].strip(),
-                        'title': news_item.split("#")[1].split("(")[0].strip(),
-                        'content': news_item.split("#\n")[1].strip()
-                    })
-        except requests.exceptions.Timeout as e:
-            ret.append({
-                    'date': '',
-                    'title': 'News not found',
-                    'content': 'Anvi\'o failed to retrieve any news for you, but see the news page [here]()'
-                })
-            print(e)
-        except:
-            ret.append({
-                    'date': '',
-                    'title': 'Something has failed',
-                    'content': 'Anvi\'o failed to retrieve any news for you, maybe you do not have internet connection or something :('
-                })
-
-        return json.dumps(ret)
+        if self.interactive.anvio_news:
+            return json.dumps(self.interactive.anvio_news)
+        else:
+            return json.dumps([{'date': '',
+                                'title': 'No news for you :(',
+                                'content': "Anvi'o couldn't bring any news for you. You can bring yourself to the news by clicking [here](%s)." % constants.anvio_news_url}])
 
 
     def random_hash(self, size=8):

--- a/anvio/constants.py
+++ b/anvio/constants.py
@@ -380,3 +380,6 @@ codon_to_RC_num_lookup = get_codon_to_num_lookup(reverse_complement=True)
 
 # KEGG setup constant - used to warn user that the KEGG MODULES.db data may need to be updated
 KEGG_SETUP_INTERVAL = 90 # days since last MODULES.db creation
+
+# anvi'o news stuff
+anvio_news_url = "https://raw.githubusercontent.com/merenlab/anvio/master/NEWS.md"

--- a/anvio/data/interactive/js/news.js
+++ b/anvio/data/interactive/js/news.js
@@ -4,6 +4,15 @@ $(document).ready(function() {
 
 function checkNews() {
     $('#news-panel-inner').empty();
+
+    if(getNews() == null) {
+      $('#news-mark-read').remove();
+      $('#news-panel-inner').append('<div id="news-not-found"> \
+                                      <p>Anvi\'o failed to retrieve any news for you :( But see the news page <a href="">here</a></p> \
+                                    </div>');
+      return;
+    }
+	
     $.ajax({
         type: 'GET',
         cache: false,
@@ -51,4 +60,11 @@ function newsMarkRead() {
     $('#news-mark-read').remove();
     $('#toggle-panel-right-3').off('mouseover');
     createCookie('last_seen_hash', md5($('.news-item > h1')[0].textContent), -1);
+}
+
+/*
+ *  Return the raw contents of the news file, or null if request failed
+ */
+function getNews() {
+  return null;
 }

--- a/anvio/data/interactive/js/news.js
+++ b/anvio/data/interactive/js/news.js
@@ -5,14 +5,6 @@ $(document).ready(function() {
 function checkNews() {
     $('#news-panel-inner').empty();
 
-    if(getNews() == null) {
-      $('#news-mark-read').remove();
-      $('#news-panel-inner').append('<div id="news-not-found"> \
-                                      <p>Anvi\'o failed to retrieve any news for you :( But see the news page <a href="">here</a></p> \
-                                    </div>');
-      return;
-    }
-	
     $.ajax({
         type: 'GET',
         cache: false,
@@ -37,7 +29,7 @@ function checkNews() {
             if (unread_count > 0) {
                 $('#toggle-panel-right-3').css('color', '#FF0000');
                 $('#toggle-panel-right-3').addClass('fading-button');
-		
+
 		$('#toggle-panel-right-3').mouseover(function() {
 			if(!$('#news-panel').is(':visible')) {
 				$(this).addClass('toggle-panel-right-pos-3');
@@ -60,11 +52,4 @@ function newsMarkRead() {
     $('#news-mark-read').remove();
     $('#toggle-panel-right-3').off('mouseover');
     createCookie('last_seen_hash', md5($('.news-item > h1')[0].textContent), -1);
-}
-
-/*
- *  Return the raw contents of the news file, or null if request failed
- */
-function getNews() {
-  return null;
 }

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -66,6 +66,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.states_table = None
         self.p_meta = {}
         self.title = 'Unknown Project'
+        self.anvio_news = None
 
         A = lambda x: args.__dict__[x] if x in args.__dict__ else None
         self.mode = A('mode')
@@ -105,7 +106,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.inspect_split_name = A('split_name')
         self.just_do_it = A('just_do_it')
         self.skip_hierarchical_clustering = A('skip_hierarchical_clustering')
-
+        self.skip_news = A('skip_news')
 
         if self.pan_db_path and self.profile_db_path:
             raise ConfigError("You can't set both a profile database and a pan database in arguments "
@@ -280,6 +281,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.check_names_consistency()
         self.gen_orders_for_items_based_on_additional_layers_data()
         self.convert_view_data_into_json()
+        self.get_anvio_news()
 
 
     def set_displayed_item_names(self):
@@ -1430,6 +1432,16 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
     def end(self):
         # FIXME: remove temp files and stuff
         pass
+
+
+    def get_anvio_news(self):
+        if self.skip_news:
+            return
+        else:
+            try:
+                self.anvio_news = utils.get_anvio_news()
+            except:
+                pass
 
 
 class StructureInteractive(VariabilitySuper, ContigsSuperclass):

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3638,11 +3638,14 @@ def download_file(url, output_file_path, check_certificate=True, progress=progre
     run.info('Downloaded successfully', output_file_path)
 
 
-def get_remote_file_content(url, gzipped=False):
+def get_remote_file_content(url, gzipped=False, timeout=None):
     import requests
     from io import BytesIO
 
-    remote_file = requests.get(url)
+    if timeout:
+        remote_file = requests.get(url, timeout=timeout)
+    else:
+        remote_file = requests.get(url)
 
     if remote_file.status_code == 404:
         raise ConfigError("Bad news. The remote file at '%s' was not found :(" % url)

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3658,6 +3658,45 @@ def get_remote_file_content(url, gzipped=False, timeout=None):
     return remote_file.content.decode('utf-8')
 
 
+def get_anvio_news():
+    """Reads news from anvi'o repository.
+
+    The format of the news file is expected to be like this:
+
+        # Title with spaces (01.01.1970) #
+        Lorem ipsum, dolor sit amet
+        ***
+        # Title with spaces (01.01.1970) #
+        Lorem ipsum, dolor sit amet
+        ***
+        # Title with spaces (01.01.1970) #
+        Lorem ipsum, dolor sit amet
+
+    Returns
+    =======
+    news : list
+        A list of dictionaries per news item
+    """
+
+    try:
+        news = get_remote_file_content(constants.anvio_news_url, timeout=1)
+    except Exception as e:
+        raise ConfigError(f"Something went wrong reading the anvi'o news :/ This is what the "
+                          f"downstream library had to say: {e}")
+
+    news_items = []
+    for news_item in news.split('***'):
+        if len(news_item) < 5:
+            # too short to parse, just skip it
+            continue
+
+        news_items.append({'date': news_item.split("(")[1].split(")")[0].strip(),
+                           'title': news_item.split("#")[1].split("(")[0].strip(),
+                           'content': news_item.split("#\n")[1].strip()})
+
+    return news_items
+
+
 def download_protein_structure(protein_code, output_path=None, chain=None, raise_if_fail=True):
     """Downloads protein structures using Biopython.
 

--- a/bin/anvi-display-pan
+++ b/bin/anvi-display-pan
@@ -60,6 +60,7 @@ if __name__ == '__main__':
     groupE.add_argument(*anvio.A('skip-init-functions'), **anvio.K('skip-init-functions'))
     groupE.add_argument(*anvio.A('dry-run'), **anvio.K('dry-run'))
     groupE.add_argument(*anvio.A('skip-auto-ordering'), **anvio.K('skip-auto-ordering'))
+    groupE.add_argument(*anvio.A('skip-news'), **anvio.K('skip-news'))
 
     groupF.add_argument(*anvio.A('ip-address'), **anvio.K('ip-address'))
     groupF.add_argument(*anvio.A('port-number'), **anvio.K('port-number'))

--- a/bin/anvi-interactive
+++ b/bin/anvi-interactive
@@ -97,6 +97,7 @@ if __name__ == '__main__':
     groupF.add_argument(*anvio.A('list-collections'), **anvio.K('list-collections'))
     groupF.add_argument(*anvio.A('skip-init-functions'), **anvio.K('skip-init-functions'))
     groupF.add_argument(*anvio.A('skip-auto-ordering'), **anvio.K('skip-auto-ordering'))
+    groupF.add_argument(*anvio.A('skip-news'), **anvio.K('skip-news'))
     groupF.add_argument(*anvio.A('distance'), **anvio.K('distance', {'help':
                                     'The distance metric for the hierarchical clustering. Only relevant if you are running\
                                      the interactive interface in "collection" mode. The default is "%(default)s".'}))

--- a/bin/anvi-refine
+++ b/bin/anvi-refine
@@ -80,6 +80,7 @@ if __name__ == '__main__':
                                                                        nice to have).")
     groupE.add_argument(*anvio.A('dry-run'), **anvio.K('dry-run'))
     groupE.add_argument(*anvio.A('skip-init-functions'), **anvio.K('skip-init-functions'))
+    groupE.add_argument(*anvio.A('skip-news'), **anvio.K('skip-news'))
 
     groupF = parser.add_argument_group('SERVER CONFIGURATION', "For power users.")
     groupE.add_argument(*anvio.A('skip-auto-ordering'), **anvio.K('skip-auto-ordering'))


### PR DESCRIPTION
Addresses #1274 where a failed request from the news page caused anvi'o to crash in Mac OS Catalina. This branch adds a timeout of 3 seconds to read NEWS.md from GitHub before pointing to a separate link containing the news page.