### PR TITLE
Ability to define output directory paths for test runs

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2789,26 +2789,11 @@ D = {
              'help': "Prints a nicely formatted table of the default tRNA feature parameterizations "
                      "that are written to a tab-delimited .ini file by the option, `--default-feature-param-file`."}
                 ),
-    'include-metadata': (
-            ['--include-metadata'],
-            {'default': False,
-            'action': 'store_true',
-            'help': "When asking for --matrix-format, you can use this flag to make sure the output matrix files include "
-                    "columns with metadata for each KEGG Module or KO (like the module name and category for example) before "
-                    "the sample columns."}
-                ),
     'include-zeros': (
             ['--include-zeros'],
             {'default': False,
             'action': 'store_true',
             'help': "If you use this flag, long-format output files will include modules with 0 percent completeness score."}
-                ),
-    'only-complete': (
-            ['--only-complete'],
-            {'default': False,
-            'action': 'store_true',
-            'help': "Choose this flag if you want only modules over the module completeness threshold to be included "
-                    "in any output files."}
                 ),
 }
 

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1777,6 +1777,13 @@ D = {
              'help': "Don't do a dry run. Just start the workflow! Useful when your job is so big it takes "
                      "hours to do a dry run."}
                 ),
+    'no-interactive': (
+            ['--no-interactive'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Don't show anything interactive (if possible)."}
+                ),
+
     'verbose': (
             ['--verbose'],
             {'default': False,

--- a/anvio/filesnpaths.py
+++ b/anvio/filesnpaths.py
@@ -148,14 +148,15 @@ def is_output_file_writable(file_path, ok_if_exists=True):
     if not file_path:
         raise FilesNPathsError("No output file is declared...")
     if os.path.isdir(file_path):
-        raise FilesNPathsError("The path you have provided for your output file ('%s') already is used .. by "
-                               "a directory :/" % (os.path.abspath(file_path)))
+        raise FilesNPathsError(f"The path you have provided for your output file ('{os.path.abspath(file_path)}') "
+                               f"already is used by a directory :/")
     if not os.access(os.path.dirname(os.path.abspath(file_path)), os.W_OK):
-        raise FilesNPathsError("You do not have permission to generate the output file '%s'" % file_path)
+        raise FilesNPathsError(f"You do not have permission to generate the output file '{file_path}'")
     if os.path.exists(file_path) and not os.access(file_path, os.W_OK):
-        raise FilesNPathsError("You do not have permission to update the contents of the file '%s' :/" % file_path)
+        raise FilesNPathsError(f"You do not have permission to update the contents of the file '{file_path}' :/")
     if os.path.exists(file_path) and not ok_if_exists:
-        raise FilesNPathsError("The file, '%s', already exists. anvio does not like overwriting stuff." % file_path)
+        raise FilesNPathsError(f"The output file '{file_path}' already exists. Generally speaking anvi'o tries to "
+                               f"avoid overwriting stuff.")
     return True
 
 
@@ -326,7 +327,8 @@ def check_output_directory(output_directory, ok_if_exists=False):
     output_directory = os.path.abspath(output_directory)
 
     if os.path.exists(output_directory) and not ok_if_exists:
-        raise FilesNPathsError("The output directory '%s' already exists. anvio does not like overwriting stuff." % output_directory)
+        raise FilesNPathsError(f"The output directory '{output_directory}' already exists (and anvi'o does not like "
+                               f"overwriting stuff (except when it does (typical anvi'o))).")
 
     return output_directory
 

--- a/anvio/tests/00.sh
+++ b/anvio/tests/00.sh
@@ -22,6 +22,13 @@ SETUP_WITH_OUTPUT_DIR() {
         output_dir="$1"
     fi
 
+    if [ -z "$2"  ]
+    then
+        dry_run_controller=""
+    else
+        dry_run_controller="--dry-run"
+    fi
+
     mkdir -p $output_dir
 
     files="sandbox"
@@ -29,6 +36,17 @@ SETUP_WITH_OUTPUT_DIR() {
     INFO "Output directory"
     echo "$output_dir"
     echo
+
+    INFO "Can has interactive displays?"
+    if [ -z "$2"  ]
+    then
+        echo "Yes, anvi'o will try to show you interactive displays that will require you to come back to the terminal and press CTRL+C to continue"
+        echo
+    else
+        echo "No interactive displays"
+        echo
+    fi
+
 
     INFO "Anvo'o version"
     anvi-profile --version

--- a/anvio/tests/00.sh
+++ b/anvio/tests/00.sh
@@ -19,7 +19,7 @@ SETUP_WITH_OUTPUT_DIR() {
         output_dir="`pwd`/sandbox/test-output"
         rm -rf $output_dir
     else
-        output_dir="$1/test-output"
+        output_dir="$1"
     fi
 
     mkdir -p $output_dir

--- a/anvio/tests/run_all_tests.sh
+++ b/anvio/tests/run_all_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Initializing raw BAM files"

--- a/anvio/tests/run_all_tests.sh
+++ b/anvio/tests/run_all_tests.sh
@@ -709,7 +709,8 @@ anvi-interactive -p $output_dir/SAMPLES-MERGED/PROFILE.db \
                  --dry-run
 
 INFO "Firing up the interactive interface to display the contigs db stats"
-anvi-display-contigs-stats $output_dir/CONTIGS.db
+anvi-display-contigs-stats $output_dir/CONTIGS.db \
+                           $dry_run_controller
 
 INFO "Firing up the interactive interface for merged samples"
 anvi-interactive -p $output_dir/SAMPLES-MERGED/PROFILE.db \
@@ -717,27 +718,36 @@ anvi-interactive -p $output_dir/SAMPLES-MERGED/PROFILE.db \
                  -A $files/additional_view_data.txt \
                  -t $output_dir/SAMPLES-MERGED/EXP-ORG-FILE.txt \
                  -V $files/additional_view.txt \
-                 --split-hmm-layers
+                 --split-hmm-layers \
+                 $dry_run_controller
+
 
 INFO "Firing up the interface to display the split bin, Bin_1"
 anvi-interactive -c $output_dir/CONCOCT_BINS_SPLIT/Bin_1/CONTIGS.db \
                  -p $output_dir/CONCOCT_BINS_SPLIT/Bin_1/PROFILE.db \
-                 --title "Split bin, Bin_1"
+                 --title "Split bin, Bin_1" \
+                 $dry_run_controller
+
 
 INFO "Firing up the interactive interface with the blank profile"
 anvi-interactive -c $output_dir/CONTIGS.db \
-                 -p $output_dir/BLANK-PROFILE/PROFILE.db
+                 -p $output_dir/BLANK-PROFILE/PROFILE.db \
+                 $dry_run_controller
+
 
 INFO "Firing up the interactive interface in 'COLLECTION' mode"
 anvi-interactive -p $output_dir/SAMPLES-MERGED/PROFILE.db \
                  -c $output_dir/CONTIGS.db \
-                 -C CONCOCT
+                 -C CONCOCT \
+                 $dry_run_controller
 
 INFO "Firing up the interactive interface to refine a bin"
 anvi-refine -p $output_dir/SAMPLES-MERGED/PROFILE.db \
             -c $output_dir/CONTIGS.db \
             -C CONCOCT \
-            -b Bin_1
+            -b Bin_1 \
+            $dry_run_controller
+
 
 INFO "Importing items and layers additional data into the genes database for CONCOCT::Bin_1"
 anvi-import-misc-data -p $output_dir/SAMPLES-MERGED/GENES/CONCOCT-Bin_1.db \
@@ -752,4 +762,5 @@ anvi-interactive -p $output_dir/SAMPLES-MERGED/PROFILE.db \
                  -c $output_dir/CONTIGS.db \
                  -C CONCOCT \
                  -b Bin_1 \
-                 --gene-mode
+                 --gene-mode \
+                 $dry_run_controller

--- a/anvio/tests/run_alons_classifier_tests.sh
+++ b/anvio/tests/run_alons_classifier_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 # Setting the folder where the files are

--- a/anvio/tests/run_contigs_workflow_tests.sh
+++ b/anvio/tests/run_contigs_workflow_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Setting up the pan analysis directory"

--- a/anvio/tests/run_gen_gene_level_stats_tests.sh
+++ b/anvio/tests/run_gen_gene_level_stats_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 # Set INSEQ files path

--- a/anvio/tests/run_metabolism_tests.sh
+++ b/anvio/tests/run_metabolism_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Migrating test databases (just in case they aren't up to date)"

--- a/anvio/tests/run_metagenomics_workflow_tests.sh
+++ b/anvio/tests/run_metagenomics_workflow_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Setting up the metagenomics analysis directory"

--- a/anvio/tests/run_metapangenomics_workflow_tests.sh
+++ b/anvio/tests/run_metapangenomics_workflow_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Setting up the pan analysis directory"

--- a/anvio/tests/run_mini_test.sh
+++ b/anvio/tests/run_mini_test.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Initializing raw BAM files"

--- a/anvio/tests/run_mini_test.sh
+++ b/anvio/tests/run_mini_test.sh
@@ -76,7 +76,8 @@ anvi-show-collections-and-bins -p $output_dir/SAMPLES-MERGED/PROFILE.db
 INFO "Firing up the interactive interface"
 # fire up the browser to show how does the merged samples look like.
 anvi-interactive -p $output_dir/SAMPLES-MERGED/PROFILE.db \
-                 -c $output_dir/CONTIGS.db
+                 -c $output_dir/CONTIGS.db \
+                 $dry_run_controller
 
 INFO "Summarizing CONCOCT results"
 anvi-summarize -p $output_dir/SAMPLES-MERGED/PROFILE.db -c $output_dir/CONTIGS.db -o $output_dir/SAMPLES-MERGED-SUMMARY -C 'CONCOCT' --init-gene-coverages

--- a/anvio/tests/run_pangenome_tests.sh
+++ b/anvio/tests/run_pangenome_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Setting up the pan analysis directory"

--- a/anvio/tests/run_pangenome_tests.sh
+++ b/anvio/tests/run_pangenome_tests.sh
@@ -122,7 +122,13 @@ anvi-import-state -p TEST/TEST-PAN.db -s default-state.json -n default
 anvi-import-state -p TEST/ANOTHER_TEST-PAN.db -s default-state.json -n default
 
 INFO "Displaying the initial pangenome analysis results"
-anvi-display-pan -p TEST/TEST-PAN.db -g TEST-GENOMES.db --title "A mock pangenome analysis"
+anvi-display-pan -p TEST/TEST-PAN.db \
+                 -g TEST-GENOMES.db \
+                 --title "A mock pangenome analysis" \
+                 $dry_run_controller
 
 INFO "Displaying the second pangenome analysis results"
-anvi-display-pan -p TEST/ANOTHER_TEST-PAN.db -g TEST-GENOMES.db --title "A mock pangenome analysis (with --min-occurrence 2)"
+anvi-display-pan -p TEST/ANOTHER_TEST-PAN.db \
+                 -g TEST-GENOMES.db \
+                 --title "A mock pangenome analysis (with --min-occurrence 2)" \
+                 $dry_run_controller

--- a/anvio/tests/run_pangenomics_workflow_tests.sh
+++ b/anvio/tests/run_pangenomics_workflow_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Setting up the pan analysis directory"

--- a/anvio/tests/run_phylogenomics_workflow_tests.sh
+++ b/anvio/tests/run_phylogenomics_workflow_tests.sh
@@ -2,7 +2,7 @@
 source 00.sh
 
 # Setup #############################
-SETUP_WITH_OUTPUT_DIR $1
+SETUP_WITH_OUTPUT_DIR $1 $2
 #####################################
 
 INFO "Setting up the pan analysis directory"

--- a/bin/anvi-display-contigs-stats
+++ b/bin/anvi-display-contigs-stats
@@ -57,6 +57,7 @@ if __name__ == '__main__':
     groupA.add_argument(*anvio.A('report-as-text'), **anvio.K('report-as-text'))
     groupA.add_argument(*anvio.A('output-file'), **anvio.K('output-file'))
     groupB = parser.add_argument_group('SERVER CONFIGURATION', "For power users.")
+    groupB.add_argument(*anvio.A('dry-run'), **anvio.K('dry-run'))
     groupB.add_argument(*anvio.A('ip-address'), **anvio.K('ip-address'))
     groupB.add_argument(*anvio.A('port-number'), **anvio.K('port-number'))
     groupB.add_argument(*anvio.A('browser-path'), **anvio.K('browser-path'))
@@ -71,16 +72,20 @@ if __name__ == '__main__':
             if not A('output_file'):
                 raise ConfigError("You set the --report-as-text flag but didn't give any --output-file. ")
 
-        args.mode = 'contigs'
-        d = interactive.ContigsInteractive(args)
-        args.port_number = utils.get_port_num(args.port_number, args.ip_address, run=run)
-
         if A('output_file'):
             write_stats_to_file(d.tables, A('output_file'))
 
         if not A('report_as_text'):
+            if args.dry_run:
+                run.info_single('Dry run, eh? Fine. Bai!', nl_after=1)
+                sys.exit()
+
+            args.mode = 'contigs'
+            d = interactive.ContigsInteractive(args)
+            port_number = utils.get_port_num(args.port_number, args.ip_address, run=run)
+
             app = BottleApplication(d)
-            app.run_application(args.ip_address, args.port_number)
+            app.run_application(args.ip_address, port_number)
     except ConfigError as e:
         print(e)
         sys.exit(-1)

--- a/bin/anvi-self-test
+++ b/bin/anvi-self-test
@@ -69,7 +69,8 @@ def main(args):
 
     try:
         for test in tests[args.suite]:
-            exitcode = subprocess.call('./%s %s' % (test, output_dir), shell=True)
+            command = f'./{test} {output_dir} {"no_interactive" if args.no_interactive else ""}'
+            exitcode = subprocess.call(command, shell=True)
             if exitcode != 0:
                 raise ConfigError("According to the exit code ('%s'), anvi'o suspects that something may have gone wrong while "
                                   "running your tests :/ We hope that the reason is clear to you from the lines above. But if you "
@@ -98,6 +99,7 @@ if __name__ == '__main__':
     parser.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir', {"help": "If you declare an outuput dir, all your data will be "
                               "stored in there, instead of being stored in a temporary directroy to be deleted once the tests are done. "
                               "This is particularly useful if you wish to play with general anvi'o output files."}))
+    parser.add_argument(*anvio.A('no-interactive'), **anvio.K('no-interactive'))
 
     args = anvio.get_args(parser)
 

--- a/bin/anvi-self-test
+++ b/bin/anvi-self-test
@@ -11,6 +11,7 @@ import subprocess
 
 import anvio
 import anvio.tests
+import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import FilesNPathsError, ConfigError
@@ -33,6 +34,7 @@ tests = {'mini': ['run_mini_test.sh'],
          'manual-interface': ['run_manual_interactive.sh'],
          'metabolism': ['run_metabolism_tests.sh']}
 
+run = terminal.Run()
 
 def __catch_sig(signum, frame):
     """We need to press CTRL+C to kill the server that is run by this script in a\
@@ -56,13 +58,18 @@ def main(args):
                                     "terrible start :( (it was looking for it under '%s')." \
                                                 % (test, tests[test], tests_dir_path))
 
-    temporary_output_dir = filesnpaths.get_temp_directory_path()
+    if args.output_dir:
+        output_dir = os.path.abspath(args.output_dir)
+        filesnpaths.check_output_directory(output_dir)
+        filesnpaths.gen_output_directory(output_dir)
+    else:
+        output_dir = filesnpaths.get_temp_directory_path()
 
     os.chdir(tests_dir_path)
 
     try:
         for test in tests[args.suite]:
-            exitcode = subprocess.call('./%s %s' % (test, temporary_output_dir), shell=True)
+            exitcode = subprocess.call('./%s %s' % (test, output_dir), shell=True)
             if exitcode != 0:
                 raise ConfigError("According to the exit code ('%s'), anvi'o suspects that something may have gone wrong while "
                                   "running your tests :/ We hope that the reason is clear to you from the lines above. But if you "
@@ -72,12 +79,11 @@ def main(args):
     except KeyboardInterrupt:
         pass
 
-    print()
-    if anvio.DEBUG:
-        print("Anvi'o's self-test is done, and the temporary output files are still here: %s\n" % temporary_output_dir)
+    if args.output_dir:
+        run.info_single(f"The self-test is done, and all the files anvi'o generated are stored in {args.output_dir}", nl_after=1)
     else:
-        shutil.rmtree(temporary_output_dir)
-        print("Anvi'o's self-test is done, and the temporary output files are cleaned.\n")
+        shutil.rmtree(output_dir)
+        run.info_single(f"Anvi'o's self-test is done, and the temporary files are all gone.", nl_after=1)
 
 
 if __name__ == '__main__':
@@ -89,6 +95,9 @@ if __name__ == '__main__':
                               commands to ensure your installation is ready to run all scenarios anvi'o developers could\
                               think of. Alternatively you can choose a specific test to run. Here is a full list of available\
                               options: %s." % ', '.join(list(tests.keys())))
+    parser.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir', {"help": "If you declare an outuput dir, all your data will be "
+                              "stored in there, instead of being stored in a temporary directroy to be deleted once the tests are done. "
+                              "This is particularly useful if you wish to play with general anvi'o output files."}))
 
     args = anvio.get_args(parser)
 


### PR DESCRIPTION
Currently `anvi-self-test` puts all of its output into a temporary directory with a cryptic name. It is in general OK since that directory is cleaned up automatically once the tests are over.

But if we want to use the files that comes out through the standard tests to demonstrate something in a reproducible fashion, this becomes a problem.

This PR introduces an `--output-dir` args, when given, `anvi-self-test` output goes into that directory. So someone can say something like this, and it would work:

> Run `anvi-self-test --suite mini -o my_test`, and then type `anvi-db-info my_test/CONTIGS.db`.

This PR also solves the issue of having to close interactive interfaces. Now it is also possible to run `anvi-self-test` with a `--no-interactive` flag. For instance, this will generate some cute output files in your output directory without invoking the interactive interface for real:

```
anvi-self-test --suite mini --no-interactive -o test-output
```