### PR TITLE
anvi-run-workflow --get-default-config error

### DIFF
--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -76,12 +76,9 @@ class WorkflowSuperClass:
             filesnpaths.is_file_json_formatted(self.config_file)
             self.config = json.load(open(self.config_file))
 
-        # Check if config version is current unless getting default
-        # config which should already be the current version
-        if self.default_config_output_path:
-           pass
-        else:
-            if not self.skip_version_check and self.config['config_version'] != workflow_config_version:
+        # If a config exists, check that its current
+        if self.config and not self.skip_version_check:
+            if self.config['config_version'] != workflow_config_version:
                 raise ConfigError(f"Anvi'o couldn't get things moving because the version of your config file is out "
                                   f"of date (your version: {self.config['config_version']}; up-to-date version: "
                                   f"{workflow_config_version}). Not a problem though, simply run `anvi-migrate {self.config_file} "

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -76,13 +76,17 @@ class WorkflowSuperClass:
             filesnpaths.is_file_json_formatted(self.config_file)
             self.config = json.load(open(self.config_file))
 
-        # Check if config version is current
-        if not self.skip_version_check and self.config['config_version'] != workflow_config_version:
-            raise ConfigError(f"Anvi'o couldn't get things moving because the version of your config file is out "
-                              f"of date (your version: {self.config['config_version']}; up-to-date version: "
-                              f"{workflow_config_version}). Not a problem though, simply run `anvi-migrate {self.config_file} "
-                              f"--migrate-dbs-safely` and it will be updated. Then re-run the command producing "
-                              f"this error message.")
+        # Check if config version is current unless getting default
+        # config which should already be the current version
+        if self.default_config_output_path:
+           pass
+        else:
+            if not self.skip_version_check and self.config['config_version'] != workflow_config_version:
+                raise ConfigError(f"Anvi'o couldn't get things moving because the version of your config file is out "
+                                  f"of date (your version: {self.config['config_version']}; up-to-date version: "
+                                  f"{workflow_config_version}). Not a problem though, simply run `anvi-migrate {self.config_file} "
+                                  f"--migrate-dbs-safely` and it will be updated. Then re-run the command producing "
+                                  f"this error message.")
 
         self.rules = []
         self.rule_acceptable_params_dict = {}


### PR DESCRIPTION
Hey @ekiefl I was getting an error making a default config on main. You can reproduce it on the main branch as follows:

```
anvi-run-workflow -w contigs --get-default-config config.json
```
![Screen Shot 2020-12-08 at 11 14 21 AM](https://user-images.githubusercontent.com/8404575/101517587-87933e80-3946-11eb-92ff-6b33dfde709e.png)

I added a conditional in this commit to skip checking the version of the config if the user is requesting the default version of a workflow config with `anvi-run-workflow --get-default-config error`.