### PR TITLE
Robust anticodon db checks

### DIFF
--- a/bin/anvi-estimate-trna-taxonomy
+++ b/bin/anvi-estimate-trna-taxonomy
@@ -43,7 +43,7 @@ def main(args):
             import anvio.trnaidentifier as trnaidentifier
             profiler = trnaidentifier.Profiler()
 
-            sequence_profile = profiler.GeneProfile(args.dna_sequence)
+            sequence_profile = profiler.profile_gene(args.dna_sequence)
             if not sequence_profile.predicted_profile:
                 raise ConfigError("As far as anvi'o knows, this sequence does not look like a tRNA sequence :/")
 


### PR DESCRIPTION
A superior strategy compared to what I had implemented in `v7`. Unlike the previous implementation, this is supposed to work with any BLAST version.

I tested this on Docker, Linux, Mac with BLAST 2.9* and 2.10*.

This closes #1624 and #1625.

Since changes here are extremely localized to a single operation, Sam and I did something crazy and retrospectively updated the asset associated with the release of `v7` to make sure future installations do not suffer from this. The new shasum should match to this:

```
shasum -a 256 anvio-7.tar.gz
56741825f94f39c8e1ee12dfe1345c77d5b3e3fefbcce4f36aad453e51a08bc0  anvio-7.tar.gz
```

Sam and I tested this package thoroughly, and everything seems to be working.