### PR TITLE
Neat displays of output files during testing

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -38,11 +38,20 @@ def P(d, dont_exit=False):
         sys.exit()
 
 
-def TABULATE(table, header, numalign="right"):
+def TABULATE(table, header, numalign="right", max_width=0):
     """Encoding-safe `tabulate`"""
 
     tablefmt = "fancy_grid" if sys.stdout.encoding == "UTF-8" else "grid"
-    print(tabulate(table, headers=header, tablefmt=tablefmt, numalign=numalign))
+    table = tabulate(table, headers=header, tablefmt=tablefmt, numalign=numalign)
+
+    if max_width:
+        # let's don't print everything if things need to be cut.
+        prefix = " // "
+        lines_in_table = table.split('\n')
+        if len(lines_in_table[0]) + len(prefix) + 2 > max_width:
+            table = '\n'.join([l[:max_width - len(prefix)] + prefix + l[-2:] for l in lines_in_table])
+
+    print(table)
 
 
 # Make sure the Python environment hasn't changed since the installation (happens more often than you'd think

--- a/anvio/tests/00.sh
+++ b/anvio/tests/00.sh
@@ -2,14 +2,25 @@
 
 set -e
 
+O() {
+    echo -e "\033[1;1m\033[41m:: $1 ...\033[0m"
+}
+
 C() {
-    echo -e "\033[1;30m\033[47m$1\033[0m"
+    echo -e "\033[1;30m\033[47m:: $1 ...\033[0m"
 }
 
 INFO() {
     echo
     echo
-    C ":: $1 ..."
+    C "$1"
+    echo
+}
+
+OUTPUT() {
+    echo
+    echo
+    O "$1"
     echo
 }
 
@@ -53,6 +64,6 @@ SETUP_WITH_OUTPUT_DIR() {
 }
 
 SHOW_FILE() {
-    echo
-    cat $1
+    OUTPUT $1
+    head -n 10 $1 | anvi-script-tabulate
 }

--- a/anvio/tests/run_all_tests.sh
+++ b/anvio/tests/run_all_tests.sh
@@ -140,6 +140,7 @@ anvi-export-functions -c $output_dir/CONTIGS.db \
 INFO "Export all functional annotations"
 anvi-export-functions -c $output_dir/CONTIGS.db \
                       -o $output_dir/exported_functions_from_all_sources.txt
+SHOW_FILE $output_dir/exported_functions_from_all_sources.txt
 
 INFO "Export genomic locus using functional annotation search"
 anvi-export-locus -c $output_dir/CONTIGS.db \
@@ -250,6 +251,7 @@ anvi-get-split-coverages -p $output_dir/SAMPLES-MERGED/PROFILE.db \
                          -o $output_dir/split_coverages_in_Bin_1.txt \
                          -C CONCOCT \
                          -b Bin_1
+SHOW_FILE $output_dir/split_coverages_in_Bin_1.txt
 
 INFO "Generating per-nt position coverage values for a single gene with its 20nt flanks across samples"
 anvi-get-split-coverages -p $output_dir/SAMPLES-MERGED/PROFILE.db \
@@ -257,6 +259,7 @@ anvi-get-split-coverages -p $output_dir/SAMPLES-MERGED/PROFILE.db \
                          -o $output_dir/gene_caller_id_5_coverages.txt \
                          --gene-caller-id 5 \
                          --flank-length 20
+SHOW_FILE $output_dir/gene_caller_id_5_coverages.txt
 
 INFO "Cluster contigs in the newly generated coverages file"
 anvi-matrix-to-newick $output_dir/SAMPLES-MERGED/SAMPLES_MERGED-COVs.txt
@@ -356,7 +359,6 @@ anvi-rename-bins -c $output_dir/CONTIGS.db \
                  --collection-to-read "cmdline_concoct" \
                  --collection-to-write "cmdline_concoct_RENAMED" \
                  --report-file $output_dir/renaming-report.txt
-
 SHOW_FILE $output_dir/renaming-report.txt
 
 INFO "Requesting collection info"
@@ -387,6 +389,7 @@ anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
                              -b PSAMPLES_Bin_00001 \
                              -o $output_dir/variability_PSAMPLES_Bin_00001.txt \
                              --quince-mode
+SHOW_FILE $output_dir/variability_PSAMPLES_Bin_00001.txt
 
 INFO "Generate a SNV profile for PSAMPLES_Bin_00001 using genes of interest (after summary)"
 anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
@@ -394,6 +397,7 @@ anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
                              --genes-of-interest $files/example_genes_of_interest.txt \
                              -o $output_dir/variability_PSAMPLES_Bin_00001_ALT_GENES_of_INTEREST.txt \
                              --engine NT
+SHOW_FILE $output_dir/variability_PSAMPLES_Bin_00001_ALT_GENES_of_INTEREST.txt
 
 INFO "Generate a SNV profile for PSAMPLES_Bin_00001 using split names of interest (after summary)"
 anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
@@ -401,6 +405,7 @@ anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
                              --splits-of-interest $output_dir/SAMPLES-MERGED-SUMMARY/bin_by_bin/PSAMPLES_Bin_00001/PSAMPLES_Bin_00001-original_split_names.txt \
                              -o $output_dir/variability_PSAMPLES_Bin_00001_ALT_SPLITS_of_INTEREST.txt \
                              --engine NT
+SHOW_FILE $output_dir/variability_PSAMPLES_Bin_00001_ALT_SPLITS_of_INTEREST.txt
 
 INFO "Generate a SCV profile for PSAMPLES_Bin_00001 using a collection id"
 anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
@@ -410,6 +415,7 @@ anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
                              -o $output_dir/variability_CDN_PSAMPLES_Bin_00001.txt \
                              --quince-mode \
                              --engine CDN
+SHOW_FILE $output_dir/variability_CDN_PSAMPLES_Bin_00001.txt
 
 INFO "Generate a SAAV profile for PSAMPLES_Bin_00001 using a collection id"
 anvi-gen-variability-profile -c $output_dir/CONTIGS.db \
@@ -431,6 +437,7 @@ INFO "Generating normalized codon frequencies for all genes in the contigs datab
 anvi-get-codon-frequencies -c $output_dir/CONTIGS.db \
                            -o $output_dir/CODON_frequencies_for_the_contigs_db.txt \
                            --merens-codon-normalization
+SHOW_FILE $output_dir/CODON_frequencies_for_the_contigs_db.txt
 
 INFO "Getting back the sequence for gene call 3"
 anvi-get-sequences-for-gene-calls -c $output_dir/CONTIGS.db \
@@ -465,6 +472,8 @@ anvi-export-gene-coverage-and-detection -p $output_dir/SAMPLES-MERGED/PROFILE.db
                                         -c $output_dir/CONTIGS.db \
                                         --gene-caller-id 1 \
                                         -O $output_dir/MERGED-GENE-01
+SHOW_FILE $output_dir/MERGED-GENE-01-GENE-COVERAGES.txt
+SHOW_FILE $output_dir/MERGED-GENE-01-GENE-DETECTION.txt
 
 INFO "Show all available HMM sources"
 anvi-get-sequences-for-hmm-hits -c $output_dir/CONTIGS.db \

--- a/sandbox/anvi-script-tabulate
+++ b/sandbox/anvi-script-tabulate
@@ -23,12 +23,15 @@ def main(args):
     for line in sys.stdin:
         lines.append(line.strip('\n').split('\t'))
 
-    anvio.TABULATE(lines[1:], lines[0])
+    anvio.TABULATE(lines[1:], lines[0], max_width=args.max_width)
 
 
 if __name__ == '__main__':
     from anvio.argparse import ArgumentParser
     parser = ArgumentParser(description=__description__)
+    parser.add_argument('--max-width', type=int, default=120, help="Maximum number of characters to be displayed in the output "
+                                        "table. The default is %(default)d to make sure tables will fit to most displays. Set "
+                                        "to 0 to see the entire table.")
     args = parser.get_args(parser)
 
     try:


### PR DESCRIPTION
This PR enhances `SHOW_FILE` function we use in our test routines to produce neat outputs like this one:

![image](https://user-images.githubusercontent.com/197307/103446322-e5fcc580-4c43-11eb-99ee-08e81785f21e.png)

With the `--max-width` option that is set to `120` by default, longer outputs automatically cut like this to not cause a mess in the terminal:

![image](https://user-images.githubusercontent.com/197307/103446337-0462c100-4c44-11eb-8acb-6966cf420b59.png)
