### PR TITLE
Read only DB

### DIFF
--- a/anvio/db.py
+++ b/anvio/db.py
@@ -43,7 +43,8 @@ def get_list_in_chunks(input_list, num_items_in_each_chunk=5000):
 
 
 class DB:
-    def __init__(self, db_path, client_version, new_database=False, ignore_version=False, skip_rowid_prepend=False, run=terminal.Run(), progress=terminal.Progress()):
+    def __init__(self, db_path, client_version, new_database=False, ignore_version=False, read_only=False, skip_rowid_prepend=False,
+                 run=terminal.Run(), progress=terminal.Progress()):
         self.db_path = db_path
         self.version = None
 
@@ -65,7 +66,11 @@ class DB:
         if new_database and os.path.exists(self.db_path):
             os.remove(self.db_path)
 
-        self.check_if_db_writable()
+        if read_only and new_database:
+            raise ConfigError("One cannot create a new database that is read-only.")
+
+        if not read_only:
+            self.check_if_db_writable()
 
         try:
             self.conn = sqlite3.connect(self.db_path)

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -1495,7 +1495,7 @@ class PDBDatabase(object):
 
 
     def load_db(self):
-        return db.DB(self.db_path, '0.1', new_database=False)
+        return db.DB(self.db_path, '0.1', new_database=False, read_only=True)
 
 
     def check_or_create_db(self):


### PR DESCRIPTION
Currently, all DB instances must pass a `check_if_db_is_writable` method, even if the database is used for read-only purposes. This PR addresses this by introducing a new parameter called `read_only`, conditionally running `check_if_db_is_writable` based on `read_only`'s value, and decorating all methods with write operations with a gatekeeper, that prevents the method being called if `read_only` is set to `True`. In other words, this PR represents a procrastination from paper writing.

@meren, @ivagljiva, @mschecht, @semiller10, tagging you all so you know about this new feature.