### PR TITLE
Issue 1588: fix --cluster-contigs param in snakemake

### DIFF
--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -783,7 +783,7 @@ if sample_name != M.default_config['anvi_profile']['--sample-name'] and sample_n
 
 def get_cluster_contigs_param(wildcards):
     """ helper function to sort out whether to cluster contigs for a single profile database"""
-    if M.get_param_value_from_config(['anvi_profile', '--cluster-contigs']):
+    if M.get_param_value_from_config(['anvi_profile', '--cluster-contigs'] is not None):
         run.warning('You chose to set the value for --cluster-contigs as %s. You can do that if you '
                     'choose to, but just so you know, if you don\'t provide a value then '
                     'the workflow would automatically cluster contigs for profile databases '

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -783,7 +783,7 @@ if sample_name != M.default_config['anvi_profile']['--sample-name'] and sample_n
 
 def get_cluster_contigs_param(wildcards):
     """ helper function to sort out whether to cluster contigs for a single profile database"""
-    if M.get_param_value_from_config(['anvi_profile', '--cluster-contigs'] is not None):
+    if M.get_param_value_from_config(['anvi_profile', '--cluster-contigs']) is not None:
         run.warning('You chose to set the value for --cluster-contigs as %s. You can do that if you '
                     'choose to, but just so you know, if you don\'t provide a value then '
                     'the workflow would automatically cluster contigs for profile databases '

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -793,7 +793,7 @@ def get_cluster_contigs_param(wildcards):
     else:
         # if profiling to individual assembly then clustering contigs
         # see --cluster-contigs in the help manu of anvi-profile
-        cluster_contigs = '--cluster-contigs' if M.group_sizes[wildcards.group] == 1 else ''
+        cluster_contigs = '--cluster-contigs' if M.group_sizes[wildcards.group] > 1 else ''
     return cluster_contigs
 
 

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -787,7 +787,7 @@ def get_cluster_contigs_param(wildcards):
         run.warning('You chose to set the value for --cluster-contigs as %s. You can do that if you '
                     'choose to, but just so you know, if you don\'t provide a value then '
                     'the workflow would automatically cluster contigs for profile databases '
-                    'that are not merged (i.e. profiles that belong to groups of size 1).' \
+                    'that will be merged (i.e. profiles that belong to groups of size greater than 1).' \
                     % M.get_param_value_from_config(['anvi_profile', '--cluster-contigs']))
         cluster_contigs = M.get_rule_param('anvi_profile', '--cluster-contigs')
     else:


### PR DESCRIPTION
This PR resolves #1588, in which 1) we could not set a value of `false` for the `--cluster-contigs` param in `anvi-profile`, and 2) the default behavior was opposite that of the recommendation (ie, clustering was run for single profiles by default, but not for profiles that would need to be merged, which is not what `anvi-profile -h` recommends as @ekiefl pointed out).

The solution to 1) was to accept parameters that are not `None`, and the solution to 2) was to flip the logic so that by default clustering is not run for single profiles, but it was run for samples in groups with more than 1 member. The warning message that prints when you explicitly set `--cluster-contigs` to something has been updated to reflect the new defaults.

**How did I test this?**
The datapack from the [snakemake workflows tutorial](https://merenlab.org/2018/07/09/anvio-snakemake-workflows/#fastatxt) was perfect for this, as it had a simple `fasta.txt` with two references, one of which has two samples mapping to it and one of which has just one sample mapping to it. So right there we have a test case for both merged and single profiles.

I downloaded the datapack, set it up, got a default config file, and did a dry run to see the command lines for `anvi-profile`:
```
anvi-run-workflow -w metagenomics -c config.json -A -n
```
Which, as expected, yielded the correct defaults of `--cluster-contigs` for profiles that would be merged (G02 group) and no clustering for the single profile (G01 group):
![image](https://user-images.githubusercontent.com/10360586/103295003-aff7e100-49b8-11eb-87e2-6bfba480dad1.png)

I then made another config in which I explicitly set the value of `--cluster-contigs` to `false` (this was not working for me before), and this time in the dry run all `anvi-profile` jobs skipped the clustering:
```
anvi-run-workflow -w metagenomics -c config_set_cluster_contigs.json -A -n
```

![image](https://user-images.githubusercontent.com/10360586/103295145-f8170380-49b8-11eb-828a-35f9839ee5dd.png)
(I am only showing the first two samples in this screenshot)

Setting the parameter value to `true` provides the opposite behavior, as expected.