### PR TITLE
Exclude --external-gene-calls as a config.json tunable

### DIFF
--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -87,7 +87,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                     ['run', '--keep-ids', '--exclude-ids', '--min-len', "--prefix", "--simplify-names", "--seq-type"]
 
 
-        gen_contigs_params = ['--description', '--skip-gene-calling', '--external-gene-calls',\
+        gen_contigs_params = ['--description', '--skip-gene-calling',\
                               '--ignore-internal-stop-codons', '--skip-mindful-splitting',\
                               '--contigs-fasta', '--project-name',\
                               '--description', '--split-length', '--kmer-size',\


### PR DESCRIPTION
Here's a pull request to address issue https://github.com/merenlab/anvio/issues/1323. Basically, I am just removing `--external-gene-calls` as an allowable parameter, since it is controlled via a column in the `fasta.txt`. This will reduce confusion for `anvi-run-workflow` users. For example, @SchmidAbby and I have both independently ran into the problem of thinking `--external-gene-calls` in `config.json` would do something.

I tested this on the infant gut data set in the following way:

```
anvi-export-gene-calls --gene-caller prodigal -o external1.txt -c CONTIGS.db
anvi-export-gene-calls --gene-caller prodigal -o external2.txt -c CONTIGS.db

anvi-export-contigs -c CONTIGS.db -o fasta1.fa
anvi-export-contigs -c CONTIGS.db -o fasta2.fa

echo -e "name\tpath\texternal_gene_calls" > fasta.txt
echo -e "fasta1\tfasta1.fa\texternal1.txt" >> fasta.txt
echo -e "fasta2\tfasta2.fa\texternal2.txt" >> fasta.txt

echo '{
    "fasta_txt": "fasta.txt",
    "anvi_gen_contigs_database": {
        "--project-name": "{group}",
        "--description": "",
        "--skip-gene-calling": "",
        "--ignore-internal-stop-codons": "",
        "--skip-mindful-splitting": "",
        "--contigs-fasta": "",
        "--split-length": "",
        "--kmer-size": "",
        "--skip-predict-frame": "",
        "--prodigal-translation-table": "",
        "threads": ""
    },
    "anvi_run_hmms": {
        "run": true,
        "threads": 3,
        "--installed-hmm-profile": "",
        "--hmm-profile-dir": "",
        "--also-scan-trnas": ""
    },
    "anvi_run_scg_taxonomy": {
        "run": true,
        "threads": 4,
        "--scgs-taxonomy-data-dir": ""
    },
    "output_dirs": {
        "FASTA_DIR": "01_FASTA",
        "CONTIGS_DIR": "02_CONTIGS",
        "LOGS_DIR": "00_LOGS"
    },
    "max_threads": "",
    "config_version": "1",
    "workflow_name": "contigs"
}' > config.json

anvi-run-workflow -w contigs -c config.json
```

`--get-default-config` now excludes `--external-gene-calls`.

**NOTE** @mschecht, @ivagljiva (and anyone else actively doing `anvi-run-workflow` stuff): Any default `contigs.json` files created before this PR will cause the following error when running `anvi-run-workflow`:

```
Config Error: some of the parameters in your config file for rule anvi_gen_contigs_database
              are not familiar to us. Here is a list of the wrong parameters: ['--external-
              gene-calls']. The only acceptable parameters for this rule are ['--description',
              '--skip-gene-calling', '--ignore-internal-stop-codons', '--skip-mindful-
              splitting', '--contigs-fasta', '--project-name', '--description', '--split-
              length', '--kmer-size', '--skip-mindful-splitting', '--skip-gene-calling', '--
              ignore-internal-stop-codons', '--skip-predict-frame', '--prodigal-translation-
              table', 'threads'].
```


