### PR TITLE
Structure interface

### DIFF
--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1550,7 +1550,10 @@ function gen_pymol_script() {
         group_object_list.push(group_object)
 
         // Initialize a selection with 0 atoms
-        s += `sele ${group_selection}, name CA and name CB\n`
+        s += `sele ${group_selection}, name CA and name CB\n`;
+
+        // Initialize a dictionary to hold each variant's attributes
+        s += `res_attrs = {}\n`;
 
         var counter = 1;
         component.reprList.slice(0).forEach((rep) => {
@@ -1563,14 +1566,17 @@ function gen_pymol_script() {
                 res_list.push(res.toString());
 
                 if (counter % 20 == 0) {
-                    s += `select ${group_selection}, ${group_selection} | (${main_object} and name CA and resi ${res_list.join('+')})\n`
+                    s += `select ${group_selection}, ${group_selection} | (${main_object} and name CA and resi ${res_list.join('+')})\n`;
+                    s += `res_attrs.update({${res_attrs}})\n`;
+
                     res_list = [];
+                    res_attrs = '';
                 }
                 counter += 1;
             }
         });
 
-        s += `res_attrs = {${res_attrs}}\n` +
+        s += `res_attrs.update({${res_attrs}})\n` +
              `select ${group_selection}, ${group_selection} | (${main_object} and name CA and resi ${res_list.join('+')})\n` +
              `create ${group_var_object}, ${group_selection}\n` +
              `for res in res_attrs: cmd.set_color('${group_var_object}' + str(res), res_attrs[res]['color'])\n` +

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1017,6 +1017,13 @@ function create_ui() {
                     $('#surface_color_variable').append(`<option value="${info_name}">${info_name}</item>`);
                 }
             }
+            column_info.forEach((item) => {
+                console.log(item)
+                if ((item['as_view'] | item['as_filter']) & item['data_type'] != 'text') {
+                    $('#backbone_color_variable').append(`<option value="${item['name']}">${item['title']}</item>`);
+                    $('#surface_color_variable').append(`<option value="${item['name']}">${item['title']}</item>`);
+                }
+            })
 
             column_info.forEach((item) => {
                 if (item['as_view']) {

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1555,6 +1555,7 @@ function gen_pymol_script() {
         var group_selection = `group_${group}_sele`
         group_object_list.push(group_object)
 
+        var counter = 0;
         component.reprList.slice(0).forEach((rep) => {
             if (rep.name == 'spacefill') {
                 var res = rep.variability.codon_number;
@@ -1562,7 +1563,14 @@ function gen_pymol_script() {
                 var scale = rep.repr.scale;
 
                 res_attrs += `${res}:{'color':[${color.r},${color.g},${color.b}],'scale':${scale}},`;
-                res_list.push(res);
+
+                if (counter % 20 == 0) {
+                    res_list.push(res.toString().concat("\\\n"));
+                } else {
+                    res_list.push(res);
+                }
+
+                counter += 1;
             }
         });
 

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -241,7 +241,7 @@ async function create_single_ngl_view(group, num_rows, num_columns) {
     });
 
     stage.loadFile(stringBlob, { ext: "pdb" }).then((component) => {
-        if( component.type !== "structure" ) return;
+        if ( component.type !== "structure" ) return;
 
         if ($('#show_surface').is(':checked')) {
             if ($('#surface_color_type').val() == 'Static') {
@@ -1579,17 +1579,21 @@ function gen_pymol_script() {
              `show spheres, ${group_var_object}\n` +
              `create ${group_object}, ${group_var_object} or ${main_object}\n`;
 
-        for (let residue in residue_info) {
-            if ($('#show_surface').is(':checked')) {
-                // FIXME assumes dynamic
-                var surface_color = hexToRgb("#".concat(calcSurfaceColor(residue, group).substring(2,8)));
-                s += `set_color ${group}_surf_${residue}, [${surface_color.r},${surface_color.g},${surface_color.b}]\n`;
-                s += `set surface_color, ${group}_surf_${residue}, ${group_object} and resi ${residue}\n`;
+        // group's surface
+        if ($('#show_surface').is(':checked')) {
+            if ($('#surface_color_type').val() == 'Dynamic') {
+                for (let residue in residue_info) {
+                    var surface_color = hexToRgb("#".concat(calcSurfaceColor(residue, group).substring(2,8)));
+                    s += `set_color ${group}_surf_${residue}, [${surface_color.r},${surface_color.g},${surface_color.b}]\n`;
+                    s += `set surface_color, ${group}_surf_${residue}, ${group_object} and resi ${residue}\n`;
+                }
+            } else {
+                var static_surface_color = hexToRgb($('#color_static_surface').attr('color'));
+                s += `set_color ${group}_surf_static, [${static_surface_color.r},${static_surface_color.g},${static_surface_color.b}]\n`;
+                s += `set surface_color, ${group}_surf_static, ${group_object}\n`;
             }
+            s += `show surface, ${group_object}\n`;
         }
-
-        s += `show surface, ${group_object}\n`;
-
     }
     s += `cmd.disable('all')\n` +
          `cmd.enable('${group_object_list[0]}')\n` +

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -530,43 +530,77 @@ async function create_single_ngl_view(group, num_rows, num_columns) {
     return defer.promise();
 }
 
+function calcBackboneColor(residue, group=null) {
+    let name = $('#backbone_color_variable').val();
+    let val;
+
+    if (residue_info[residue].hasOwnProperty(name)) {
+        // The selected dynamic variable is in residue_info
+        val = residue_info[residue][name];
+    } else if (variability[group].hasOwnProperty(residue)) {
+        // The selected dynamic variable is in the variability data
+        val = variability[group][residue][name];
+    } else {
+        // It's in neither. Not good
+        val = null;
+    }
+
+    if (val == null) {
+        // This can be true either because the value was absent, or the name requested was
+        // invalid. In this case we return the min value color
+        return '0x' + $('#backbone_color_start').attr('color').substring(1, 7).toUpperCase()
+    }
+
+    let min_value = parseFloat($('#backbone_color_min').val());
+    let max_value = parseFloat($('#backbone_color_max').val());
+    let val_normalized = (parseFloat(val) - min_value) / (max_value - min_value);
+    val_normalized = Math.max(0, Math.min(1, val_normalized));
+
+    var hex = getGradientColor($('#backbone_color_start').attr('color'), $('#backbone_color_end').attr('color'), val_normalized);
+    return '0x' + hex.substring(1, 7).toUpperCase()
+}
+
 function getBackboneColorScheme(group=null) {
     // group is only needed if the selected color variable has a group-specific value, i.e. entropy
     // is a group specific parameter but predicted ligand binding frequency is not
 
     var schemeId_backbone = NGL.ColormakerRegistry.addScheme(function (params) {
       this.atomColor = function (atom) {
-        let name = $('#backbone_color_variable').val();
-        let val;
-
-        if (residue_info[atom.resno].hasOwnProperty(name)) {
-            // The selected dynamic variable is in residue_info
-            val = residue_info[atom.resno][name];
-        } else if (variability[group].hasOwnProperty(atom.resno)) {
-            // The selected dynamic variable is in the variability data
-            val = variability[group][atom.resno][name];
-        } else {
-            // It's in neither. Not good
-            val = null;
-        }
-
-        if (val == null) {
-            // This can be true either because the value was absent, or the name requested was
-            // invalid. In this case we return the min value color
-            return '0x' + $('#backbone_color_start').attr('color').substring(1, 7).toUpperCase()
-        }
-
-        let min_value = parseFloat($('#backbone_color_min').val());
-        let max_value = parseFloat($('#backbone_color_max').val());
-        let val_normalized = (parseFloat(val) - min_value) / (max_value - min_value);
-        val_normalized = Math.max(0, Math.min(1, val_normalized));
-
-        var hex = getGradientColor($('#backbone_color_start').attr('color'), $('#backbone_color_end').attr('color'), val_normalized);
-        return '0x' + hex.substring(1, 7).toUpperCase()
+        return calcBackboneColor(atom.resno, group);
       }
     })
 
     return schemeId_backbone;
+}
+
+function calcSurfaceColor(residue, group=null) {
+    let name = $('#surface_color_variable').val();
+    let val;
+
+    if (residue_info[residue].hasOwnProperty(name)) {
+        // The selected dynamic variable is in residue_info
+        val = residue_info[residue][name];
+    } else if (variability[group].hasOwnProperty(residue)) {
+        // The selected dynamic variable is in the variability data
+        val = variability[group][residue][name];
+    } else {
+        // It's in neither. Not good
+        val = null;
+    }
+
+    if (val == null) {
+        // This can be true either because the value was absent, or the name requested was
+        // invalid. In this case we return the min value color
+        return '0x' + $('#surface_color_start').attr('color').substring(1, 7).toUpperCase()
+    }
+
+    let min_value = parseFloat($('#surface_color_min').val());
+    let max_value = parseFloat($('#surface_color_max').val());
+    let val_normalized = (parseFloat(val) - min_value) / (max_value - min_value);
+    val_normalized = Math.max(0, Math.min(1, val_normalized));
+
+    var hex = getGradientColor($('#surface_color_start').attr('color'), $('#surface_color_end').attr('color'), val_normalized);
+    return '0x' + hex.substring(1, 7).toUpperCase()
 }
 
 function getSurfaceColorScheme(group=null) {
@@ -575,33 +609,7 @@ function getSurfaceColorScheme(group=null) {
 
     var schemeId_surface = NGL.ColormakerRegistry.addScheme(function (params) {
       this.atomColor = function (atom) {
-        let name = $('#surface_color_variable').val();
-        let val;
-
-        if (residue_info[atom.resno].hasOwnProperty(name)) {
-            // The selected dynamic variable is in residue_info
-            val = residue_info[atom.resno][name];
-        } else if (variability[group].hasOwnProperty(atom.resno)) {
-            // The selected dynamic variable is in the variability data
-            val = variability[group][atom.resno][name];
-        } else {
-            // It's in neither. Not good
-            val = null;
-        }
-
-        if (val == null) {
-            // This can be true either because the value was absent, or the name requested was
-            // invalid. In this case we return the min value color
-            return '0x' + $('#surface_color_start').attr('color').substring(1, 7).toUpperCase()
-        }
-
-        let min_value = parseFloat($('#surface_color_min').val());
-        let max_value = parseFloat($('#surface_color_max').val());
-        let val_normalized = (parseFloat(val) - min_value) / (max_value - min_value);
-        val_normalized = Math.max(0, Math.min(1, val_normalized));
-
-        var hex = getGradientColor($('#surface_color_start').attr('color'), $('#surface_color_end').attr('color'), val_normalized);
-        return '0x' + hex.substring(1, 7).toUpperCase()
+        return calcSurfaceColor(atom.resno, group);
       }
     })
 

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1592,6 +1592,8 @@ function gen_pymol_script() {
                 s += `set_color ${group}_backbone_static, [${static_backbone_color.r},${static_backbone_color.g},${static_backbone_color.b}]\n`;
                 s += `set cartoon_color, ${group}_backbone_static, ${group_object}\n`;
             }
+        } else {
+            s += `hide cartoon, ${group_object}\n`
         }
 
         // group's surface

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1570,11 +1570,6 @@ function gen_pymol_script() {
             }
         });
 
-        // If res_list happens to be divisible by 20, it will end in \\n. This undoes that
-        if (res_list[res_list.length-1].endsWith('\\\n') & res_list.length > 0) {
-            res_list[res_list.length-1] = res_list[res_list.length-1].substring(0, res_list[res_list.length-1].length-2)
-        }
-
         s += `res_attrs = {${res_attrs}}\n` +
              `select ${group_selection}, ${group_selection} | (${main_object} and name CA and resi ${res_list.join('+')})\n` +
              `create ${group_var_object}, ${group_selection}\n` +

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1568,6 +1568,11 @@ function gen_pymol_script() {
             }
         });
 
+        // If res_list happens to be divisible by 20, it will end in \\n. This undoes that
+        if (res_list[res_list.length-1].endsWith('\\\n') & res_list.length > 0) {
+            res_list[res_list.length-1] = res_list[res_list.length-1].substring(0, res_list[res_list.length-1].length-2)
+        }
+
         var res_sele = res_list.join('+');
         s += `res_attrs = {${res_attrs}}\n` +
              `select ${group_selection}, ${main_object} and name CA and resi ${res_sele}\n` +

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1584,13 +1584,13 @@ function gen_pymol_script() {
             if ($('#backbone_color_type').val() == 'Dynamic') {
                 for (let residue in residue_info) {
                     var backbone_color = hexToRgb("#".concat(calcBackboneColor(residue, group).substring(2,8)));
-                    s += `set_color ${group}_backbone_${residue}, [${backbone_color.r},${backbone_color.g},${backbone_color.b}]\n`;
-                    s += `set cartoon_color, ${group}_backbone_${residue}, ${group_object} and resi ${residue}\n`;
+                    s += `set_color ${prefix}_${group}_backbone_${residue}, [${backbone_color.r},${backbone_color.g},${backbone_color.b}]\n`;
+                    s += `set cartoon_color, ${prefix}_${group}_backbone_${residue}, ${group_object} and resi ${residue}\n`;
                 }
             } else {
                 var static_backbone_color = hexToRgb($('#color_static_backbone').attr('color'));
-                s += `set_color ${group}_backbone_static, [${static_backbone_color.r},${static_backbone_color.g},${static_backbone_color.b}]\n`;
-                s += `set cartoon_color, ${group}_backbone_static, ${group_object}\n`;
+                s += `set_color ${prefix}_${group}_backbone_static, [${static_backbone_color.r},${static_backbone_color.g},${static_backbone_color.b}]\n`;
+                s += `set cartoon_color, ${prefix}_${group}_backbone_static, ${group_object}\n`;
             }
         } else {
             s += `hide cartoon, ${group_object}\n`
@@ -1601,13 +1601,13 @@ function gen_pymol_script() {
             if ($('#surface_color_type').val() == 'Dynamic') {
                 for (let residue in residue_info) {
                     var surface_color = hexToRgb("#".concat(calcSurfaceColor(residue, group).substring(2,8)));
-                    s += `set_color ${group}_surf_${residue}, [${surface_color.r},${surface_color.g},${surface_color.b}]\n`;
-                    s += `set surface_color, ${group}_surf_${residue}, ${group_object} and resi ${residue}\n`;
+                    s += `set_color ${prefix}_${group}_surf_${residue}, [${surface_color.r},${surface_color.g},${surface_color.b}]\n`;
+                    s += `set surface_color, ${prefix}_${group}_surf_${residue}, ${group_object} and resi ${residue}\n`;
                 }
             } else {
                 var static_surface_color = hexToRgb($('#color_static_surface').attr('color'));
-                s += `set_color ${group}_surf_static, [${static_surface_color.r},${static_surface_color.g},${static_surface_color.b}]\n`;
-                s += `set surface_color, ${group}_surf_static, ${group_object}\n`;
+                s += `set_color ${prefix}_${group}_surf_static, [${static_surface_color.r},${static_surface_color.g},${static_surface_color.b}]\n`;
+                s += `set surface_color, ${prefix}_${group}_surf_static, ${group_object}\n`;
             }
             s += `show surface, ${group_object}\n`;
         }

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -401,13 +401,35 @@ async function create_single_ngl_view(group, num_rows, num_columns) {
                 if ($('#backbone_color_type').val() == 'Dynamic') {
                     let name = $('#backbone_color_variable').val();
                     if (!tooltip_HTML_body.includes(name)) {
-                        tooltip_HTML_body += `<tr><td>${name}</td><td>${residue_info[residue][name]}</td></tr>`
+                        let backbone_val;
+                        if (residue_info[residue].hasOwnProperty(name)) {
+                            // The selected dynamic variable is in residue_info
+                            backbone_val = residue_info[residue][name];
+                        } else if (variability[group].hasOwnProperty(residue)) {
+                            // The selected dynamic variable is in the variability data
+                            backbone_val = variability[group][residue][name];
+                        } else {
+                            // It's in neither. Not good
+                            backbone_val = null;
+                        }
+                        tooltip_HTML_body += `<tr><td>${name}</td><td>${backbone_val}</td></tr>`
                     }
                 }
                 if ($('#surface_color_type').val() == 'Dynamic') {
                     let name = $('#surface_color_variable').val();
                     if (!tooltip_HTML_body.includes(name)) {
-                        tooltip_HTML_body += `<tr><td>${name}</td><td>${residue_info[residue][name]}</td></tr>`
+                        let surface_val;
+                        if (residue_info[residue].hasOwnProperty(name)) {
+                            // The selected dynamic variable is in residue_info
+                            surface_val = residue_info[residue][name];
+                        } else if (variability[group].hasOwnProperty(residue)) {
+                            // The selected dynamic variable is in the variability data
+                            surface_val = variability[group][residue][name];
+                        } else {
+                            // It's in neither. Not good
+                            surface_val = null;
+                        }
+                        tooltip_HTML_body += `<tr><td>${name}</td><td>${surface_val}</td></tr>`
                     }
                 }
 

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1171,7 +1171,6 @@ function onTargetResidueInfoChange(element) {
     } else {
       for (i in column_info) {
         let item = column_info[i];
-        console.log(item)
         if (item['name'] == name) {
           $(`#backbone_color_min`).val(item['min']);
           $(`#backbone_color_max`).val(item['max']);

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1579,6 +1579,21 @@ function gen_pymol_script() {
              `show spheres, ${group_var_object}\n` +
              `create ${group_object}, ${group_var_object} or ${main_object}\n`;
 
+        // group's backbone
+        if ($('#show_backbone').is(':checked')) {
+            if ($('#backbone_color_type').val() == 'Dynamic') {
+                for (let residue in residue_info) {
+                    var backbone_color = hexToRgb("#".concat(calcBackboneColor(residue, group).substring(2,8)));
+                    s += `set_color ${group}_backbone_${residue}, [${backbone_color.r},${backbone_color.g},${backbone_color.b}]\n`;
+                    s += `set cartoon_color, ${group}_backbone_${residue}, ${group_object} and resi ${residue}\n`;
+                }
+            } else {
+                var static_backbone_color = hexToRgb($('#color_static_backbone').attr('color'));
+                s += `set_color ${group}_backbone_static, [${static_backbone_color.r},${static_backbone_color.g},${static_backbone_color.b}]\n`;
+                s += `set cartoon_color, ${group}_backbone_static, ${group_object}\n`;
+            }
+        }
+
         // group's surface
         if ($('#show_surface').is(':checked')) {
             if ($('#surface_color_type').val() == 'Dynamic') {

--- a/sandbox/anvi-script-calculate-pn-ps-ratio
+++ b/sandbox/anvi-script-calculate-pn-ps-ratio
@@ -98,10 +98,12 @@ def load_contigs_db(args):
 
 
 def report(args, pNpS, SAAV, sSCV):
+    index_label = "sample_id" if args.no_gene else "gene_callers_id"
+
     # write it to folder
-    pNpS.to_csv(os.path.join(args.output_dir, "pN_pS_ratio.txt"), sep="\t", index = True, index_label = "gene_callers_id")
-    sSCV.to_csv(os.path.join(args.output_dir, "sSCV_counts.txt"), sep="\t", index = True, index_label = "gene_callers_id")
-    SAAV.to_csv(os.path.join(args.output_dir, "SAAV_counts.txt"), sep="\t", index = True, index_label = "gene_callers_id")
+    pNpS.to_csv(os.path.join(args.output_dir, "pN_pS_ratio.txt"), sep="\t", index = True, index_label = index_label)
+    sSCV.to_csv(os.path.join(args.output_dir, "sSCV_counts.txt"), sep="\t", index = True, index_label = index_label)
+    SAAV.to_csv(os.path.join(args.output_dir, "SAAV_counts.txt"), sep="\t", index = True, index_label = index_label)
 
     run.info_single("Done! Contents have been output to the directory '{}'.".format(args.output_dir),
                     nl_before=1,
@@ -121,11 +123,10 @@ def calculate_pN_pS_ratio(args):
     gene_caller_ids = var_dataframe['corresponding_gene_call'].unique()
     samples = var_dataframe['sample_id'].unique()
 
-    # creation of SAAV count table, sSCV count table, and SAAV_to_sSCV ratio table
+    # creation of SAAV count table and sSCV count table
     i = 0
     SAAV = {sample: [] for sample in samples}
     sSCV = {sample: [] for sample in samples}
-    SAAV_to_sSCV = {sample: [] for sample in samples}
     progress.new("Calculating SAAV and sSCV counts")
     for gene_callers_id in gene_caller_ids:
         temp = var_dataframe[var_dataframe['corresponding_gene_call'] == gene_callers_id]
@@ -134,11 +135,6 @@ def calculate_pN_pS_ratio(args):
 
             SAAV[sample].append(counts.get('AA', 0))
             sSCV[sample].append(counts.get('CDN', 0) - counts.get('AA', 0)) # fully synonymous only
-            if counts.get('CDN', 0) < args.minimum_num_variants:
-                SAAV_to_sSCV[sample].append(np.nan)
-            else:
-                with np.errstate(divide='ignore'):
-                    SAAV_to_sSCV[sample].append(counts.get('AA', 0) / (counts['CDN'] - counts.get('AA', 0)))
 
         if i % 100 == 0:
             progress.update('Processed {} of {} genes.'.format(i, len(gene_caller_ids)))
@@ -148,27 +144,43 @@ def calculate_pN_pS_ratio(args):
     # make tables dataframes
     sSCV = pd.DataFrame(sSCV); sSCV.index = gene_caller_ids
     SAAV = pd.DataFrame(SAAV); SAAV.index = gene_caller_ids
-    SAAV_to_sSCV = pd.DataFrame(SAAV_to_sSCV); SAAV_to_sSCV.index = gene_caller_ids
 
-    # calc potential synonymity for each gene
-    potential_synonymity_ratio = np.zeros(len(gene_caller_ids))
-    total_ambiguous_codons = 0
-    for i, gene_callers_id in enumerate(gene_caller_ids):
-        gene_call = contigs_db.genes_in_contigs_dict[gene_callers_id]
+    if args.no_gene:
+        # We are going to aggregate all the per-gene results
+        codon_list = []
+        for i, gene_callers_id in enumerate(gene_caller_ids):
+            gene_call = contigs_db.genes_in_contigs_dict[gene_callers_id]
+            codon_list.extend(utils.get_list_of_codons_for_gene_call(gene_call, contigs_db.contig_sequences))
 
-        codon_list_for_gene = utils.get_list_of_codons_for_gene_call(gene_call, contigs_db.contig_sequences)
-        syn_potential, non_syn_potential, num_ambiguous_codons = utils.get_synonymous_and_non_synonymous_potential(codon_list_for_gene)
+        syn_potential, non_syn_potential, total_ambiguous_codons = utils.get_synonymous_and_non_synonymous_potential(codon_list, just_do_it=True)
+        potential_synonymity_ratio = syn_potential / non_syn_potential
 
-        # we are adding the number of codons in this gene that were not included
-        # in the calculations above as they included ambiguous nucleotides
-        total_ambiguous_codons += num_ambiguous_codons
+        SAAV = SAAV.sum(axis=0)
+        sSCV = sSCV.sum(axis=0)
 
-        potential_synonymity_ratio[i] = syn_potential / non_syn_potential
+    else:
+        # calc potential synonymity for each gene
+        potential_synonymity_ratio = np.zeros(len(gene_caller_ids))
+        total_ambiguous_codons = 0
+        for i, gene_callers_id in enumerate(gene_caller_ids):
+            gene_call = contigs_db.genes_in_contigs_dict[gene_callers_id]
+
+            codon_list_for_gene = utils.get_list_of_codons_for_gene_call(gene_call, contigs_db.contig_sequences)
+            syn_potential, non_syn_potential, num_ambiguous_codons = utils.get_synonymous_and_non_synonymous_potential(codon_list_for_gene)
+
+            # we are adding the number of codons in this gene that were not included
+            # in the calculations above as they included ambiguous nucleotides
+            total_ambiguous_codons += num_ambiguous_codons
+
+            potential_synonymity_ratio[i] = syn_potential / non_syn_potential
 
     if total_ambiguous_codons:
         run.warning("Please note that %d codons among your %d genes included nucleotides "
                     "that were not unambiguous (i.e., 'N's or any other bases than A, T, "
                     "C, or G) and were excluded from synonymity calculations." % (total_ambiguous_codons, len(gene_caller_ids)))
+
+    SAAV_to_sSCV = SAAV / sSCV
+    SAAV_to_sSCV[sSCV < args.minimum_num_variants] = np.nan
 
     # normalize the SAAV_to_sSCV ratio by the potential synonymity ratio to make pN/pS
     pNpS = SAAV_to_sSCV.multiply(potential_synonymity_ratio, axis=0)
@@ -203,6 +215,9 @@ if __name__ == '__main__':
 
     groupO = parser.add_argument_group('OUTPUT', 'The output of this program is a folder directory with several tables.')
     groupO.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir', {'required':True}))
+    groupO.add_argument('--no-gene', action='store_true', help='Normally, a value is provided for each sample-gene combination. '
+                        'So if you have 10 genes and 100 samples, you would get 10*100=1000 separate values. If this flag is provided, '
+                        'the output is not subdivided on a per-gene basis, and instead you will get 1 aggregated value for each sample.')
 
     args = anvio.get_args(parser)
 


### PR DESCRIPTION
Ability to add variability-specific info for dynamic coloring of surfaces and backbones. Before, only residue-specific info like relative solvent accessibility could be used.

A very, very, very comprehensive conversion to pymol.

`anvi-script-calculate-pn-ps-ratio` can be calculated for arbitrary variability tables without splitting gene-by-gene.