### PR TITLE
Display SCG taxonomy, and not gene-level taxonomy, in summary outputs

### DIFF
--- a/anvio/data/static/template/profile-index.tmpl
+++ b/anvio/data/static/template/profile-index.tmpl
@@ -85,10 +85,10 @@
 
                 <div class="row">
                     {% if not meta|lookup:"profile"|lookup:"blank" %}
-                    <div class="col-lg-6 col-md-6 col-sm-6">
-                      <div class="panel panel-default" style="margin-left:10px;">
+                    <div class="col-lg-12 col-md-12 col-sm-12">
+                        <div class="panel panel-default" style="margin-right:10px; margin-left:10px;">
                             <div class="panel-heading">
-                                Profile DB for <b>{{ meta|lookup:"profile"|lookup:"sample_id"|humanize }}</b> w/ {{ meta|lookup:"profile"|lookup:"samples"|length|pretty }} samples.
+                                Profile DB (<b>{{ meta|lookup:"profile"|lookup:"sample_id"|humanize }}</b> w/ {{ meta|lookup:"profile"|lookup:"samples"|length|pretty }} samples).
                             </div>
                             <div class="panel-body">
                                 <table class="table table-striped">
@@ -101,7 +101,7 @@
                                     <tbody>
                                         {% for entry in basics_pretty|lookup:"profile" %}
                                         <tr>
-                                            <td>{{ entry.0 }}</td>
+                                            <td width="25%">{{ entry.0 }}</td>
                                             <td>{{ entry.1 }}</td>
                                         </tr>
                                       {% endfor %}
@@ -112,15 +112,10 @@
                     </div>
                     {% endif %}
 
-                    {% if meta|lookup:"profile"|lookup:"blank" %}
                     <div class="col-lg-12 col-md-12 col-sm-12">
                         <div class="panel panel-default" style="margin-right:10px; margin-left:10px;">
-                    {% else %}
-                    <div class="col-lg-6 col-md-6 col-sm-6">
-                        <div class="panel panel-default" style="margin-right:10px;">
-                    {% endif %}
                             <div class="panel-heading">
-                                Contigs DB
+                                Contigs DB (<b>{{ meta|lookup:"contigs"|lookup:"project_name"|humanize }}</b>)
                             </div>
                             <div class="panel-body">
                                 <table class="table table-striped">
@@ -133,7 +128,7 @@
                                     <tbody>
                                         {% for entry in basics_pretty|lookup:"contigs" %}
                                         <tr>
-                                            <td>{{ entry.0 }}</td>
+                                            <td width="25%">{{ entry.0 }}</td>
                                             <td>{{ entry.1 }}</td>
                                         </tr>
                                       {% endfor %}

--- a/anvio/data/static/template/profile-index.tmpl
+++ b/anvio/data/static/template/profile-index.tmpl
@@ -457,18 +457,31 @@
                                     <thead id="tblHead_bin">
                                         <tr>
                                             <th>Sample</th>
-                                            {% for bin in bin_percent_abundance_items %}
+                                            {% for bin in bin_percent_abundance_items|slice:slice_header_items_tmpl %}
+                                            {% if bin|length > 8 %}
+                                            <th class="text-center">{{ bin|slice:"0:5" }} <a href="#" data-toggle="tooltip" title="{{ bin }}">...</a></th>
+                                            {% else %}
                                             <th class="text-center">{{ bin }}</th>
+                                            {% endif %} 
                                             {% endfor %}
+
+                                            {% if bin_percent_abundance_items|length > max_shown_header_items %}
+                                            <th class="text-center"><span data-toggle="tooltip" title="{{ num_not_shown_samples }} more">...</span></th>
+                                            {% endif %} 
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {% for sample in meta|lookup:"profile"|lookup:"samples" %}
                                         <tr>
                                             <td style="vertical-align: middle;">{{ sample }}</td>
-                                            {% for bin in bin_percent_abundance_items %}
-                                            <td class="text-center" style="vertical-align: middle;" data-value="{{ bin_percent_recruitment|lookup:sample|lookup:bin }}">{{ bin_percent_recruitment|lookup:sample|lookup:bin|humanize_n }}%</td>
+
+                                            {% for bin in bin_percent_abundance_items|slice:slice_header_items_tmpl %}
+                                                <td class="text-center" data-value="{{ collection_profile|lookup:bin|lookup:sample|lookup:bin }}">{{ bin_percent_recruitment|lookup:sample|lookup:bin|humanize_n }}</td>
                                             {% endfor %}
+
+                                            {% if bin_percent_abundance_items|length > max_shown_header_items %}
+                                                <td class="text-center"><span data-toggle="tooltip" title="{{ num_not_shown_samples }} more">...</span></td>
+                                            {% endif %} 
                                         </tr>
                                         {% endfor %}
                                     </tbody>

--- a/anvio/data/static/template/profile-index.tmpl
+++ b/anvio/data/static/template/profile-index.tmpl
@@ -73,7 +73,7 @@
                     <h1 class="panel-title"><a data-toggle="collapse" data-parent="#basics_panel" href="#collapse-basics">Basics</a></h1>
                 </div>
 
-                <div id="collapse-basics" class="panel-collapse collapse in">
+                <div id="collapse-basics" class="panel-collapse in">
 
                 <div class="well" style="margin: 10px;">The {% if meta|lookup:"profile"|lookup:"blank" %} blank {% else %}{% if meta|lookup:"profile"|lookup:"merged" == 1 %} merged {% else %} single {% endif %}{% endif %} profile database that was generated
                                                         with the minimum contig length of <b>{{ meta|lookup:"profile"|lookup:"min_contig_length"|pretty }}</b>
@@ -151,7 +151,7 @@
                     <h1 class="panel-title"><a data-toggle="collapse" data-parent="#description_panel" href="#collapse-description">Profile DB description</a></h1>
                 </div>
 
-                <div id="collapse-description" class="panel-collapse collapse">
+                <div id="collapse-description" class="panel-collapse">
 
                 <div class="well" style="margin: 10px;">{% autoescape off %}{{ basics_pretty|lookup:"description" }}{% endautoescape %}</div>
 
@@ -169,7 +169,7 @@
                     <h1 class="panel-title"><a data-toggle="collapse" data-parent="#bins_panel" href="#collapse-bins">Summary of Bins ({{ meta|lookup:"num_bins"|pretty }})</a></h1>
                 </div>
 
-                <div id="collapse-bins" class="panel-collapse collapse">
+                <div id="collapse-bins" class="panel-collapse">
                     <div class="panel-body">
                         <p style="color: #AAAAAA; padding: 20px;">Summary of of each bin. You can download the information below also as a <a href="{{ files|lookup:'bins_summary' }}">TAB-delimited file</a>. Here is another TAB-delimited file that reports <a href="{{ files|lookup:'misc_data_layers' }}">data for each single profile (such as number of reads mapped, etc)</a>.</p>
 
@@ -368,7 +368,7 @@
                 <h1 class="panel-title"><a data-toggle="collapse" data-parent="#bins_across_samples_panel" href="#collapse-bins-across-samples">Across Samples ({{ meta|lookup:"profile"|lookup:"samples"|length|pretty }})</a></h1> 
             </div>
 
-            <div id="collapse-bins-across-samples" class="panel-collapse collapse">
+            <div id="collapse-bins-across-samples" class="panel-collapse">
 
                 <div role="tabpanel" style="margin: 10px;">
                     <!-- Nav tabs -->
@@ -445,7 +445,7 @@
                     <h1 class="panel-title"><a data-toggle="collapse" data-parent="#bins_percent_recruitment_panel" href="#collapse-bins-percent-recruitment">Percent Recruitment</a></h1>
                 </div>
 
-                <div id="collapse-bins-percent-recruitment" class="panel-collapse collapse">
+                <div id="collapse-bins-percent-recruitment" class="panel-collapse">
                     <div class="panel-body">
                         <p style="color: #AAAAAA; padding: 0px 20px;">This panel shows how much of the mapped data is recruited by each bin (and how much of the mapped data was not binned under 'splits_not_binned' column). The way these percents calculated is quite simple: summarize the mean coverage of each split in each bin, and normalize every bin with respect to each other. It is critical to remember that these values do not take the unasssambled data into account. This is how you should read this table: <i>"X percent of all mapped reads in Sample Y mapped to splits that were binned into bin Z"</i>.</p>
                         <p style="color: #AAAAAA; padding: 20px;">TAB-delimited matrix file for percent recruitment: <a href="{{ files|lookup:'bins_percent_recruitment' }}">{{ files|lookup:'bins_percent_recruitment' }}</a></p>
@@ -505,7 +505,7 @@
                 <h1 class="panel-title"><a data-toggle="collapse" data-parent="#genes_panel" href="#collapse-functions">Gene calls (their functions, coverage and detection across samples, etc)</a></h1>
             </div>
 
-            <div id="collapse-functions" class="panel-collapse collapse">
+            <div id="collapse-functions" class="panel-collapse">
                 <div class="panel-body">
 
                     <p style="color: #AAAAAA; padding: 20px;">An overview of genes and functions based on the information found in the contigs database. If you haven't assigned any functions, these tables will only contain coverages of ORFs across samples.</a></p>
@@ -571,7 +571,7 @@
                     <h1 class="panel-title"><a data-toggle="collapse" data-parent="#hmms_panel" href="#collapse-hmms">Hits for non-single-copy gene HMM profiles</a></h1>
                 </div>
 
-                <div id="collapse-hmms" class="panel-collapse collapse">
+                <div id="collapse-hmms" class="panel-collapse">
 
                     <div class="panel-body">
                         <p style="color: #AAAAAA; padding: 20px;">This panel shows you the result of non-single copy gene hits in your bins and contigs for each HMM profile. Here is a table that shows the total number of HMM hits in each bin for each HMM search type (<a href="{{ files|lookup:'hmm_hit_totals' }}">from {{ files|lookup:'hmm_hit_totals' }}</a>):</p>

--- a/anvio/data/static/template/profile-index.tmpl
+++ b/anvio/data/static/template/profile-index.tmpl
@@ -204,8 +204,8 @@
                                             <td style="vertical-align: middle;">{{ bin }}</td>
                                             <td class="text-center"  style="vertical-align: middle; font-style: italic;">{{ collection|lookup:bin|lookup:"source" }}</td>
 
-                                            {% if meta|lookup:"contigs"|lookup:"gene_level_taxonomy_source" %}
-                                            <td class="text-center" data-value="{{ collection|lookup:bin|lookup:"taxon" }}"><button type="button" class="btn btn-default" data-toggle="modal" data-target="#modTaxonomy_{{bin}}"><i>{{ collection|lookup:bin|lookup:"taxon" }}</i></button></td>
+                                            {% if meta|lookup:"contigs"|lookup:"scg_taxonomy_was_run" %}
+                                            <td class="text-center" data-value="{{ collection|lookup:bin|lookup:"taxon" }}"><button type="button" class="btn btn-default" data-toggle="modal" data-target="#modTaxonomy_{{bin}}"><i>{{ collection|lookup:bin|lookup:"scg_taxonomy_simple" }}</i></button></td>
                                             {% else %}
                                             <td class="text-center">N/A</td>
                                             {% endif %}

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -20,7 +20,6 @@ import anvio.tables as t
 import anvio.utils as utils
 import anvio.dbops as dbops
 import anvio.terminal as terminal
-import anvio.summarizer as summarizer
 import anvio.ccollections as ccollections
 
 from anvio.errors import ConfigError
@@ -429,6 +428,8 @@ class GenomeDescriptions(object):
 
 
     def init_external_genomes(self):
+        from anvio.summarizer import ContigSummarizer
+
         self.progress.new('Initializing external genomes', progress_total_items=len(self.external_genome_names))
         for genome_name in self.external_genome_names:
             c = self.genomes[genome_name]
@@ -436,7 +437,7 @@ class GenomeDescriptions(object):
 
             self.progress.update('working on %s' % (genome_name), increment=True)
 
-            contigs_db_summary = summarizer.ContigSummarizer(c['contigs_db_path']).get_contigs_db_info_dict(gene_caller_to_use=self.gene_caller)
+            contigs_db_summary = ContigSummarizer(c['contigs_db_path']).get_contigs_db_info_dict(gene_caller_to_use=self.gene_caller)
 
             for key in contigs_db_summary:
                 c[key] = contigs_db_summary[key]
@@ -458,6 +459,8 @@ class GenomeDescriptions(object):
 
 
     def init_internal_genomes(self):
+        from anvio.summarizer import ContigSummarizer
+
         self.progress.new('Initializing internal genomes')
 
         # to not initialize things over and over again:
@@ -479,7 +482,7 @@ class GenomeDescriptions(object):
                 # here we are using the get_contigs_db_info_dict function WITH split names we found in the collection
                 # which returns a partial summary from the contigs database focusing only those splits. a small workaround
                 # to be able to use the same function for bins in collections:
-                contigs_summary = summarizer.ContigSummarizer(c['contigs_db_path'])
+                contigs_summary = ContigSummarizer(c['contigs_db_path'])
                 summary_from_contigs_db_summary = contigs_summary.get_contigs_db_info_dict(split_names=split_names_of_interest,
                                                                                            gene_caller_to_use=self.gene_caller)
 

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -808,30 +808,43 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
                                 }
 
         # I am not sure whether this is the best place to do this,
+        T = lambda x: 'True' if x else 'False'
+        renderer = mistune.Renderer(escape=False)
+        markdown = mistune.Markdown(renderer=renderer)
         self.summary['basics_pretty'] = {'profile': [
                                                      ('Created on', self.p_meta['creation_date']),
                                                      ('Version', self.p_meta['version']),
-                                                     ('Minimum contig length', pretty(self.p_meta['min_contig_length'])),
                                                      ('Number of contigs', pretty(int(self.p_meta['num_contigs']))),
                                                      ('Number of splits', pretty(int(self.p_meta['num_splits']))),
+                                                     ('Contig length cutoff min', pretty(self.p_meta['min_contig_length'])),
+                                                     ('Contig length cutoff max', pretty(self.p_meta['max_contig_length'])),
+                                                     ('Samples in profile', ', '.join(self.p_meta['samples'])),
                                                      ('Total nucleotides', humanize_n(int(self.p_meta['total_length']))),
-                                                     ('SNVs profiled', self.p_meta['SNVs_profiled']),
-                                                     ('SCVs profiled', self.p_meta['SCVs_profiled']),
+                                                     ('SNVs profiled', T(self.p_meta['SNVs_profiled'])),
+                                                     ('SCVs profiled', T(self.p_meta['SCVs_profiled'])),
+                                                     ('IN/DELs profiled', T(self.p_meta['INDELs_profiled'])),
+                                                     ('Report variability full', T(self.p_meta['report_variability_full'])),
+                                                     ('Min coverage for variability', humanize_n(int(self.p_meta['min_coverage_for_variability']))),
+                                                     ('Min IN/DEL fraction', self.p_meta['min_indel_fraction']),
                                                     ],
                                          'contigs': [
-                                                        ('Created on', self.p_meta['creation_date']),
+                                                        ('Project name', self.a_meta['project_name']),
+                                                        ('Created on', self.a_meta['creation_date']),
                                                         ('Version', self.a_meta['version']),
-                                                        ('Split length', pretty(int(self.a_meta['split_length']))),
+                                                        ('Total nucleotides', humanize_n(int(self.a_meta['total_length']))),
                                                         ('Number of contigs', pretty(int(self.a_meta['num_contigs']))),
                                                         ('Number of splits', pretty(int(self.a_meta['num_splits']))),
-                                                        ('Total nucleotides', humanize_n(int(self.a_meta['total_length']))),
+                                                        ('Genes are called', T(self.a_meta['genes_are_called'])),
+                                                        ('External gene calls', T(self.a_meta['external_gene_calls'])),
+                                                        ('External amino acid sequences', T(self.a_meta['external_gene_amino_acid_seqs'])),
                                                         ('K-mer size', self.a_meta['kmer_size']),
-                                                        ('Genes are called', self.a_meta['genes_are_called']),
-                                                        ('Splits consider gene calls', self.a_meta['splits_consider_gene_calls']),
+                                                        ('Split length', pretty(int(self.a_meta['split_length']))),
+                                                        ('Splits consider gene calls', T(self.a_meta['splits_consider_gene_calls'])),
+                                                        ('SCG taxonomy was run', T(self.a_meta['scg_taxonomy_was_run'])),
                                                         ('Gene function sources', ', '.join(self.gene_function_call_sources) if self.gene_function_call_sources else 'None :('),
                                                         ('Summary reformatted contig names', self.reformat_contig_names),
                                                     ],
-                                        'description': mistune.markdown(self.p_meta['description']),
+                                        'description': markdown(self.p_meta['description']),
                                         }
 
         self.summary['max_shown_header_items'] = 10

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -887,9 +887,13 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
         if not self.quick:
             # generate a TAB-delimited text output file for bin summaries
             summary_of_bins = {}
-            properties = ['taxon', 'total_length', 'num_contigs', 'N50', 'GC_content']
+            properties = ['total_length', 'num_contigs', 'N50', 'GC_content']
+
             if self.completeness_data_available:
                 properties += ['percent_completion', 'percent_redundancy']
+
+            if self.scg_taxonomy:
+                properties += constants.levels_of_taxonomy
 
             for bin_name in self.summary['collection']:
                 summary_of_bins[bin_name] = dict([(prop, self.summary['collection'][bin_name][prop]) for prop in properties])

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -88,7 +88,6 @@ class ArgsTemplateForSummarizerClass:
         self.pan_db = None
         self.contigs_db = None
         self.collection_name = None
-        self.taxonomic_level = 't_genus'
         self.list_collections = None
         self.list_bins = None
         self.debug = None
@@ -137,7 +136,6 @@ class SummarizerSuperClass(object):
         self.output_directory = A('output_dir')
         self.quick = A('quick_summary')
         self.debug = A('debug')
-        self.taxonomic_level = A('taxonomic_level') or 't_genus'
         self.cog_data_dir = A('cog_data_dir')
         self.report_aa_seqs_for_gene_calls = A('report_aa_seqs_for_gene_calls')
         self.report_DNA_sequences = A('report_DNA_sequences')
@@ -754,8 +752,6 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
         # databases initiated, let's make sure we have gene covereges data avaialable.
         if self.gene_level_coverage_stats_dict:
             self.gene_level_coverage_stats_available = True
-
-        self.init_splits_taxonomy(self.taxonomic_level)
 
         self.collection_dict = {}
         self.bins_info_dict = {}

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -44,6 +44,7 @@ import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
 import anvio.completeness as completeness
+import anvio.scgtaxonomyops as scgtaxonomyops
 
 from anvio.errors import ConfigError
 from anvio.dbops import DatabasesMetaclass, ContigsSuperclass, PanSuperclass
@@ -777,6 +778,12 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
 
         # load gene functions from contigs db superclass
         self.init_functions()
+
+        # get an instance of SCG taxonomy:
+        if self.a_meta['scg_taxonomy_was_run']:
+            self.scg_taxonomy = scgtaxonomyops.SCGTaxonomyEstimatorSingle(argparse.Namespace(contigs_db=self.contigs_db_path))
+        else:
+            self.scg_taxonomy = None
 
         # set up the initial summary dictionary
         self.summary['meta'] = {'quick': self.quick,

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -1691,7 +1691,7 @@ class Bin:
         self.store_data_in_file('GC_content.txt', '%.4f' % self.bin_info_dict['GC_content'])
 
 
-    def get_output_file_handle(self, prefix='output.txt', overwrite=False, key=None):
+    def get_output_file_handle(self, prefix='output.txt', overwrite=False, key=None, just_the_path=False):
         file_path = os.path.join(self.output_directory, '%s-%s' % (self.bin_id, prefix))
 
         if os.path.exists(file_path) and not overwrite:
@@ -1702,7 +1702,7 @@ class Bin:
 
         self.bin_info_dict['files'][key] = file_path[len(self.summary.output_directory):].strip('/')
 
-        return open(file_path, 'w')
+        return file_path if just_the_path else open(file_path, 'w')
 
 
     def store_data_in_file(self, output_file_name_posfix, content):

--- a/bin/anvi-summarize
+++ b/bin/anvi-summarize
@@ -110,7 +110,6 @@ if __name__ == '__main__':
     groupE.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
     groupE.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir'))
     groupE.add_argument(*anvio.A('list-collections'), **anvio.K('list-collections'))
-    groupE.add_argument(*anvio.A('taxonomic-level'), **anvio.K('taxonomic-level'))
     groupE.add_argument(*anvio.A('cog-data-dir'), **anvio.K('cog-data-dir'))
     groupE.add_argument(*anvio.A('quick-summary'), **anvio.K('quick-summary'))
 


### PR DESCRIPTION
This addresses the feature request in #1502. It is a lot of code, but the most critical line is here and makes me ❤️ anvi'o, so I wanted to share:

``` python
scg_taxonomy_dict = self.summary.scg_taxonomy.estimate_for_list_of_splits(self.split_names, bin_name=self.bin_id)
```

:)

BYE NOW.