### PR TITLE
anvi-display-contigs-stats update

### DIFF
--- a/anvio/data/interactive/contigs.html
+++ b/anvio/data/interactive/contigs.html
@@ -74,32 +74,34 @@
             var max_hmm_hits = 0;
             var active_index = 0;
             Object.keys(stats.gene_hit_counts_per_hmm_source).forEach(function(source, gene_chart_index) {
-                var plot_container_id = 'gene_chart_' + prefix + '_' + gene_chart_index;
+                if (stats.hmm_sources_for_SCGs.includes(source)){
+                    var plot_container_id = 'gene_chart_' + prefix + '_' + gene_chart_index;
 
-                var hits_sum = 0;
+                    var hits_sum = 0;
 
-                Object.keys(stats.gene_hit_counts_per_hmm_source[source]).forEach(function (gene) {
-                    hits_sum += stats.gene_hit_counts_per_hmm_source[source][gene];
-                });
+                    Object.keys(stats.gene_hit_counts_per_hmm_source[source]).forEach(function (gene) {
+                        hits_sum += stats.gene_hit_counts_per_hmm_source[source][gene];
+                    });
 
-                if (hits_sum > max_hmm_hits) {
-                    max_hmm_hits = hits_sum;
-                    active_index = gene_chart_index;
+                    if (hits_sum > max_hmm_hits) {
+                        max_hmm_hits = hits_sum;
+                        active_index = gene_chart_index;
+                    }
+
+                    tabs.append('li')
+                            .append('a')
+                                .attr('href', '#' + plot_container_id)
+                                .attr('data-toggle', 'tab')
+                                .text(source.replace(/_/g, ' '));
+
+
+                    var plot_container = tab_content.append('div')
+                                            .attr('class', 'tab-pane')
+                                            .attr('role', 'tabpanel')
+                                            .attr('id', plot_container_id);
+
+                    draw_gene_counts_chart('#' + plot_container_id, stats.gene_hit_counts_per_hmm_source[source]);
                 }
-
-                tabs.append('li')
-                        .append('a')
-                            .attr('href', '#' + plot_container_id)
-                            .attr('data-toggle', 'tab')
-                            .text(source.replace(/_/g, ' '));
-
-
-                var plot_container = tab_content.append('div')
-                                        .attr('class', 'tab-pane')
-                                        .attr('role', 'tabpanel')
-                                        .attr('id', plot_container_id);
-
-                draw_gene_counts_chart('#' + plot_container_id, stats.gene_hit_counts_per_hmm_source[source]);
             });
 
             $('a[href="#gene_chart_' + prefix + '_' + active_index + '"').tab('show');

--- a/anvio/data/interactive/contigs.html
+++ b/anvio/data/interactive/contigs.html
@@ -179,13 +179,13 @@
                 var layer_extent = d3.extent(table_line.slice(1, table_line.length).map(Number));
                 var layer_range = layer_extent[1] - layer_extent[0];
 
-                table_line.forEach(function(table_item, i) { 
+                table_line.forEach(function(table_item, i) {
                     var td_class = (i > 0) ? 'text-center' : '';
                     var td_color =  '#333';
-                    
+
                     if (color_numbers && i > 0 && layer_range > 0) {
                         td_color = getGradientColor('#B3DDCC', '#101648', (table_item - layer_extent[0]) / layer_range );
-                    } 
+                    }
 
                     if (human_readable && i > 0) {
                         table_str += '<td class="' + td_class + '" style="color: ' + td_color +'">' + getReadableSeqSizeString(parseInt(table_item)) + '</td>';
@@ -218,7 +218,7 @@
         $('#select-left,#select-right').change(function() {
             $('.parent-container>.row-plots').empty();
             create_plots(parseInt($('#select-left').val()), 'left');
-            create_plots(parseInt($('#select-right').val()), 'right'); 
+            create_plots(parseInt($('#select-right').val()), 'right');
         });
 
         d3.json("/data/get_contigs_stats", function(error, response) {

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -2484,12 +2484,12 @@ class ContigsInteractive():
         self.progress.update('Number of contigs ...')
         contig_lengths_for_all = [c['contig_lengths'] for c in self.contigs_stats.values()]
         X = lambda n: [len([count for count in contig_lengths_for_one if count >= n]) for contig_lengths_for_one in contig_lengths_for_all]
-        basic_stats.append(['Num Contigs > 2.5 kb'] + X(2500))
-        basic_stats.append(['Num Contigs > 5 kb'] + X(5000))
-        basic_stats.append(['Num Contigs > 10 kb'] + X(10000))
-        basic_stats.append(['Num Contigs > 20 kb'] + X(20000))
-        basic_stats.append(['Num Contigs > 50 kb'] + X(50000))
         basic_stats.append(['Num Contigs > 100 kb'] + X(100000))
+        basic_stats.append(['Num Contigs > 50 kb'] + X(50000))
+        basic_stats.append(['Num Contigs > 20 kb'] + X(20000))
+        basic_stats.append(['Num Contigs > 10 kb'] + X(10000))
+        basic_stats.append(['Num Contigs > 5 kb'] + X(5000))
+        basic_stats.append(['Num Contigs > 2.5 kb'] + X(2500))
 
         self.progress.update('Contig lengths ...')
         contig_lengths_for_all = [c['contig_lengths'] for c in self.contigs_stats.values()]

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -1159,6 +1159,7 @@ class ContigSummarizer(SummarizerSuperClass):
         summary['n_values'] = self.calculate_N_values(contig_lengths, total_length, N=100)
         summary['contig_lengths'] = contig_lengths
         summary['gene_hit_counts_per_hmm_source'] = hmm.get_gene_hit_counts_per_hmm_source()
+        summary['hmm_sources_for_SCGs'] = sorted([s for s in hmm.hmm_hits_info if hmm.hmm_hits_info[s]['search_type'] == 'singlecopy'])
         summary['num_genomes_per_SCG_source_dict'] = hmm.get_num_genomes_from_SCG_sources_dict()
 
         self.progress.end()


### PR DESCRIPTION
This PR is primarily to change this section of the output interface,

![image](https://user-images.githubusercontent.com/197307/98385298-6f14c900-2014-11eb-8834-b755f2cd92db.png)

to show only the distribution of SCGs within a metagenome like this:

![image](https://user-images.githubusercontent.com/197307/98385224-5c9a8f80-2014-11eb-8479-9d331ba6a429.png)

Because only the distribution of hits for HMMs of `singlecopy` type are really relevant for this section.