### PR TITLE
High GC leads to low quality ORF prediction: research

### DIFF
--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -322,7 +322,6 @@ class TablesForGeneCalls(Table):
 
         from collections import Counter
         frame_count = Counter()
-        correct = []
         quality = []
 
         # the main loop to go through all the gene calls.
@@ -363,10 +362,9 @@ class TablesForGeneCalls(Table):
             elif predict_frame:
                 # no amino acid sequence is provided, BUT USER WANTS FRAME TO BE PREDICTED
                 # we may be good, if we can try to predict one for it.
-                frame, amino_acid_sequence, qual = utils.get_most_likely_translation_frame(sequence, model=model)
+                frame, amino_acid_sequence, d = utils.get_most_likely_translation_frame(sequence, model=model)
                 frame_count[frame] += 1
-                correct.append('correct' if frame == 0 else 'incorrect')
-                quality.append(qual)
+                quality.append(d)
 
                 if frame is None:
                     # we not good because we couldn't find a frame for it. because this gene call has no predicted frame,
@@ -431,9 +429,11 @@ class TablesForGeneCalls(Table):
 
             amino_acid_sequences[gene_callers_id] = amino_acid_sequence
 
-        print(frame_count)
         import pandas as pd
-        pd.DataFrame({'outcome': correct, 'quality': quality}).to_csv('results.txt', sep='\t', index=False)
+        df = pd.concat(quality)
+        print(df.outcome_stop.value_counts())
+        print(df.outcome_prob.value_counts())
+        df.to_csv('results.txt', sep='\t', index=False)
 
         # reporting time
         self.run.warning(None, header="EXTERNAL GENE CALLS PARSER REPORT", lc="cyan")

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -447,6 +447,9 @@ class TablesForGeneCalls(Table):
             gc = 0
         total = correct + incorrect
 
+        output = pd.concat(quality)
+        output.to_csv("results.txt", sep='\t', index=False)
+
         print(correct)
         print(incorrect)
         print(gc)

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -261,10 +261,7 @@ class TablesForGeneCalls(Table):
                 raise ConfigError("The task at hand calls for the use of the anvi'o Markov model to predict proper open reading "
                                   "frames for external gene calls when necessary, but the model does not seem to be in the right "
                                   "place in the anvi'o codebase. FAILING BIG HERE.")
-
             model = numpy.load(model_path)
-            null_prob = numpy.median(model)
-            stop_prob = model.min()/1e6
 
         gene_caller_ids_with_user_provided_amino_acid_sequences = set([])
 
@@ -361,7 +358,7 @@ class TablesForGeneCalls(Table):
             elif predict_frame:
                 # no amino acid sequence is provided, BUT USER WANTS FRAME TO BE PREDICTED
                 # we may be good, if we can try to predict one for it.
-                frame, amino_acid_sequence = utils.get_most_likely_translation_frame(sequence, model=model, stop_prob=stop_prob, null_prob=null_prob)
+                frame, amino_acid_sequence = utils.get_most_likely_translation_frame(sequence, model=model)
 
                 if frame is None:
                     # we not good because we couldn't find a frame for it. because this gene call has no predicted frame,

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -369,7 +369,7 @@ class TablesForGeneCalls(Table):
                     correct += 1
                 else:
                     incorrect += 1
-                frame_count['correct' if frame == 0 else 'incorrect'] += 1
+                frame_count[frame] += 1
                 quality.append(d)
 
                 if frame is None:
@@ -439,19 +439,22 @@ class TablesForGeneCalls(Table):
         df = pd.concat(quality)
         from pathlib import Path
 
-        name = anvio.dbops.ContigsDatabase(self.db_path).get_meta_value('project_name')
-        gc = sum(utils.get_GC_content_for_FASTA_entries().values())/len(utils.get_GC_content_for_FASTA_entries(name + '.fa'))
+        name = db.DB(self.db_path, anvio.__contigs__version__).get_meta_value('project_name')
+        try:
+            gc_dict = utils.get_GC_content_for_FASTA_entries('contigs.fa').values()
+            gc = sum(list(gc_dict))/len(gc_dict)
+        except:
+            gc = 0
+        total = correct + incorrect
 
         print(correct)
         print(incorrect)
         print(gc)
         print(name)
         with open('many_genomes.txt', 'a') as f:
-            f.write(f"{name}\t{total}\t{correct}\t{incorrect}\t{GC}")
-        #print(frame_count)
-        print(df.outcome_stop.value_counts())
-        print(df.outcome_prob.value_counts())
-        df.to_csv('results.txt', sep='\t', index=False)
+            f.write(f"{name}\t{total}\t{correct}\t{incorrect}\t{correct/total}\t{gc}\n")
+
+        import sys; sys.exit()
 
         # reporting time
         self.run.warning(None, header="EXTERNAL GENE CALLS PARSER REPORT", lc="cyan")

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -2154,7 +2154,7 @@ def get_most_likely_translation_frame(sequence, model=None, null_prob=None, stop
     amino_acid_sequence = candidates[frame_best]['sequence']
 
     # if the best amino acid sequence ends with a stop codon, remove it.
-    amino_acid_sequence = amino_acid_sequence[:-1] if amino_acid_sequence.endswith('*') else amino_acid_sequence
+    #amino_acid_sequence = amino_acid_sequence[:-1] if amino_acid_sequence.endswith('*') else amino_acid_sequence
 
     d = {
         'frame_best_prob': frame_best,
@@ -2164,10 +2164,21 @@ def get_most_likely_translation_frame(sequence, model=None, null_prob=None, stop
 
         'log_prob_0': candidates[0]['log_prob'],
         'stop_count_0': candidates[0]['sequence'].count('*'),
+        'sequence_0': candidates[0]['sequence'],
+        'ends_stop_0': True if candidates[0]['sequence'].endswith('*') else False,
+        'starts_m_0': True if candidates[0]['sequence'].startswith('M') else False,
+
         'log_prob_1': candidates[1]['log_prob'],
         'stop_count_1': candidates[1]['sequence'].count('*'),
+        'sequence_1': candidates[1]['sequence'],
+        'ends_stop_1': True if candidates[1]['sequence'].endswith('*') else False,
+        'starts_m_1': True if candidates[1]['sequence'].startswith('M') else False,
+
         'log_prob_2': candidates[2]['log_prob'],
         'stop_count_2': candidates[2]['sequence'].count('*'),
+        'sequence_2': candidates[2]['sequence'],
+        'ends_stop_2': True if candidates[2]['sequence'].endswith('*') else False,
+        'starts_m_2': True if candidates[2]['sequence'].startswith('M') else False,
 
         'prob_quality': 1 - (log_prob_second - log_prob_worst)/(log_prob_best - log_prob_worst),
         'stop_quality': min([candidates[0]['sequence'].count('*'), candidates[1]['sequence'].count('*'), candidates[2]['sequence'].count('*')])

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -2090,7 +2090,7 @@ def get_most_likely_translation_frame(sequence, model=None, null_prob=None, stop
 
     order = len(model.shape)
     null_prob = stop_prob if stop_prob is not None else np.median(model)
-    stop_prob = stop_prob if stop_prob is not None else model.min()/1e6
+    stop_prob = stop_prob if stop_prob is not None else np.median(model)
 
     aas = [constants.AA_to_single_letter_code[aa] for aa in constants.amino_acids if aa != 'STP']
     aa_to_array_index = {aa: i for i, aa in enumerate(aas)}
@@ -2186,6 +2186,7 @@ def get_most_likely_translation_frame(sequence, model=None, null_prob=None, stop
         'starts_m_2': True if candidates[2]['sequence'].startswith('M') else False,
 
         'prob_quality': 1 - (log_prob_second - log_prob_worst)/(log_prob_best - log_prob_worst),
+        'prob_diff': log_prob_best - log_prob_second,
         'stop_qual': stop_qual,
     }
 

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -2137,21 +2137,24 @@ def get_most_likely_translation_frame(sequence, model=None, null_prob=None, stop
 
         candidates[frame]['log_prob'] = np.sum(np.log10(trans_probs))
 
-    frame_second, frame_best = sorted(candidates, key=lambda frame: candidates[frame]['log_prob'])[-2:]
+    frame_worst, frame_second, frame_best = sorted(candidates, key=lambda frame: candidates[frame]['log_prob'])[-3:]
     log_prob_best = candidates[frame_best]['log_prob']
     log_prob_second = candidates[frame_second]['log_prob']
+    log_prob_worst = candidates[frame_worst]['log_prob']
 
-    if (log_prob_best - log_prob_second) < log_likelihood_cutoff:
-        # Frame is not league's better than the competing frame, which it should be if we are to
-        # have any confidence in it. The sequence is returned
-        return None, candidates[frame_best]['sequence']
+    quality = 1 - (log_prob_second - log_prob_worst)/(log_prob_best - log_prob_worst)
+
+    #if (log_prob_best - log_prob_second) < log_likelihood_cutoff:
+    #    # Frame is not league's better than the competing frame, which it should be if we are to
+    #    # have any confidence in it. The sequence is returned
+    #    return None, candidates[frame_best]['sequence'], quality
 
     amino_acid_sequence = candidates[frame_best]['sequence']
 
     # if the best amino acid sequence ends with a stop codon, remove it.
     amino_acid_sequence = amino_acid_sequence[:-1] if amino_acid_sequence.endswith('*') else amino_acid_sequence
 
-    return frame_best, amino_acid_sequence
+    return frame_best, amino_acid_sequence, quality
 
 
 def get_codon_order_to_nt_positions_dict(gene_call, subtract_by=0):


### PR DESCRIPTION
This is a new way of doing things for me, and I wonder if it will work out. Basically, this pull request will never be merged into master. In fact, right after the is posted, I will close it. But ideally, this will serve as a comprehensive resource for what I did and why I did it, so that when I submit my branch that _will_ end up being merged, all of the design decisions can be learned from this janky version of anvi'o that I unforgivably hack.

# The problem

In this PR https://github.com/merenlab/anvio/pull/1428 I added a frame prediction so that if people use external genomes without a `aa_sequence` column, we try and predict the best frame for each gene and forgive the user for internal stop codons and non-divisible by 3 errors.

But in this issue https://github.com/merenlab/lab-fiesta/issues/1144 I determined that frame prediction is very inaccurate for genomes with GC content > 50%. This is because the Markov model I used is based on the uniref50 database, which presumably is full of human, yeast, and ecoli, all of which have GC content < 50%.

Here I try and find a solution to the high GC orf prediction problem.