### PR TITLE
Ability to show gene cluster details

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -19,7 +19,6 @@ import base64
 import random
 import getpass
 import argparse
-import requests
 import datetime
 import importlib
 

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -182,6 +182,7 @@ class BottleApplication(Bottle):
         self.route('/data/check_homogeneity_info',             callback=self.check_homogeneity_info, method='POST')
         self.route('/data/search_items',                       callback=self.search_items_by_name, method='POST')
         self.route('/data/get_taxonomy',                       callback=self.get_taxonomy, method='POST')
+        self.route('/data/get_functions_for_gene_clusters',    callback=self.get_functions_for_gene_clusters, method='POST')
         self.route('/data/get_gene_info/<gene_callers_id>',    callback=self.get_gene_info)
         self.route('/data/get_metabolism',                     callback=self.get_metabolism)
 
@@ -1403,3 +1404,23 @@ class BottleApplication(Bottle):
             return json.dumps({'status': 1, 'message': message})
 
         return json.dumps(output)
+
+
+    def get_functions_for_gene_clusters(self):
+        if not len(self.interactive.gene_clusters_function_sources):
+            message = "Gene cluster functions seem to have not been initialized, so that button has nothing to show you :/ Please carry on."
+            run.warning(message)
+            return json.dumps({'status': 1, 'message': message})
+
+        gene_cluster_names = json.loads(request.forms.get('gene_clusters'))
+
+        d = {}
+        for gene_cluster_name in gene_cluster_names:
+            if gene_cluster_name not in self.interactive.gene_clusters_functions_summary_dict:
+                message = (f"At least one of the gene clusters in your list (e.g., {gene_cluster_name}) is missing in "
+                           f"the functions summary dict :/")
+                return json.dumps({'status': 1, 'message': message})
+                
+            d[gene_cluster_name] = self.interactive.gene_clusters_functions_summary_dict[gene_cluster_name]
+
+        return json.dumps({'functions': d, 'sources': list(self.interactive.gene_clusters_function_sources)})

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -184,7 +184,8 @@ class COGs:
             COG_ids = cogs_data.p_id_to_cog_id[ncbi_protein_id]
 
             annotations = []
-            categories = set([])
+            categories = []
+            category_descriptions = []
             for COG_id in COG_ids:
                 # is missing?
                 if COG_id in cogs_data.missing_cogs:
@@ -194,7 +195,8 @@ class COGs:
 
                 # resolve categories
                 for category in cogs_data.cogs[COG_id]['categories']:
-                    categories.add(category)
+                    categories.append(category)
+                    category_descriptions.append(cogs_data.categories[category])
 
                 # append annotation
                 annotations.append(cogs_data.cogs[COG_id]['annotation'])
@@ -204,7 +206,7 @@ class COGs:
             # 9pm. Where am I? In the lab. Is it OK for me to let this slip away if it means for me to go home sooner? Yes, probably. Am I
             # gonna remember this crap in the code for the next two months at random times in the shower and feel bad about myself? Fuck yes.
             add_entry(gene_callers_id, 'COG_FUNCTION', '!!!'.join(COG_ids), '!!!'.join(annotations), self.hits[gene_callers_id]['evalue'])
-            add_entry(gene_callers_id, 'COG_CATEGORY', '!!!'.join(categories), '!!!'.join(categories), 0.0)
+            add_entry(gene_callers_id, 'COG_CATEGORY', '!!!'.join(categories), '!!!'.join(category_descriptions), 0.0)
 
         # store hits in contigs db.
         gene_function_calls_table = TableForGeneFunctions(self.contigs_db_path, self.run, self.progress)

--- a/anvio/data/interactive/js/bin.js
+++ b/anvio/data/interactive/js/bin.js
@@ -748,6 +748,27 @@ Bins.prototype.ExportCollection = function(use_bin_id=false) {
 };
 
 
+Bins.prototype.ExportBin = function(bin_id_to_export, use_bin_id=false) {
+    for (let tr of this.container.querySelectorAll('tr.bin-row')) {
+        let bin_id = tr.getAttribute('bin-id');
+
+        if (bin_id == bin_id_to_export) {
+            let bin_name = tr.querySelector('.bin-name').value;
+            let bin_color = tr.querySelector('.colorpicker').getAttribute('color');
+            let items = [];
+
+            for (let node of this.selections[bin_id].values()) {
+                if (node.IsLeaf()) {
+                    items.push(node.label);
+                }
+            }
+
+            return {'items': items, 'color': bin_color, 'bin_name': bin_name};
+        }
+    }
+};
+
+
 Bins.prototype.HighlightItems = function(item_list) {
     if (!Array.isArray(item_list)) {
         item_list = [item_list];

--- a/anvio/data/interactive/js/bin.js
+++ b/anvio/data/interactive/js/bin.js
@@ -86,8 +86,8 @@ Bins.prototype.NewBin = function(id, binState) {
                            <td data-value="${contig_length}" class="length-sum"><span>${contig_length}</span></td>
                        ` : ''}
                        ${mode == 'pan' ? `
-                            <td data-value="${num_gene_clusters}" class="num-gene-clusters"><input type="button" value="${num_gene_clusters}"></td>
-                            <td data-value="${num_gene_calls}" class="num-gene-calls"><input type="button" value="${num_gene_calls}"></td>                           
+                            <td data-value="${num_gene_clusters}" class="num-gene-clusters"><input type="button" value="${num_gene_clusters}" title="Click for quick gene cluster summaries" onClick="showGeneClusterDetails(${id});"></td>
+                            <td data-value="${num_gene_calls}" class="num-gene-calls"><input type="button" value="${num_gene_calls}"></td>
                        ` : `
                             <td data-value="${completeness}" class="completeness"><input type="button" value="${completeness}" title="Click for completeness table" onClick="showCompleteness(${id});"></td>
                             <td data-value="${redundancy}" class="redundancy"><input type="button" value="${redundancy}" title="Click for redundant hits" onClick="showRedundants(${id}); "></td>

--- a/anvio/data/interactive/js/constants.js
+++ b/anvio/data/interactive/js/constants.js
@@ -65,6 +65,9 @@ var named_functional_sources = {
 
 
 function decorateAccession(source, accession_id){
+    if (!accession_id)
+        return accession_id;
+
     if (source in named_functional_sources){
         if ('accession_decorator' in named_functional_sources[source]){
             return named_functional_sources[source]['accession_decorator'](accession_id);

--- a/anvio/data/interactive/js/constants.js
+++ b/anvio/data/interactive/js/constants.js
@@ -27,7 +27,7 @@ var COG_categories = {
 }
 
 var named_functional_sources = {
-    'EGGNOG (BACT)': {
+    'EGGNOG_BACT': {
         'accession_decorator': (function (d) {
                                     return '<a href="http://www.uniprot.org/uniprot/?query=' + d + '&sort=score" target="_blank">' + d + '</a>';
                                 }),

--- a/anvio/data/interactive/js/constants.js
+++ b/anvio/data/interactive/js/constants.js
@@ -41,6 +41,20 @@ var named_functional_sources = {
                                 }),
     },
 
+    'KOfam': {
+        'accession_decorator': (function (d) {
+                                    var kos = d.split(', ').map((function (c){return '<a href="https://www.genome.jp/dbget-bin/www_bget?ko:' + c +'" target=_"blank">' + c + '</a>';}));
+                                    return kos.join(', ');
+                                }),
+    },
+
+    'Pfam': {
+        'accession_decorator': (function (d) {
+                                    var pfams = d.split(', ').map((function (c){return '<a href="https://pfam.xfam.org/family/' + c +'" target=_"blank">' + c + '</a>';}));
+                                    return pfams.join(', ');
+                                }),
+    },
+
     'COG_CATEGORY': {
         'annotation_decorator': (function (d) {
                                     var cogs = d.split(', ').map((function (c){if (c in COG_categories) {return COG_categories[c];} else {return c;}}));

--- a/anvio/data/interactive/js/constants.js
+++ b/anvio/data/interactive/js/constants.js
@@ -64,6 +64,25 @@ var named_functional_sources = {
 }
 
 
+function getPrettyFunctionsString(fstring, source) {
+    if (!fstring)
+        return ["-"];
+    else
+        farray = fstring.split('!!!');
+
+        if ((source == null) || source == '' || source == 'None')
+            return farray.join(' / ');
+        else {
+            var dec = new Array();
+
+            for (f in farray)
+                dec.push(decorateAccession(source, farray[f]))
+
+            return dec.join(' / ')
+        }
+}
+
+
 function decorateAccession(source, accession_id){
     if (!accession_id)
         return accession_id;

--- a/anvio/data/interactive/js/inspectionutils.js
+++ b/anvio/data/interactive/js/inspectionutils.js
@@ -101,13 +101,19 @@ function get_gene_functions_table_html(gene){
     functions_table_html += '<th>Annotation</th></thead>';
     functions_table_html += '<tbody>';
 
-    for (function_source in gene.functions){
+    const gene_functions = {};
+    Object.keys(gene.functions).sort().forEach(function(key) {
+      gene_functions[key] = gene.functions[key];
+    });
+
+    console.log(gene_functions);
+    for (function_source in gene_functions){
         functions_table_html += '<tr>';
 
         functions_table_html += '<td><b>' + function_source + '</b></td>';
         if (gene.functions[function_source]) {
-            functions_table_html += '<td>' + decorateAccession(function_source, gene.functions[function_source][0]) + '</td>';
-            functions_table_html += '<td><em>' + decorateAnnotation(function_source, gene.functions[function_source][1]) + '</em></td>';
+            functions_table_html += '<td>' + getPrettyFunctionsString(gene.functions[function_source][0], function_source) + '</td>';
+            functions_table_html += '<td><em>' + getPrettyFunctionsString(gene.functions[function_source][1]) + '</em></td>';
         } else {
             functions_table_html += '<td>&nbsp;</td>';
             functions_table_html += '<td>&nbsp;</td>';

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -1746,6 +1746,7 @@ function showGeneClusterDetails(bin_id, updateOnly) {
         return;
 
     let bin_info = bins.ExportBin(bin_id);
+    console.log(bin_info);
 
     $.ajax({
         type: 'POST',
@@ -1802,7 +1803,7 @@ function showGeneClusterDetails(bin_id, updateOnly) {
 
         content += `</tbody></table>`
 
-        showGeneClusterFunctionsSummaryTableDialog('A summary of functions for gene clusters in ' + bin_id, content + '</table>');
+        showGeneClusterFunctionsSummaryTableDialog('A summary of functions for ' + bin_info['items'].length + ' gene clusters in "' + bin_info['bin_name'] + '".', content + '</table>');
         }
     });
 

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -120,7 +120,7 @@ $(document).ready(function() {
     }
 
     $('#tree_type').change(function() {
-        if ($('#tree_type').val()=='circlephylogram') 
+        if ($('#tree_type').val()=='circlephylogram')
         {
             $('.phylogram_settings').hide();
             $('.circlephylogram_settings').show();
@@ -168,7 +168,7 @@ $(document).ready(function() {
         if ($(this).hasClass('disabled')) {
             e.preventDefault();
             return false;
-        }  
+        }
     });
 
     if (!$.browser.chrome)
@@ -238,11 +238,11 @@ function initData() {
             var available_views = response.views[2];
             $('#views_container').append(getComboBoxContent(default_view, available_views));
 
-            $("#tbody_layers").sortable({helper: fixHelperModified, handle: '.drag-icon', items: "> tr"}).disableSelection(); 
-            $("#tbody_samples").sortable({helper: fixHelperModified, handle: '.drag-icon', items: "> tr"}).disableSelection(); 
-                        
+            $("#tbody_layers").sortable({helper: fixHelperModified, handle: '.drag-icon', items: "> tr"}).disableSelection();
+            $("#tbody_samples").sortable({helper: fixHelperModified, handle: '.drag-icon', items: "> tr"}).disableSelection();
+
             let merged = samplesMergeStackbarLayers(response.layers_information, response.layers_information_default_order);
-            
+
             samples_order_dict = response.layers_order;
             samples_information_dict = merged['dict'];
             let samples_information_default_layer_order = merged['default_order'];
@@ -273,11 +273,11 @@ function initData() {
             if (response.functions_sources.length > 0) {
                 $('#functions_sources_list').empty();
             }
-            
+
             response.functions_sources.forEach((source) => {
                 $('#functions_sources_list').append(`<label style="margin: 5px;"><input type="checkbox" value="${source}" checked="checked" style="margin-right: 2px;"/>${source}</label>`);
             });
-            
+
             buildSamplesTable(convert_samples_order_to_array(samples_information_default_layer_order));
             toggleSampleGroups();
             changeViewData(response.views[1]);
@@ -314,7 +314,7 @@ function initData() {
                         setTimeout(toggleLeftPanel, 500);
                     }
                  });
-            } 
+            }
         }
     });
 }
@@ -432,11 +432,11 @@ function onViewChange() {
     $('#views_container').prop('disabled', false);
     $('#btn_draw_tree').prop('disabled', true);
 
-    waitingDialog.show('Requesting view data from the server ...', 
+    waitingDialog.show('Requesting view data from the server ...',
         {
-            dialogSize: 'sm', 
+            dialogSize: 'sm',
             onHide: function() {
-                defer.resolve(); 
+                defer.resolve();
             },
             onShow: function() {
                 $.ajax({
@@ -459,7 +459,7 @@ function changeViewData(view_data) {
     layerdata = mergeStackbarLayers(view_data);
     parameter_count = layerdata[0].length;
 
-    // since we are painting parent layers odd-even, 
+    // since we are painting parent layers odd-even,
     // we should remove single parents (single means no parent)
     removeSingleParents(); // in utils.js
 
@@ -551,14 +551,14 @@ function populateColorDicts() {
                 for (var j=0; j < bars.length; j++)
                 {
                     stack_bar_colors[layer_id][bars[j]] = getNamedCategoryColor(bars[j]);
-                    
+
                     let sum = 0;
                     for (let i=1; i < layerdata.length; i++) {
                         sum += parseFloat(layerdata[i][layer_id].split(';')[j]);
                     }
 
                     stack_bar_stats[layer_id][bars[j]] = sum;
-                } 
+                }
             }
         }
 
@@ -624,7 +624,7 @@ function populateColorDicts() {
                             }
 
                             samples_stack_bar_stats[group][sample_layer_name][item_name] = sum;
-                        } 
+                        }
                     }
                 }
                 else // categorical
@@ -664,7 +664,7 @@ function buildLegendTables() {
         $('#legend_settings').accordion("destroy");
         $('#legend_settings').empty();
     }
-    
+
     legends = [];
 
     for (let pindex in categorical_data_colors)
@@ -697,7 +697,7 @@ function buildLegendTables() {
             'item_names': names,
             'item_keys': names,
             'stats': stack_bar_stats[pindex]
-        });    
+        });
     }
 
     for (let group in samples_categorical_colors) {
@@ -761,7 +761,7 @@ function buildLegendTables() {
                                 <td class="col-md-10">
                                     <input type="radio" name="batch_rule_`+i+`" value="all" checked> All <br />
                                     <input type="radio" name="batch_rule_`+i+`" value="name"> Name contains <input type="text" id="name_rule_`+i+`" size="8"><br />
-                                    <input type="radio" name="batch_rule_`+i+`" value="count"> Count 
+                                    <input type="radio" name="batch_rule_`+i+`" value="count"> Count
                                         <select id="count_rule_`+i+`">
                                             <option selected>==</option>
                                             <option>&lt;</option>
@@ -835,7 +835,7 @@ function batchColor(legend_id) {
                     window[legend['source']][legend['group']][legend['key']][legend['item_keys'][i]] = color;
                 }
             }
-        } 
+        }
         else if (rule == 'count') {
             if (eval("legend['stats'][legend['item_keys'][i]] " + unescape($('#count_rule_'+legend_id).val()) + " " + parseFloat($('#count_rule_value_'+legend_id).val()))) {
                 if (typeof legend['group'] === 'undefined') {
@@ -874,13 +874,13 @@ function createLegendColorPanel(legend_id) {
             _name = _name + ' (' + legend['stats'][_name] + ')';
         }
 
-        template = template + '<div style="float: left; width: 50%; display: inline-block; padding: 3px 5px;">' + 
+        template = template + '<div style="float: left; width: 50%; display: inline-block; padding: 3px 5px;">' +
                                 '<div class="colorpicker-base legendcolorpicker" color="' + _color + '"' +
                                 'style="margin-right: 5px; background-color: ' + _color + '"' +
                                 'callback_source="' + legend['source'] + '"' +
                                 'callback_group="' + ((typeof legend['group'] !== 'undefined') ? legend['group'] : '') + '"' +
                                 'callback_pindex="' + legend['key'] + '"' +
-                                'callback_name="' + legend['item_keys'][j] + '"' + 
+                                'callback_name="' + legend['item_keys'][j] + '"' +
                                '></div>' + _name + '</div>';
     }
 
@@ -919,7 +919,7 @@ function orderLegend(legend_id, type) {
 
 function loadOrderingAdditionalData(order) {
     collapsedNodes = [];
-    
+
     if (order.hasOwnProperty('additional')) {
         let orders_additional = order['additional'];
 
@@ -939,13 +939,13 @@ function onTreeClusteringChange() {
     $('#trees_container').prop('disabled', true);
     $('#btn_draw_tree').prop('disabled', true);
 
-    waitingDialog.show('Requesting the tree data ...', 
+    waitingDialog.show('Requesting the tree data ...',
         {
-            dialogSize: 'sm', 
-            onHide: function() { 
-                defer.resolve(); 
+            dialogSize: 'sm',
+            onHide: function() {
+                defer.resolve();
             },
-            onShow: function() {    
+            onShow: function() {
                 $.ajax({
                     type: 'GET',
                     cache: false,
@@ -955,7 +955,7 @@ function onTreeClusteringChange() {
                         loadOrderingAdditionalData(order);
 
                         $('#trees_container').attr('disabled', false);
-                        $('#btn_draw_tree').attr('disabled', false); 
+                        $('#btn_draw_tree').attr('disabled', false);
                         waitingDialog.hide();
                     }
                 });
@@ -976,7 +976,7 @@ function syncViews() {
 
             views[current_view][layer_id] = {};
             views[current_view][layer_id]["normalization"] = $(layer).find('.normalization').val();
-            views[current_view][layer_id]["min"] = {'value': $(layer).find('.input-min').val(), 'disabled': $(layer).find('.input-min').is(':disabled') }; 
+            views[current_view][layer_id]["min"] = {'value': $(layer).find('.input-min').val(), 'disabled': $(layer).find('.input-min').is(':disabled') };
             views[current_view][layer_id]["max"] = {'value': $(layer).find('.input-max').val(), 'disabled': $(layer).find('.input-max').is(':disabled') };
 
             layers[layer_id]["color"] = $(layer).find('.colorpicker:last').attr('color');
@@ -988,7 +988,7 @@ function syncViews() {
             if (layers[layer_id]["type"] === 'text')
                 layers[layer_id]["height"] = '0';
         }
-    );    
+    );
 }
 
 
@@ -1026,7 +1026,7 @@ function getComboBoxContent(default_item, available_items){
 
 function buildLayersTable(order, settings)
 {
-    for (var i = 0; i < order.length; i++) 
+    for (var i = 0; i < order.length; i++)
     {
         // common layer variables
         var layer_id = order[i];
@@ -1055,12 +1055,12 @@ function buildLayersTable(order, settings)
         {
            layer_types[layer_id] = 0;
 
-            if (hasLayerSettings) 
+            if (hasLayerSettings)
             {
                 var height = layer_settings['height'];
                 var margin = layer_settings['margin'];
             }
-            else 
+            else
             {
                 var height = '50';
                 var margin = '15';
@@ -1088,7 +1088,7 @@ function buildLayersTable(order, settings)
         //
         // stack bar layer
         //
-        else if (layer_name.indexOf(';') > -1) 
+        else if (layer_name.indexOf(';') > -1)
         {
             layer_types[layer_id] = 1;
 
@@ -1100,7 +1100,7 @@ function buildLayersTable(order, settings)
             else
             {
                 var height = '300';
-                var margin = '15';           
+                var margin = '15';
             }
 
             if (hasViewSettings)
@@ -1159,7 +1159,7 @@ function buildLayersTable(order, settings)
             // categorical layer
             //
             if (!is_numeric)
-            { 
+            {
                 layer_types[layer_id] = 2;
 
                 if (hasLayerSettings)
@@ -1184,7 +1184,7 @@ function buildLayersTable(order, settings)
                         var type = 'color';
                     }
 
-                    // set default categorical layer type to 'text' 
+                    // set default categorical layer type to 'text'
                     // if there are more than 11 unique values and leaf count is less than 300
                     // 301 because layerdata has one extra row for the titles
                     if (layerdata.length <= 301)
@@ -1205,7 +1205,7 @@ function buildLayersTable(order, settings)
                         }
                     }
                 }
-                
+
                 var template = '<tr>' +
                     '<td><img class="drag-icon" src="images/drag.gif" /></td>' +
                     '<td title="{name}" class="titles" id="title{id}">{short-name}</td>' +
@@ -1238,7 +1238,7 @@ function buildLayersTable(order, settings)
                                    .replace(new RegExp('{margin}', 'g'), margin);
 
                 $('#tbody_layers').append(template);
-            } 
+            }
             //
             // numerical layer
             //
@@ -1330,7 +1330,7 @@ function buildLayersTable(order, settings)
 
                 $('#tbody_layers').append(template);
             }
-            
+
         }
 
         $('#tbody_layers .input-height:last').change(function (ev) {
@@ -1395,7 +1395,7 @@ function getLayerName(layer_id)
     return layerdata[0][layer_id];
 }
 
-function getLayerId(layer_name) 
+function getLayerId(layer_name)
 {
     for (var i=0; i < parameter_count; i++)
     {
@@ -1442,7 +1442,7 @@ function serializeSettings(use_layer_names) {
     state['background-opacity'] = $('#background_opacity').val();
     state['max-font-size-label'] = $('#max_font_size_label').val();
     state['draw-guide-lines'] = $('#draw_guide_lines').val();
-    
+
     // sync views object and layers table
     syncViews();
 
@@ -1556,11 +1556,11 @@ function drawTree() {
     // clear existing diagram, if any
     document.getElementById('svg').innerHTML = "";
 
-    waitingDialog.show('Drawing ...', 
+    waitingDialog.show('Drawing ...',
         {
-            dialogSize: 'sm', 
+            dialogSize: 'sm',
             onHide: function() {
-                defer.resolve(); 
+                defer.resolve();
             },
             onShow: function() {
                 try {
@@ -1571,13 +1571,13 @@ function drawTree() {
                     let issue_title = encodeURIComponent("Interactive interface, " + error);
                     let issue_body = encodeURIComponent("Anvi'o version: `" + ANVIO_VERSION + "`\n```\n" + error.stack + "```");
 
-                    showDraggableDialog('An exception occured', 
+                    showDraggableDialog('An exception occured',
                         '<textarea style="width: 100%; height: 360px;">' + error.stack + '</textarea>\
                         <a target="_blank" href="https://github.com/merenlab/anvio/issues/new?title='+issue_title+'&body='+issue_body+'&labels=bug,interface">\
                             <button type="button" class="btn btn-success btn-sm">Report this on GitHub</button>\
                         </a> * Requires GitHub account.');
                 }
-                
+
                 // last_settings used in export svg for layer information,
                 // we didn't use "settings" sent to draw_tree because draw_tree updates layer's min&max
                 last_settings = serializeSettings();
@@ -1694,12 +1694,12 @@ function showCompleteness(bin_id, updateOnly) {
 
     var msg = '<table class="table table-striped sortable">' +
               '<thead><tr>' +
-                  '<th>&nbsp;</th>' + 
-                  '<th data-sortcolumn="1" data-sortkey="1-0">Domain</th>' + 
-                  '<th data-sortcolumn="2" data-sortkey="2-0">Domain Confidence</th>' + 
-                  '<th data-sortcolumn="3" data-sortkey="3-0">HMM Source</th>' + 
-                  '<th data-sortcolumn="4" data-sortkey="4-0">Completion</th>' + 
-                  '<th data-sortcolumn="5" data-sortkey="5-0">Redundancy</th>' + 
+                  '<th>&nbsp;</th>' +
+                  '<th data-sortcolumn="1" data-sortkey="1-0">Domain</th>' +
+                  '<th data-sortcolumn="2" data-sortkey="2-0">Domain Confidence</th>' +
+                  '<th data-sortcolumn="3" data-sortkey="3-0">HMM Source</th>' +
+                  '<th data-sortcolumn="4" data-sortkey="4-0">Completion</th>' +
+                  '<th data-sortcolumn="5" data-sortkey="5-0">Redundancy</th>' +
               '</tr></thead><tbody>';
 
     for (let source in stats){
@@ -1803,7 +1803,7 @@ function showRedundants(bin_id, updateOnly) {
 }
 
 function exportSvg(dontDownload) {
-    if (!drawer) 
+    if (!drawer)
         return;
 
     // draw bin and layer legend to output svg
@@ -1820,13 +1820,13 @@ function exportSvg(dontDownload) {
             };
 
             if (mode == 'pan') {
-                _bin_info['gene_clusters'] = $('#completeness_' + bin_id).val(); 
-                _bin_info['gene-calls'] = $('#redundancy_' + bin_id).val(); 
+                _bin_info['gene_clusters'] = $('#completeness_' + bin_id).val();
+                _bin_info['gene-calls'] = $('#redundancy_' + bin_id).val();
             } else {
                 _bin_info['contig-length'] = $('#contig_length_' + bin_id).html();
                 _bin_info['contig-count'] = $('#contig_count_' + bin_id).val();
             }
-            
+
             bins_to_draw.push(_bin_info);
         }
     );
@@ -1843,9 +1843,9 @@ function exportSvg(dontDownload) {
     // we used current settings because we want current bin information.
     // now we are going to use "last_settings" which updated by draw button.
     var settings = {};
-    settings = last_settings; 
+    settings = last_settings;
     drawLayerLegend(settings['layers'], settings['views'][current_view], settings['layer-order'], top, left);
-    
+
     var detached = $('#tree path.clone').detach();
     var detachedSamples = $('#samples_tree path.clone').detach();
     drawTitle(last_settings);
@@ -1878,8 +1878,8 @@ function storeRefinedBins() {
         type: 'POST',
         cache: false,
         url: '/data/store_refined_bins',
-        data: { 
-            data: JSON.stringify(collection_info['data'], null, 4), 
+        data: {
+            data: JSON.stringify(collection_info['data'], null, 4),
             colors: JSON.stringify(collection_info['colors'], null, 4)
         },
         success: function(data) {
@@ -1937,7 +1937,7 @@ function showSaveStateWindow()
                 var _select = "";
                 if (state_name == current_state_name)
                 {
-                    _select = ' selected="selected"'; 
+                    _select = ' selected="selected"';
                 }
                 $('#saveState_list').append('<option ' + _select + '>' + state_name + '</option>');
             }
@@ -2000,11 +2000,11 @@ function generatePhylogeneticTree() {
     var new_phylogeny_name = $('#phylogeny_name').val();
     var gene_cluster_list = [];
     var gene_clusters_id = $('#phylogeny_gene_cluster').val();
-    
+
     for (const node of bins.selections[gene_clusters_id].values()) {
         if (node.IsLeaf()) {
             gene_cluster_list.push(node.label);
-        } 
+        }
     }
 
     if (gene_cluster_list.length == 0) {
@@ -2047,7 +2047,7 @@ function generatePhylogeneticTree() {
     });
 }
 
-function saveState() 
+function saveState()
 {
     var name = $('#saveState_name').val();
 
@@ -2209,11 +2209,11 @@ function loadState()
     }
 
     var state_name = $('#loadState_list').val();
-    waitingDialog.show('Requesting state data from the server ...', 
+    waitingDialog.show('Requesting state data from the server ...',
         {
-            dialogSize: 'sm', 
+            dialogSize: 'sm',
             onHide: function() {
-                defer.resolve(); 
+                defer.resolve();
             },
             onShow: function() {
                 $.ajax({
@@ -2311,7 +2311,7 @@ function processState(state_name, state) {
         layers = {};
         for (let key in state['layers'])
         {
-            
+
             let layer_id = getLayerId(key);
             if (layer_id != -1)
             {
@@ -2433,14 +2433,14 @@ function processState(state_name, state) {
         for (let key in state['samples-categorical-colors']) {
             if (key in samples_categorical_colors) {
                 samples_categorical_colors[key] = state['samples-categorical-colors'][key];
-            } 
+            }
         }
     }
     if (state.hasOwnProperty('samples-stack-bar-colors')) {
         for (let key in state['samples-stack-bar-colors']) {
             if (key in samples_stack_bar_colors) {
                 samples_stack_bar_colors[key] = state['samples-stack-bar-colors'][key];
-            } 
+            }
         }
     }
 
@@ -2528,7 +2528,7 @@ function showTaxonomy()
         type: 'POST',
         url: '/data/get_taxonomy',
         data: {
-            'collection': JSON.stringify(collection_info['data'], null, 4), 
+            'collection': JSON.stringify(collection_info['data'], null, 4),
         },
         success: (response) => {
             if (response.hasOwnProperty('status') && response.status != 0) {
@@ -2629,7 +2629,7 @@ function showTaxonomy()
 
                 if(d['total_scgs'] == 0){
                     // If actually there are no SCGs for this bin that were useful to estimatet taxonomy,
-                    // don't add the `scg_table_content` to the actual content. 
+                    // don't add the `scg_table_content` to the actual content.
                     content += `<tr id="collapse-${ bin_name }" class="panel-collapse fade collapse" style="background: #acaf3330;"><td colspan="10">
                                     None of the contigs in this bin contained SCGs anvi'o could use to estimate taxonomy :/`;
                 } else {
@@ -2664,7 +2664,7 @@ function showGenePopup(element, gene_callers_id) {
 
     $('[data-toggle="popover"]').on('shown.bs.popover', function (e) {
       var popover = $(e.target).data("bs.popover").$tip;
-      
+
       if ($(popover).css('top').charAt(0) === '-') {
         $(popover).css('top', '0px');
       }
@@ -2704,11 +2704,11 @@ function toggleTaxonomyEstimation() {
     let is_checked = $('#estimate_taxonomy').is(':checked');
 
     if (is_checked) {
-        $('.taxonomy-name-label').each((index, elem) => { 
+        $('.taxonomy-name-label').each((index, elem) => {
             $(elem).closest('tr').show();
         });
     } else {
-        $('.taxonomy-name-label').each((index, elem) => { 
+        $('.taxonomy-name-label').each((index, elem) => {
             $(elem).closest('tr').hide();
         });
     }

--- a/anvio/data/interactive/js/utils.js
+++ b/anvio/data/interactive/js/utils.js
@@ -285,6 +285,45 @@ function showTaxonomyTableDialog(title, content)
     $.bootstrapSortable({ applyLast: true })
 }
 
+
+function showGeneClusterFunctionsSummaryTableDialog(title, content)
+{
+    var randomID = title.hashCode();
+
+    var template = `
+    <div class="modal fade taxonomyTableDialog" id="modal` + randomID + `" role="dialog" data-backdrop="false" style="pointer-events: none; width: 100%;">
+        <div class="modal-dialog" style="pointer-events: all; width: 1200px;">
+            <div class="modal-content">
+
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                     <h4 class="modal-title">` + title + `</h4>
+                </div>
+
+                <p style="margin: 20px; font-style: italic;">Please note that this is just a quick view of the functions associated with your gene clusters. A much more appropriate way to summarize this information and more is to use the program <a href="http://merenlab.org/software/anvio/help/programs/anvi-summarize/" target="_blank">anvi-summarize</a>, and inspect the resulting TAB-delimited output file</p>
+
+                <div class="modal-body">
+                    ` + content + `
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Fine</button>
+                </div>
+            </div>
+        </div>
+    </div>`;
+
+    $('body').append(template);
+    $('#modal' + randomID).modal({'show': true, 'backdrop': true, 'keyboard': false}).find('.modal-dialog').draggable({handle: '.modal-header'});
+    $('#modal' + randomID).on('hidden.bs.modal', function () {
+        $(this).remove();
+    });
+
+    // trigger bootstrap-sortable in case newly generated page content may have sortable tables.
+    $.bootstrapSortable({ applyLast: true })
+}
+
+
 function showDraggableDialog(title, content, updateOnly)
 {
     var randomID = title.hashCode();

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1534,6 +1534,40 @@ class PanSuperclass(object):
 
     def get_gene_clusters_functions_summary_dict(self, functional_annotation_source):
         """ A function to assign functions to gene clusters for an annotation_source
+    def get_gene_cluster_function_summary(self, gene_cluster_id, functional_annotation_source):
+        """Returns the most frequently occurring functional annotation across genes in a gene cluster
+        for a given functional annotation source.
+
+        A single function and accession number is determined purely based on frequencies of occurrence.
+        If multiple functions have the same number of votes then one will be chosen arbitrarily.
+
+        Parameters
+        ==========
+        gene_cluster_id : str
+            A gene cluster id that is defined in the `gene_clusters_functions_dict`
+
+        functional_annotation_source : str
+            A known functional annotation source
+
+        Returns
+        =======
+        (most_common_accession, most_common_function) : tuple
+            The representative function and its accession id for `gene_cluster_id` and `functional_annotation_source`
+        """
+
+        if not self.functions_initialized:
+            raise ConfigError("Although it is an expensive step, this function currently requires functions to be "
+                              "initialized first :/ If you are a programmer and need this functionality to be much "
+                              "more effective for ad hoc use, please let us know (the right solution in that case is "
+                              "to work directly with the genome storage database to recover functions for a single gene "
+                              "cluster).")
+
+        functions_counter = Counter({})
+        for genome_name in self.gene_clusters_functions_dict[gene_cluster_id]:
+            for gene_caller_id in self.gene_clusters_functions_dict[gene_cluster_id][genome_name]:
+                if functional_annotation_source in self.gene_clusters_functions_dict[gene_cluster_id][genome_name][gene_caller_id]:
+                    annotation_blob = self.gene_clusters_functions_dict[gene_cluster_id][genome_name][gene_caller_id][functional_annotation_source]
+                    functions_counter[annotation_blob] += 1
 
             use an annotation source and choose a function for the gene cluster
             using a voting approach, i.e. the most commonly annotated function

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1532,8 +1532,6 @@ class PanSuperclass(object):
         self.run.info('Output file for phylogenomics', output_file_path, mc='green')
 
 
-    def get_gene_clusters_functions_summary_dict(self, functional_annotation_source):
-        """ A function to assign functions to gene clusters for an annotation_source
     def get_gene_cluster_function_summary(self, gene_cluster_id, functional_annotation_source):
         """Returns the most frequently occurring functional annotation across genes in a gene cluster
         for a given functional annotation source.
@@ -1569,24 +1567,19 @@ class PanSuperclass(object):
                     annotation_blob = self.gene_clusters_functions_dict[gene_cluster_id][genome_name][gene_caller_id][functional_annotation_source]
                     functions_counter[annotation_blob] += 1
 
-            use an annotation source and choose a function for the gene cluster
-            using a voting approach, i.e. the most commonly annotated function
-            for the genes in the gene cluster will be chosen.
+        if not len(functions_counter):
+            return (None, None)
 
-            If multiple functinos have the same number of votes then one will
-            be chosen arbitrarily.
+        most_common_accession, most_common_function = functions_counter.most_common()[0][0].split('|||')
 
-            OUTPUT:
+        return (most_common_accession, most_common_function)
 
-            gene_clusters_functions_summary_dict
-                dictionary with gene_cluster ids as keys
-                the values are dictionaries, where:
-                gene_clusters_functions_summary_dict[gene_cluster_id]['gene_clusters_function'] - contains the chosen function
 
-                If you want to see all the functions and number of votes per function, simply do:
-                for f in gene_clusters_functions_summary_dict[gene_cluster_id]:
-                    print('For gene cluster %s: the number of votes for function %s is %s'\
-                            % (gene_cluster_id, f, gene_clusters_functions_summary_dict[gene_cluster_id][f])
+    def get_gene_clusters_functions_summary_dict(self, functional_annotation_source):
+        """Returns a dictionary where each gene cluster is associated with a single function.
+
+           See `get_gene_cluster_function_summary` for details since this function is merely
+           calling it for each gene cluster.
         """
 
         if functional_annotation_source not in self.gene_clusters_function_sources:

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1603,28 +1603,12 @@ class PanSuperclass(object):
 
         gene_clusters_functions_summary_dict = {}
 
-        self.progress.new('Summarizing functions for gene clusters')
+        self.progress.new(f'Summarizing "{functional_annotation_source}" for gene clusters')
         self.progress.update('Creating a dictionary')
         for gene_cluster in self.gene_clusters_functions_dict:
-            gene_clusters_functions_summary_dict[gene_cluster] = {}
-            gene_clusters_functions_summary_dict[gene_cluster]['gene_cluster_function'] = None
-            gene_clusters_functions_summary_dict[gene_cluster]['gene_cluster_function_accession'] = None
-            max_votes = 0
-            for genome in self.gene_clusters_functions_dict[gene_cluster]:
-                for gene_caller_id in self.gene_clusters_functions_dict[gene_cluster][genome]:
-                    if functional_annotation_source in self.gene_clusters_functions_dict[gene_cluster][genome][gene_caller_id]:
-                        annotation_blob = self.gene_clusters_functions_dict[gene_cluster][genome][gene_caller_id][functional_annotation_source]
-                        accessions, annotations = [l.split('!!!') for l in annotation_blob.split("|||")]
-                        for a, f in zip(accessions, annotations):
-                            if f not in gene_clusters_functions_summary_dict[gene_cluster]:
-                                gene_clusters_functions_summary_dict[gene_cluster][f] = 0
-
-                            gene_clusters_functions_summary_dict[gene_cluster][f] += 1
-                            if gene_clusters_functions_summary_dict[gene_cluster][f] > max_votes:
-                                # The function has the votes!
-                                max_votes = gene_clusters_functions_summary_dict[gene_cluster][f]
-                                gene_clusters_functions_summary_dict[gene_cluster]['gene_cluster_function'] = f
-                                gene_clusters_functions_summary_dict[gene_cluster]['gene_cluster_function_accession'] = a
+            accession, function = self.get_gene_cluster_function_summary(gene_cluster, functional_annotation_source)
+            gene_clusters_functions_summary_dict[gene_cluster]['gene_cluster_function'] = function
+            gene_clusters_functions_summary_dict[gene_cluster]['gene_cluster_function_accession'] = accession
 
         self.progress.end()
 

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -929,6 +929,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
         if not self.skip_init_functions:
             self.init_gene_clusters_functions()
+            self.init_gene_clusters_functions_summary_dict()
 
         PanSuperclass.init_items_additional_data(self)
 


### PR DESCRIPTION
This PR adds a long-missed function into the interactive interface in pan mode.

Now when the user clicks on the buttons in the 'Gene Clusters' column in the bins panel,

![image](https://user-images.githubusercontent.com/197307/95666583-b2b50980-0b20-11eb-8d34-e3e270232e1e.png)

Anvi'o will show them a dialogue window with a summary of all gene cluster functions:

![image](https://user-images.githubusercontent.com/197307/95666681-9b2a5080-0b21-11eb-9d2a-654a3ded114f.png)

This will enable a quick functional insights into interesting parts of pangenomes.