### PR TITLE
Db variant variable

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -442,6 +442,16 @@ D = {
                      "desired lengths (although some functionality may become unavailable for the projects that rely on "
                      "a contigs database that is initiated this way)."}
                 ),
+    'db-variant': (
+            ['--db-variant'],
+            {'metavar': 'VARIANT',
+             'required': False,
+             'default': 'unknown',
+             'help': "A free-form text variable to associate a database with a variant for power users and/or programmers "
+                     "Please leave this blank unless you are certain that you need to set a db variant since it may influence "
+                     "downstream processes. In an ideal world a varainat would be a single-word, without any capitalized letters "
+                     "or special characters."}
+                ),
     'contigs-fasta': (
             ['-f', '--contigs-fasta'],
             {'metavar': 'FASTA',

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3912,6 +3912,7 @@ class ContigsDatabase:
     def create(self, args):
         A = lambda x: args.__dict__[x] if x in args.__dict__ else None
         contigs_fasta = A('contigs_fasta')
+        db_variant = A('db_variant') or 'unknown'
         project_name = A('project_name')
         description_file_path = A('description')
         split_length = A('split_length')
@@ -4063,6 +4064,7 @@ class ContigsDatabase:
 
         # know thyself
         self.db.set_meta_value('db_type', 'contigs')
+        self.db.set_meta_value('db_variant', db_variant)
         self.db.set_meta_value('project_name', project_name)
         self.db.set_meta_value('description', description)
 

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3496,7 +3496,7 @@ def get_genes_database_path_for_bin(profile_db_path, collection_name, bin_name):
     return os.path.join(os.path.dirname(profile_db_path), 'GENES', '%s-%s.db' % (collection_name, bin_name))
 
 
-def get_db_type(db_path):
+def get_db_type_and_variant(db_path):
     filesnpaths.is_file_exists(db_path)
     database = db.DB(db_path, None, ignore_version=True)
 
@@ -3506,9 +3506,23 @@ def get_db_type(db_path):
         raise ConfigError("'%s' does not seem to be a anvi'o database..." % db_path)
 
     db_type = database.get_meta_value('db_type')
+
+    try:
+        db_variant = database.get_meta_value('db_variant')
+    except:
+        db_variant = None
+
     database.disconnect()
 
-    return db_type
+    return (db_type, db_variant)
+
+
+def get_db_type(db_path):
+    return get_db_type_and_variant(db_path)[0]
+
+
+def get_db_variant(db_path):
+    return get_db_type_and_variant(db_path)[1]
 
 
 def get_required_version_for_db(db_path):
@@ -3622,14 +3636,12 @@ def get_variability_table_engine_type(table_path, dont_raise=False):
 
 
 def is_contigs_db(db_path):
-    filesnpaths.is_file_exists(db_path)
     if get_db_type(db_path) != 'contigs':
         raise ConfigError("'%s' is not an anvi'o contigs database." % db_path)
     return True
 
 
 def is_trnaseq_db(db_path):
-    filesnpaths.is_file_exists(db_path)
     if get_db_type(db_path) != 'trnaseq':
         raise ConfigError("'%s' is not an anvi'o trnaseq database." % db_path)
     return True
@@ -3667,7 +3679,6 @@ def is_structure_db(db_path):
 
 
 def is_modules_db(db_path):
-    filesnpaths.is_file_exists(db_path)
     if get_db_type(db_path) != 'modules':
         raise ConfigError("'%s' is not an anvi'o modules database." % db_path)
     return True

--- a/bin/anvi-gen-contigs-database
+++ b/bin/anvi-gen-contigs-database
@@ -45,6 +45,7 @@ if __name__ == '__main__':
 
     groupC = parser.add_argument_group('OPTIONAL INPUTS', 'Things you may want to tweak.')
     groupC.add_argument(*anvio.A('output-db-path'), **anvio.K('output-db-path', {'default': 'CONTIGS.db'}))
+    groupC.add_argument(*anvio.A('db-variant'), **anvio.K('db-variant'))
     groupC.add_argument(*anvio.A('description'), **anvio.K('description'))
     groupC.add_argument(*anvio.A('split-length'), **anvio.K('split-length'))
     groupC.add_argument(*anvio.A('skip-mindful-splitting'), **anvio.K('skip-mindful-splitting'))


### PR DESCRIPTION
This PR introduces a generic variable for the `self` tables of all db types, even though it will first be used for contigs databases.

The need for this comes from the fact that our contigs databases can now serve multiple purposes, and giving the user/programmer option to set explicitly what variant the database they wish to create can empower us to be able to do more things downstream without having to predict whether a new function is appropriate for a given database.

The first application of this will be to distinguish contigs databases generated by `anvi-trnaseq` workflows from contigs databases generated by `anvi-gen-contigs-database`.

In addition to a new flag to set the `db_variant` while generating a new contigs database, in this PR there is a fool-proof and backwards-compatible way to learn about `db_variant` in `utils.get_db_type()`.