### PR TITLE
Blank interactive layers refactor

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -552,6 +552,14 @@ D = {
                      "searches that were performed against non-singlecopy gene HMM profiles into "
                      "their own layer. Please see the documentation for details."}
                 ),
+    'show-all-layers': (
+            ['--show-all-layers'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "When declared, this flag tells the interface to show every additional layer even if "
+                     "there are no hits. By default, anvi'o doesn't show layers if there are no hits for "
+                     "any of your items."}
+                ),
     'taxonomic-level': (
             ['--taxonomic-level'],
             {'default': 't_genus',

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2628,7 +2628,7 @@ class ProfileSuperclass(object):
             raise ConfigError("ProfileSuper is initialized with args that contain both `split_names_of_interest`,\
                                and `collection_name`. You can initialize the ProfileSuper with either of those. As\
                                a programmer if you have no control over incoming `args` and just passing things\
-                               aroung, you might need to implement a workaround to set either of those params to None\
+                               around, you might need to implement a workaround to set either of those params to None\
                                and then reset them back to their original in `args` once you are done with\
                                ProfileSuper.")
 

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1366,10 +1366,28 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
             # (4) then add 'additional' headers as the outer ring:
             if self.items_additional_data_keys:
+                self.items_additional_data_keys = sorted(self.get_layer_names_with_at_least_one_hit_for_splits(self.items_additional_data_keys, self.items_additional_data_dict))
                 json_header.extend(self.items_additional_data_keys)
 
             # (5) finally add hmm search results
             if self.hmm_searches_dict:
+                if not self.split_hmm_layers:
+                    layer_names_for_hmm_hits = self.get_layer_names_with_at_least_one_hit_for_splits([tpl[1] for tpl in self.hmm_searches_header], self.hmm_searches_dict)
+
+                    # because keys for HMMs are weird to make sure we can easily switch between
+                    # the regular form of displaying HMMs and the form comes with the user flag
+                    # `self.split_hmm_layers`, we have to do something more here to clean up
+                    # the global `self.hmm_searches_header` list that is used again down
+                    # below:
+                    self.hmm_searches_header = [tpl for tpl in self.hmm_searches_header if tpl[1] in layer_names_for_hmm_hits]
+                else:
+                    # if the user asked for HMM layers to be split, we don't want to do anything.
+                    # it gets too prickly otherwise.
+                    pass
+
+                # let's sort these layers alphabetically
+                self.hmm_searches_header = sorted(self.hmm_searches_header)
+
                 json_header.extend([tpl[0] for tpl in self.hmm_searches_header])
 
             # (6) add taxonomy, if exitsts:
@@ -1391,7 +1409,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                 json_entry.extend([view_dict[split_name][header] for header in view_headers])
 
                 # (4) adding additional layers
-                if self.items_additional_data_dict:
+                if self.items_additional_data_keys:
                     json_entry.extend([self.items_additional_data_dict[split_name][header] if split_name in self.items_additional_data_dict else None for header in self.items_additional_data_keys])
 
                 # (5) adding hmm stuff

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1335,6 +1335,9 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                             layer_names_with_hits.append(layer_name)
                             layer_names_considered.add(layer_name)
 
+        # update our class variable so we know what is not going to be shown
+        self.layers_that_will_not_be_shown.update(set(layer_names_list) - set(layer_names_with_hits))
+
         return layer_names_with_hits
 
 
@@ -1345,6 +1348,10 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         including HMM hits, or user-provided data through the command line or misc
         data tables.
         '''
+
+        # we will fill this one up through `self.get_layer_names_with_at_least_one_hit_for_splits`
+        # to warn the user.
+        self.layers_that_will_not_be_shown = set([])
 
         for view in self.views:
             # here we will populate runinfo['views'] with json objects.
@@ -1430,6 +1437,14 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                 json_object.append(json_entry)
 
             self.views[view] = json_object
+
+        if len(self.layers_that_will_not_be_shown):
+            self.run.warning(f"Even thought he following layer names were associated with your data, they "
+                             f"will not be shown in your interactive display since none of the splits you "
+                             f"are in terested at this point had any hits in those layers: "
+                             f"\"{', '.join(sorted(list(self.layers_that_will_not_be_shown)))}\". If you "
+                             f"would like every layer to be shown in the interface even when there are no"
+                             "hits, please include the flag `--show-all-layers` in your command.")
 
 
     def store_refined_bins(self, refined_bin_data, refined_bins_info_dict):

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -77,6 +77,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.collection_name = A('collection_name')
         self.manual_mode = A('manual_mode')
         self.split_hmm_layers = A('split_hmm_layers')
+        self.show_all_layers = A('show_all_layers')
         self.taxonomic_level = A('taxonomic_level') or 't_genus'
         self.additional_layers_path = A('additional_layers')
         self.additional_view_path = A('additional_view')
@@ -1304,6 +1305,9 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
     def get_layer_names_with_at_least_one_hit_for_splits(self, layer_names_list, splits_dict):
         """This is a funciton to remove layers with no hits from default displays."""
+
+        if self.show_all_layers:
+            return layer_names_list
 
         layer_names_with_hits = []
         layer_names_to_consider = copy.deepcopy(layer_names_list)

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1451,12 +1451,12 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
             self.views[view] = json_object
 
         if len(self.layers_that_will_not_be_shown):
-            self.run.warning(f"Even thought he following layer names were associated with your data, they "
+            self.run.warning(f"Even though the following layer names were associated with your data, they "
                              f"will not be shown in your interactive display since none of the splits you "
                              f"are in terested at this point had any hits in those layers: "
                              f"\"{', '.join(sorted(list(self.layers_that_will_not_be_shown)))}\". If you "
                              f"would like every layer to be shown in the interface even when there are no"
-                             "hits, please include the flag `--show-all-layers` in your command.")
+                             f"hits, please include the flag `--show-all-layers` in your command.")
 
 
     def store_refined_bins(self, refined_bin_data, refined_bins_info_dict):

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -280,7 +280,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
         self.check_names_consistency()
         self.gen_orders_for_items_based_on_additional_layers_data()
-        self.convert_view_data_into_json()
+        self.finalize_view_data()
         self.get_anvio_news()
 
 
@@ -1302,8 +1302,13 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.progress.end()
 
 
-    def convert_view_data_into_json(self):
-        '''This function's name must change to something more meaningful.'''
+    def finalize_view_data(self):
+        '''Finalize what will be shown in the interactive interface.
+
+        This includes expanding available 'view's with additional layers to be shown,
+        including HMM hits, or user-provided data through the command line or misc
+        data tables.
+        '''
 
         for view in self.views:
             # here we will populate runinfo['views'] with json objects.

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -258,8 +258,8 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.set_displayed_item_names()
 
         # now we know what splits we are interested in (self.displayed_item_names_ordered), we can get rid of all the
-        # unnecessary splits stored in views dicts.
-        self.prune_view_dicts()
+        # unnecessary splits stored in views and other additional dicts.
+        self.prune_view_and_additional_data_dicts()
 
         self.process_external_item_order()
         self.gen_alphabetical_orders_of_items()
@@ -1289,9 +1289,10 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                             "are warned!" % (one_example, num_all))
 
 
-    def prune_view_dicts(self):
+    def prune_view_and_additional_data_dicts(self):
         self.progress.new('Pruning view dicts')
         self.progress.update('...')
+
         splits_in_views = set(list(self.views.values())[0]['dict'].keys())
         splits_to_remove = splits_in_views - set(self.displayed_item_names_ordered)
 
@@ -1299,6 +1300,13 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
             self.progress.update('processing view "%s"' % view)
             for split_name in splits_to_remove:
                 self.views[view]['dict'].pop(split_name)
+
+        self.progress.update("working on items additional data")
+        splits_in_items_additional_data_dict = set(list(self.items_additional_data_dict.keys()))
+        splits_to_remove = splits_in_items_additional_data_dict - set(self.displayed_item_names_ordered)
+
+        for split_name in splits_to_remove:
+            self.items_additional_data_dict.pop(split_name)
 
         self.progress.end()
 

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1302,6 +1302,42 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.progress.end()
 
 
+    def get_layer_names_with_at_least_one_hit_for_splits(self, layer_names_list, splits_dict):
+        """This is a funciton to remove layers with no hits from default displays."""
+
+        layer_names_with_hits = []
+        layer_names_to_consider = copy.deepcopy(layer_names_list)
+        layer_names_considered = set([])
+
+        layer_types = {}
+        for layer_name in layer_names_to_consider:
+            layer_types[layer_name] = utils.get_predicted_type_of_items_in_a_dict(splits_dict, layer_name)
+
+        for hits in splits_dict.values():
+            for layer_name in layer_names_to_consider:
+                if layer_name in layer_names_considered:
+                    continue
+
+                if layer_types[layer_name] == None:
+                    # all items in this layer has type None, there can't possibly
+                    # be anything worth showing here.
+                    layer_names_considered.add(layer_name)
+                    continue
+
+                if layer_name in hits:
+                    if layer_types[layer_name] in [int, float]:
+                        if hits[layer_name] > 0:
+                            layer_names_with_hits.append(layer_name)
+                            layer_names_considered.add(layer_name)
+                    else:
+                        # which means we have layer type of str, dict, or list
+                        if len(hits[layer_name]):
+                            layer_names_with_hits.append(layer_name)
+                            layer_names_considered.add(layer_name)
+
+        return layer_names_with_hits
+
+
     def finalize_view_data(self):
         '''Finalize what will be shown in the interactive interface.
 

--- a/anvio/tables/miscdata.py
+++ b/anvio/tables/miscdata.py
@@ -15,8 +15,6 @@ from anvio.tables.tableops import Table
 
 import pandas as pd
 
-from math import floor
-
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
 __copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"

--- a/anvio/tests/sandbox/example_description.md
+++ b/anvio/tests/sandbox/example_description.md
@@ -10,12 +10,20 @@ If this is your first time with anvi'o, or if you are not familiar with the plat
 
 Anvi'o has a relatively steep learning curve, but once you get the basics, the rest comes quite rapidly.
 
-You can start by taking a look at the [anvi'o vignette](http://merenlab.org/software/anvio/vignette/) to see all anvi'o programs in a single page along with their help menus. The power of anvi'o comes from its Lego-like design, where a [large number of small programs operate on a small number of concepts](http://merenlab.org/software/anvio/network/). This strategy allows you to build very complex ideas in a reproducible and robust fashion.
+* You can start by taking a look at the [anvi'o programs and artifacts](https://merenlab.org/software/anvio/help/main/).
+
+* [Take a look at this short paper](https://doi.org/10.1038/s41564-020-00834-3) to have an idea about the principles behind the platform.
 
 [<img src="http://merenlab.org/images/anvio-network.png" style="width: 100%;" />](http://merenlab.org/software/anvio/network/)
 
-[This page](http://merenlab.org/software/anvio/) offers theoretical and practical insights into 'omics analyses you can perform with anvi'o through tutorials and blog posts. You can also scroll through some of our online reproducible bioinformatics workflows such as [this one](http://merenlab.org/data/prochlorococcus-metapangenome/) or [this one](http://merenlab.org/data/wolbachia-plasmid/) to see various uses of anvi'o in the context of scientific questions.
+* [This page](http://merenlab.org/software/anvio/) offers theoretical and practical insights into 'omics analyses you can perform with anvi'o through tutorials and blog posts.
+
+* If you are new to microbial 'omics, you can [watch these introductory videos](https://www.youtube.com/playlist?list=PL7133RHfhW-MwCLz-c2DZxAmtoHipqBcL) to get yourself familiarized with common concepts.
 
 ### Join the conversation
 
-[Developers of anvi'o](https://github.com/merenlab/anvio/blob/master/AUTHORS.txt) strive to tailor this platform to **your** needs. Please do not hesitate to get in touch with us if you need technical help, have suggestions, or simply in need of bouncing computational and experimental 'omics ideas from others. You can join the conversation through [anvi'o slack](https://slackin-ezbpfhwsmh.now.sh/) or [anvi'o Google Groups](https://groups.google.com/forum/#!forum/anvio). If you run into technical problems despite our best efforts, you can always [file an issue report on GitHub](https://github.com/merenlab/anvio/issues).
+[Developers of anvi'o](https://github.com/merenlab/anvio/blob/master/AUTHORS.txt) strive to tailor this platform to **your** needs. Please do not hesitate to get in touch with us if you need technical help, have suggestions, or simply in need of bouncing computational and experimental 'omics ideas from others.
+
+* Here you can find [most up-to-date ways to get help from the anvi'o community](https://merenlab.org/2019/10/07/getting-help/), which includes options to reach out to us through the anvi'o Slack and Google Groups.
+
+* If you run into technical problems despite our best efforts, you can always [file an issue report on GitHub](https://github.com/merenlab/anvio/issues).

--- a/anvio/tests/sandbox/example_state.json
+++ b/anvio/tests/sandbox/example_state.json
@@ -5,7 +5,7 @@
     "current-view": "mean_coverage",
     "angle-min": "0",
     "angle-max": "270",
-    "tree-radius": "1500",
+    "tree-radius": "2000",
     "tree-height": "0",
     "tree-width": "0",
     "layer-margin": "15",
@@ -20,7 +20,7 @@
     "max-font-size": "60",
     "optimize-speed": true,
     "show-bin-labels": true,
-    "begins-from-branch": true,
+    "begins-from-branch": false,
     "bin-labels-font-size": "128",
     "autorotate-bin-labels": true,
     "estimate-taxonomy": false,
@@ -35,11 +35,9 @@
         "SAMPLE_01",
         "SAMPLE_02",
         "SAMPLE_03",
-        "hmms_Ribosomal_RNAs",
-        "hmms_Transfer_RNAs",
-        "hmms_external_hmm_genes",
-        "taxonomy"
+        "hmms_external_hmm_genes"
     ],
+    "categorical_data_colors": {},
     "stack_bar_colors": {},
     "layers": {
         "length": {
@@ -58,21 +56,21 @@
         },
         "SAMPLE_01": {
             "color": "#000000",
-            "height": "250",
+            "height": "300",
             "margin": "30",
             "type": "bar",
             "color-start": "#FFFFFF"
         },
         "SAMPLE_02": {
             "color": "#000000",
-            "height": "250",
+            "height": "300",
             "margin": "15",
             "type": "bar",
             "color-start": "#FFFFFF"
         },
         "SAMPLE_03": {
             "color": "#000000",
-            "height": "250",
+            "height": "300",
             "margin": "15",
             "type": "bar",
             "color-start": "#FFFFFF"
@@ -81,33 +79,12 @@
             "height": "50",
             "margin": "15"
         },
-        "hmms_Ribosomal_RNAs": {
-            "color": "#882222",
-            "height": "150",
-            "margin": "30",
-            "type": "intensity",
-            "color-start": "#FFDDDD"
-        },
-        "hmms_Transfer_RNAs": {
-            "color": "#226ab2",
-            "height": "150",
-            "margin": "15",
-            "type": "intensity",
-            "color-start": "#bfd9f3"
-        },
         "hmms_external_hmm_genes": {
             "color": "#3b003b",
             "height": "150",
             "margin": "15",
             "type": "intensity",
             "color-start": "#f5e1f5"
-        },
-        "taxonomy": {
-            "color": "#000000",
-            "height": "0",
-            "margin": "15",
-            "type": "color",
-            "color-start": "#DDDDDD"
         }
     },
     "views": {
@@ -175,28 +152,6 @@
                     "disabled": false
                 }
             },
-            "hmms_Ribosomal_RNAs": {
-                "normalization": "sqrt",
-                "min": {
-                    "value": "0",
-                    "disabled": false
-                },
-                "max": {
-                    "value": "0",
-                    "disabled": false
-                }
-            },
-            "hmms_Transfer_RNAs": {
-                "normalization": "sqrt",
-                "min": {
-                    "value": "0",
-                    "disabled": false
-                },
-                "max": {
-                    "value": "0",
-                    "disabled": false
-                }
-            },
             "hmms_external_hmm_genes": {
                 "normalization": "sqrt",
                 "min": {
@@ -205,14 +160,6 @@
                 },
                 "max": {
                     "value": "1.4142135623730951",
-                    "disabled": false
-                }
-            },
-            "taxonomy": {
-                "min": {
-                    "disabled": false
-                },
-                "max": {
                     "disabled": false
                 }
             }
@@ -256,43 +203,27 @@
             "group": "default"
         },
         {
-            "layer_name": "bars!bar1;bar2;bar3",
+            "layer_name": "num_INDELs_reported",
             "group": "default"
         },
         {
-            "layer_name": "t_domain!Bacteria",
-            "group": "t_domain"
+            "layer_name": "num_SCVs_reported",
+            "group": "default"
         },
         {
-            "layer_name": "t_order!Bifidobacteriales;Bacillales",
-            "group": "t_order"
+            "layer_name": "total_reads_kept",
+            "group": "default"
         },
         {
-            "layer_name": "t_genus!Listeria;Bifidobacterium",
-            "group": "t_genus"
-        },
-        {
-            "layer_name": "t_species!Unknown_t_genus_Bifidobacterium;Unknown_t_genus_Listeria;Bifidobacterium_adolescentis",
-            "group": "t_species"
-        },
-        {
-            "layer_name": "t_class!Actinobacteria;Bacilli",
-            "group": "t_class"
-        },
-        {
-            "layer_name": "t_family!Bifidobacteriaceae;Listeriaceae",
-            "group": "t_family"
-        },
-        {
-            "layer_name": "t_phylum!Firmicutes;Actinobacteria",
-            "group": "t_phylum"
+            "layer_name": "bars!bar1;bar2;bar3",
+            "group": "default"
         }
     ],
     "samples-layers": {
         "default": {
             "total_reads_mapped": {
                 "data-type": "numeric",
-                "height": 500,
+                "height": 300,
                 "margin": 15,
                 "normalization": "none",
                 "color": "#004c59",
@@ -309,7 +240,7 @@
             },
             "num_SNVs_reported": {
                 "data-type": "numeric",
-                "height": 500,
+                "height": 300,
                 "margin": 15,
                 "normalization": "none",
                 "color": "#96004b",
@@ -326,7 +257,7 @@
             },
             "percent_mapped_reads": {
                 "data-type": "numeric",
-                "height": 500,
+                "height": 300,
                 "margin": 15,
                 "normalization": "none",
                 "color": "#540054",
@@ -343,8 +274,8 @@
             },
             "visits": {
                 "data-type": "categorical",
-                "height": 80,
-                "margin": 15,
+                "height": 50,
+                "margin": 60,
                 "min": {
                     "value": null,
                     "disabled": false
@@ -354,25 +285,26 @@
                     "disabled": false
                 }
             },
-            "bars!bar1;bar2;bar3": {
-                "data-type": "stack-bar",
-                "height": 500,
-                "margin": 15,
+            "num_INDELs_reported": {
+                "data-type": "numeric",
+                "height": 200,
+                "margin": 60,
                 "normalization": "none",
+                "color": "#919191",
                 "min": {
-                    "value": null,
+                    "value": 0,
                     "disabled": false
                 },
                 "max": {
-                    "value": null,
+                    "value": 2,
                     "disabled": false
-                }
-            }
-        },
-        "t_domain": {
-            "t_domain!Bacteria": {
+                },
+                "type": "bar",
+                "color-start": "#EFEFEF"
+            },
+            "num_SCVs_reported": {
                 "data-type": "numeric",
-                "height": 500,
+                "height": 200,
                 "margin": 15,
                 "normalization": "none",
                 "color": "#919191",
@@ -381,98 +313,33 @@
                     "disabled": false
                 },
                 "max": {
-                    "value": 9155,
+                    "value": 32,
                     "disabled": false
                 },
                 "type": "bar",
                 "color-start": "#EFEFEF"
-            }
-        },
-        "t_order": {
-            "t_order!Bifidobacteriales;Bacillales": {
-                "data-type": "stack-bar",
-                "height": 500,
+            },
+            "total_reads_kept": {
+                "data-type": "numeric",
+                "height": 200,
                 "margin": 15,
                 "normalization": "none",
+                "color": "#919191",
                 "min": {
-                    "value": null,
+                    "value": 0,
                     "disabled": false
                 },
                 "max": {
-                    "value": null,
-                    "disabled": false
-                }
-            }
-        },
-        "t_genus": {
-            "t_genus!Listeria;Bifidobacterium": {
-                "data-type": "stack-bar",
-                "height": 500,
-                "margin": 15,
-                "normalization": "none",
-                "min": {
-                    "value": null,
+                    "value": 24870,
                     "disabled": false
                 },
-                "max": {
-                    "value": null,
-                    "disabled": false
-                }
-            }
-        },
-        "t_species": {
-            "t_species!Unknown_t_genus_Bifidobacterium;Unknown_t_genus_Listeria;Bifidobacterium_adolescentis": {
+                "type": "bar",
+                "color-start": "#EFEFEF"
+            },
+            "bars!bar1;bar2;bar3": {
                 "data-type": "stack-bar",
-                "height": 500,
-                "margin": 15,
-                "normalization": "none",
-                "min": {
-                    "value": null,
-                    "disabled": false
-                },
-                "max": {
-                    "value": null,
-                    "disabled": false
-                }
-            }
-        },
-        "t_class": {
-            "t_class!Actinobacteria;Bacilli": {
-                "data-type": "stack-bar",
-                "height": 500,
-                "margin": 15,
-                "normalization": "none",
-                "min": {
-                    "value": null,
-                    "disabled": false
-                },
-                "max": {
-                    "value": null,
-                    "disabled": false
-                }
-            }
-        },
-        "t_family": {
-            "t_family!Bifidobacteriaceae;Listeriaceae": {
-                "data-type": "stack-bar",
-                "height": 500,
-                "margin": 15,
-                "normalization": "none",
-                "min": {
-                    "value": null,
-                    "disabled": false
-                },
-                "max": {
-                    "value": null,
-                    "disabled": false
-                }
-            }
-        },
-        "t_phylum": {
-            "t_phylum!Firmicutes;Actinobacteria": {
-                "data-type": "stack-bar",
-                "height": 500,
-                "margin": 15,
+                "height": 600,
+                "margin": 60,
                 "normalization": "none",
                 "min": {
                     "value": null,
@@ -484,15 +351,5 @@
                 }
             }
         }
-    },
-    "samples-groups": {
-        "default": true,
-        "t_class": false,
-        "t_domain": false,
-        "t_family": false,
-        "t_genus": false,
-        "t_order": false,
-        "t_phylum": false,
-        "t_species": false
     }
 }

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -220,10 +220,33 @@ def get_predicted_type_of_items_in_a_dict(d, key):
 
     items = [x[key] for x in d.values()]
 
-    if(set(items) == set([None])):
-        # all items is of type None.
+    if not items:
+        # there is nothing to see here
         return None
 
+    try:
+        if(set(items) == set([None])):
+            # all items is of type None.
+            return None
+    except TypeError:
+        # this means we are working with an unhashable type.
+        # it is either list or dict. we will go through items
+        # and return the type of first item that is not None:
+        for item in items:
+            if item == None:
+                continue
+            else:
+                return type(item)
+
+        # the code should never come to this line since if everything
+        # was None that would have been captured by the try block and the
+        # exception would have never been thrown, but here is a final line
+        # just to be sure we are not moving on with the rest of the code
+        # if we entered into this block:
+        return None
+
+    # if we are here, it means not all items are None, and they are not of
+    # unhashable types (so they must be atomic types such as int, float, or str)
     not_float = False
     for item in items:
         try:

--- a/bin/anvi-interactive
+++ b/bin/anvi-interactive
@@ -80,6 +80,7 @@ if __name__ == '__main__':
     groupE.add_argument(*anvio.A('view'), **anvio.K('view'))
     groupE.add_argument(*anvio.A('title'), **anvio.K('title'))
     groupE.add_argument(*anvio.A('taxonomic-level'), **anvio.K('taxonomic-level'))
+    groupE.add_argument(*anvio.A('show-all-layers'), **anvio.K('show-all-layers'))
     groupE.add_argument(*anvio.A('split-hmm-layers'), **anvio.K('split-hmm-layers'))
     groupE.add_argument(*anvio.A('hide-outlier-SNVs'), **anvio.K('hide-outlier-SNVs'))
     groupE.add_argument(*anvio.A('state-autoload'), **anvio.K('state-autoload'))

--- a/bin/anvi-refine
+++ b/bin/anvi-refine
@@ -70,6 +70,7 @@ if __name__ == '__main__':
 
     groupD = parser.add_argument_group('VISUALS RELATED', "Parameters that give access to various adjustements regarding\
                                                            the interface.")
+    groupD.add_argument(*anvio.A('show-all-layers'), **anvio.K('show-all-layers'))
     groupD.add_argument(*anvio.A('split-hmm-layers'), **anvio.K('split-hmm-layers'))
     groupD.add_argument(*anvio.A('taxonomic-level'), **anvio.K('taxonomic-level'))
     groupD.add_argument(*anvio.A('hide-outlier-SNVs'), **anvio.K('hide-outlier-SNVs'))


### PR DESCRIPTION
This PR addresses the issue #1562 and more, including:

* If a given HMM and/or item additional data layer does not have any data points for a given set of splits to be displayed, remove them from anvi'o displays initialized by `anvi-interactive` and `anvi-refine`, but let the user overwrite that behavior via the flag `--show-all-layers`.
* Prune items additional data dict given the splits of interest prior to initializing the interface.

I imported the following items additional data to infant gut dataset prior to testing this:

|name|TEST_KEY_SHOW|TEST_KEY_NOSHOW|TEST_INT_SHOW|TEST_INT_NOSHOW|TEST_FLOAT_SHOW|TEST_FLOAT_NO_SHOW|
|:--|:--:|:--:|:--:|:--:|:--:|:--:|
|IGD_000000002399_split_00001|TRUE||1|0|0.5|0.0|
|IGD_000000001622_split_00001|FALSE||2|0|0.1|0.0|

This is how the IGD looks before the changes in this PR:

![image](https://user-images.githubusercontent.com/197307/103327895-2da10880-4a1c-11eb-96f8-fa8fe61f33b2.png)

And this is how it looks now:

![image](https://user-images.githubusercontent.com/197307/103327859-034f4b00-4a1c-11eb-9133-3d60b9629175.png)

Mini test before:

![image](https://user-images.githubusercontent.com/197307/103327965-7bb60c00-4a1c-11eb-9bcf-012f86df3d31.png)

Mini test now:

![image](https://user-images.githubusercontent.com/197307/103328019-b5871280-4a1c-11eb-94f3-93c2b3963e53.png)

And this was shown in the terminal:

```
WARNING
===============================================
Even though the following layer names were associated with your data, they will
not be shown in your interactive display since none of the splits you are in
terested at this point had any hits in those layers: "Ribosomal_RNA_12S,
Ribosomal_RNA_16S, Ribosomal_RNA_18S, Ribosomal_RNA_23S, Ribosomal_RNA_28S,
Ribosomal_RNA_5S". If you would like every layer to be shown in the interface
even when there are nohits, please include the flag `--show-all-layers` in your
command.
```

I think this is good to go.