### PR TITLE
added --seq-type parameter for fastas with non-standard characters

### DIFF
--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -119,10 +119,12 @@ rule anvi_script_reformat_fasta:
     params:
         prefix = "{group}",
         min_len = M.get_rule_param("anvi_script_reformat_fasta", "--min-len"),
+        seq_type = M.get_rule_param("anvi_script_reformat_fasta", "--seq-type"),
     threads: M.T('anvi_script_reformat_fasta')
     resources: nodes = M.T('anvi_script_reformat_fasta'),
     shell: w.r("""anvi-script-reformat-fasta {input} \
                                              -o {output.contigs} \
+                                             {params.seq_type} \
                                              {params.min_len} >> {log} 2>&1""")
 
 

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -84,7 +84,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                          '--use-version']
 
         self.rule_acceptable_params_dict['anvi_script_reformat_fasta'] = \
-                    ['run', '--keep-ids', '--exclude-ids', '--min-len', "--prefix", "--simplify-names"]
+                    ['run', '--keep-ids', '--exclude-ids', '--min-len', "--prefix", "--simplify-names", "--seq-type"]
 
 
         gen_contigs_params = ['--description', '--skip-gene-calling', '--external-gene-calls',\


### PR DESCRIPTION
Maybe the smallest PR in anvi'o history! I added the `--seq-type` parameter to the rule `anvi_script_reformat_fasta` so that the contig workflow can handle fastas with non-standard characters. I ran this test below to confirm it's functionality:

```
# download the data pack
wget http://merenlab.org/files/WORKFLOW_TUTORIAL_DATA.tar.gz

# unpack it
tar -xvzf WORKFLOW_TUTORIAL_DATA.tar.gz

# go into the directory
cd WORKFLOW_TUTORIAL_DATA

# uncompress the mock contigs FASTA files
gzip -d three_samples_example/*contigs*.gz

# get default config
anvi-run-workflow -w contigs --get-default-config contigs.json

# run default (if you dont have anvi-run-kegg-kofams set up locally it will fail there)
anvi-run-workflow -w contigs -c contigs.json

# rm workflow output
rm -rf 0*

# Edit one of the fastas with non-standard characters
sed -i.bak 's|AGAC|asdf|g' three_samples_example/G01-contigs.fa

# Run workflow again and it should fail because of "asdf" strings 
# (should fail at anvi_gen_contigs_database rule)
anvi-run-workflow -w contigs -c contigs.json

# Clear workflow output
rm -rf 0*

# Now edit config file to add `--seq-type NT` to anvi-script-reformat-fasta
 sed -i.bak -e 's|--seq-type": "|--seq-type": "NT|' contigs.json

# Run workflow again and it should be able to hangle the non-standard characters
# in the input fasta files
anvi-run-workflow -w contigs -c contigs.json
```

Additionally, I ran the `run_contigs_workflow_tests.sh` and everything ran.

