### PR TITLE
anvi-cluster-contigs += --log-file

### DIFF
--- a/anvio/drivers/binsanity.py
+++ b/anvio/drivers/binsanity.py
@@ -81,10 +81,11 @@ class BinSanity:
         utils.is_program_exists(self.program_name)
 
 
-    def cluster(self, input_files, args, work_dir, threads=1):
+    def cluster(self, input_files, args, work_dir, threads=1, log_file_path=None):
         J = lambda p: os.path.join(work_dir, p)
 
-        log_path = J('logs.txt')
+        if not log_file_path:
+            log_file_path = J('logs.txt')
 
         translation = {
             'preference': 'p',
@@ -103,14 +104,14 @@ class BinSanity:
 
         self.progress.new(self.program_name)
         self.progress.update('Running using %d threads...' % threads)
-        utils.run_command(cmd_line, log_path)
+        utils.run_command(cmd_line, log_file_path)
         self.progress.end()
 
 
         output_file_paths = glob.glob(J('*.fna'))
         if not len(output_file_paths):
             raise ConfigError("Some critical output files are missing. Please take a look at the "
-                              "log file: %s" % (log_path))
+                              "log file: %s" % (log_file_path))
 
         clusters = {}
         bin_count = 0

--- a/anvio/drivers/binsanity.py
+++ b/anvio/drivers/binsanity.py
@@ -2,7 +2,6 @@
 """Interface to BinSanity."""
 import os
 import glob
-import shutil
 
 import anvio
 import anvio.utils as utils

--- a/anvio/drivers/concoct.py
+++ b/anvio/drivers/concoct.py
@@ -108,10 +108,12 @@ class CONCOCT:
         utils.is_program_exists(self.program_name)
 
 
-    def cluster(self, input_files, args, work_dir, threads=1):
+    def cluster(self, input_files, args, work_dir, threads=1, log_file_path=None):
         J = lambda p: os.path.join(work_dir, p)
 
-        log_path = J('logs.txt')
+        if not log_file_path:
+            log_file_path = J('logs.txt')
+
         cmd_line = [self.program_name,
             '--coverage_file', input_files.contig_coverages,
             '--composition_file', input_files.contigs_fasta,
@@ -121,7 +123,7 @@ class CONCOCT:
 
         self.progress.new(self.program_name)
         self.progress.update('Running using %d threads...' % threads)
-        utils.run_command(cmd_line, log_path)
+        utils.run_command(cmd_line, log_file_path)
         self.progress.end()
 
         clusters = {}
@@ -131,7 +133,7 @@ class CONCOCT:
         output_file_path = J(output_file_name)
         if not os.path.exists(output_file_path):
             raise ConfigError("One of the critical output files is missing ('%s'). Please take a look at the "
-                              "log file: %s" % (output_file_name, log_path))
+                              "log file: %s" % (output_file_name, log_file_path))
 
         with open(output_file_path, 'r') as f:
             lines = f.readlines()[1:]

--- a/anvio/drivers/dastool.py
+++ b/anvio/drivers/dastool.py
@@ -89,12 +89,14 @@ class DAS_Tool:
         utils.is_program_exists(self.program_name)
 
 
-    def cluster(self, input_files, args, work_dir, threads=1):
+    def cluster(self, input_files, args, work_dir, threads=1, log_file_path=None):
         J = lambda p: os.path.join(work_dir, p)
 
         cwd_backup = os.getcwd()
         os.chdir(work_dir)
-        log_path = J('logs.txt')
+
+        if not log_file_path:
+            log_file_path = J('logs.txt')
 
         c = ccollections.Collections(r = run, p = progress)
         c.populate_collections_dict(input_files.profile_db)
@@ -130,14 +132,14 @@ class DAS_Tool:
 
         self.progress.new(self.program_name)
         self.progress.update('Running using %d threads...' % threads)
-        utils.run_command(cmd_line, log_path)
+        utils.run_command(cmd_line, log_file_path)
         self.progress.end()
 
         output_file_name = 'OUTPUT_DASTool_scaffolds2bin.txt'
         output_file_path = J(output_file_name)
         if not os.path.exists(output_file_path):
             raise ConfigError("One of the critical output files is missing ('%s'). Please take a look at the "
-                              "log file: %s" % (output_file_name, log_path))
+                              "log file: %s" % (output_file_name, log_file_path))
 
         clusters = {}
         with open(output_file_path, 'r') as f:

--- a/anvio/drivers/maxbin2.py
+++ b/anvio/drivers/maxbin2.py
@@ -2,7 +2,6 @@
 """Interface to MaxBin2."""
 import os
 import glob
-import shutil
 
 import anvio
 import anvio.utils as utils

--- a/anvio/drivers/maxbin2.py
+++ b/anvio/drivers/maxbin2.py
@@ -67,11 +67,13 @@ class MaxBin2:
         utils.is_program_exists(self.program_name)
 
 
-    def cluster(self, input_files, args, work_dir, threads=1):
+    def cluster(self, input_files, args, work_dir, threads=1, log_file_path=None):
         J = lambda p: os.path.join(work_dir, p)
 
         output_file_prefix = J('MAXBIN_')
-        log_path = J('logs.txt')
+
+        if not log_file_path:
+            log_file_path = J('logs.txt')
 
         cmd_line = [self.program_name,
             '-contig', input_files.contigs_fasta,
@@ -83,13 +85,13 @@ class MaxBin2:
 
         self.progress.new(self.program_name)
         self.progress.update('Running using %d threads...' % threads)
-        utils.run_command(cmd_line, log_path)
+        utils.run_command(cmd_line, log_file_path)
         self.progress.end()
 
         output_file_paths = glob.glob(J(output_file_prefix + '*.fasta'))
         if not len(output_file_paths):
             raise ConfigError("Some critical output files are missing. Please take a look at the "
-                              "log file: %s" % (log_path))
+                              "log file: %s" % (log_file_path))
 
         clusters = {}
         bin_count = 0

--- a/anvio/drivers/metabat2.py
+++ b/anvio/drivers/metabat2.py
@@ -2,7 +2,6 @@
 """Interface to MetaBAT2."""
 import os
 import glob
-import shutil
 
 import anvio
 import anvio.utils as utils

--- a/anvio/drivers/metabat2.py
+++ b/anvio/drivers/metabat2.py
@@ -107,11 +107,13 @@ class MetaBAT2:
         utils.is_program_exists(self.program_name)
 
 
-    def cluster(self, input_files, args, work_dir, threads=1):
+    def cluster(self, input_files, args, work_dir, threads=1, log_file_path=None):
         J = lambda p: os.path.join(work_dir, p)
 
         bin_prefix = J('METABAT_')
-        log_path = J('logs.txt')
+
+        if not log_file_path:
+            log_file_path = J('logs.txt')
 
         cmd_line = [self.program_name,
             '-i', input_files.contigs_fasta,
@@ -124,13 +126,13 @@ class MetaBAT2:
 
         self.progress.new(self.program_name)
         self.progress.update('Running using %d threads...' % threads)
-        utils.run_command(cmd_line, log_path)
+        utils.run_command(cmd_line, log_file_path)
         self.progress.end()
 
         output_file_paths = glob.glob(J(bin_prefix + '*'))
         if not len(output_file_paths):
             raise ConfigError("Some critical output files are missing. Please take a look at the "
-                              "log file: %s" % (log_path))
+                              "log file: %s" % (log_file_path))
 
         clusters = {}
         bin_count = 0

--- a/bin/anvi-cluster-contigs
+++ b/bin/anvi-cluster-contigs
@@ -151,6 +151,9 @@ def main(args, unknown):
                            'ANY characters but digits, ASCII letters and underscore character(s). There should not be '
                            'any space characters, and the collection name should not start with a digit.' % collection_name)
 
+    if args.log_file:
+        filesnpaths.is_output_file_writable(args.log_file)
+
     utils.is_profile_db_and_contigs_db_compatible(args.profile_db, args.contigs_db)
 
     merged_profile_db = dbops.ProfileDatabase(args.profile_db)
@@ -206,7 +209,7 @@ def main(args, unknown):
                           "module please address this in your code. If you are a user, please consider dropping a line to anvi'o "
                           "developers." % (binning_module_name))
 
-    clusters = binning_module.cluster(input_files, sub_args, working_dir, threads=args.num_threads)
+    clusters = binning_module.cluster(input_files, sub_args, working_dir, threads=args.num_threads, log_file_path=args.log_file)
 
     if not anvio.DEBUG:
         shutil.rmtree(working_dir)
@@ -235,6 +238,7 @@ if __name__ == '__main__':
     parent_parser.add_argument(*anvio.A('driver'), **anvio.K('driver',
         {'choices': list(driver_modules['binning'].keys()), 'type': str.lower}))
     parent_parser.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
+    parent_parser.add_argument(*anvio.A('log-file'), **anvio.K('log-file'))
     parent_parser.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     show_help = ('--help' in sys.argv) or ('-h' in sys.argv)


### PR DESCRIPTION
Anvi'o automatically assigns a temp file path to store the STDOUT and STDERR while running clustering algorithms, however, this causes issues when the run fails on HPCs and clusters where the temporary file path is not accessible from the head node.

The new parameter `--log-file` enables the user to pass an explicit file path (so it is accessible form everywhere).