### PR TITLE
anvi-db-info shall show functional annotations for contigs dbs

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3881,7 +3881,7 @@ class ContigsDatabase:
     def list_function_sources(self):
         self.run.warning(None, header="AVAILABLE FUNCTIONAL ANNOTATION SOURCES", lc="green")
 
-        gene_function_sources = sorted(self.meta['gene_function_sources'])
+        gene_function_sources = sorted(self.meta['gene_function_sources']) if self.meta['gene_function_sources'] else []
 
         if not len(gene_function_sources):
             self.run.info_single('No functional annotations found in this contigs database :/', nl_before=1, nl_after=1, mc='red')

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3891,6 +3891,23 @@ class ContigsDatabase:
                 self.run.info_single(f'{source} ({pp(num_annotations)} annotations)', nl_after = 1 if source == gene_function_sources[-1] else 0)
 
 
+    def list_available_hmm_sources(self):
+        self.run.warning(None, header="AVAILABLE HMM SOURCES", lc="green")
+
+        hmm_sources_dict = self.db.get_table_as_dict(t.hmm_hits_info_table_name)
+        hmm_sources = sorted(list(hmm_sources_dict.keys()))
+
+        if not len(hmm_sources_dict):
+            self.run.info_single("This contigs db does not have HMMs :/")
+        else:
+            for source in hmm_sources:
+                source_type = hmm_sources_dict[source]['search_type']
+                num_models = len(hmm_sources_dict[source]['genes'].split(','))
+                num_hits = self.db.get_row_counts_from_table(t.hmm_hits_table_name, where_clause=f'source="{source}"')
+                self.run.info_single(f"'{source}' (type '{source_type}' with {P('model', num_models)} and {P('hit', num_hits)})",
+                                     nl_after = 1 if source == hmm_sources[-1] else 0)
+
+
     def remove_data_from_db(self, tables_dict):
         """This is quite an experimental function to clean up tables in contgis databases. Use with caution.
 

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3881,7 +3881,7 @@ class ContigsDatabase:
     def list_function_sources(self):
         self.run.warning(None, header="AVAILABLE FUNCTIONAL ANNOTATION SOURCES", lc="green")
 
-        gene_function_sources = self.meta['gene_function_sources']
+        gene_function_sources = sorted(self.meta['gene_function_sources'])
 
         if not len(gene_function_sources):
             self.run.info_single('No functional annotations found in this contigs database :/', nl_before=1, nl_after=1, mc='red')

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3884,7 +3884,7 @@ class ContigsDatabase:
         gene_function_sources = sorted(self.meta['gene_function_sources']) if self.meta['gene_function_sources'] else []
 
         if not len(gene_function_sources):
-            self.run.info_single('No functional annotations found in this contigs database :/', nl_before=1, nl_after=1, mc='red')
+            self.run.info_single('No functional annotations found in this contigs database :/', nl_after=1, mc='red')
         else:
             for source in gene_function_sources:
                 num_annotations = self.db.get_row_counts_from_table(t.gene_function_calls_table_name, where_clause=f'source="{source}"')

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -566,16 +566,7 @@ class ContigsSuperclass(object):
 
 
     def list_function_sources(self):
-        contigs_db = ContigsDatabase(self.contigs_db_path, run=terminal.Run(verbose=False))
-        gene_function_sources = contigs_db.meta['gene_function_sources']
-        contigs_db.disconnect()
-
-        if not len(gene_function_sources):
-            self.run.info_single('No functional annotations found in this contigs database :/', nl_before=1, nl_after=1, mc='red')
-        else:
-            self.run.warning('', 'AVAILABLE FUNCTIONS (%d FOUND)' % (len(gene_function_sources)), lc='yellow')
-            for source in gene_function_sources:
-                self.run.info_single('%s' % (source), nl_after = 1 if source == gene_function_sources[-1] else 0)
+        ContigsDatabase(self.contigs_db_path).list_function_sources()
 
 
     def check_functional_annotation_sources(self, sources=None, dont_panic=False):
@@ -3880,6 +3871,19 @@ class ContigsDatabase:
             for gene_caller_source, num_genes in gene_caller_sources:
                 self.run.info_single("'%s' (%s gene calls)" % (gene_caller_source, pp(num_genes)),
                                      nl_after = 1 if gene_caller_source == gene_caller_sources[-1][0] else 0)
+
+
+    def list_function_sources(self):
+        run.warning(None, header="AVAILABLE FUNCTIONAL ANNOTATION SOURCES", lc="green")
+
+        gene_function_sources = self.meta['gene_function_sources']
+
+        if not len(gene_function_sources):
+            self.run.info_single('No functional annotations found in this contigs database :/', nl_before=1, nl_after=1, mc='red')
+        else:
+            for source in gene_function_sources:
+                num_annotations = self.db.get_row_counts_from_table(t.gene_function_calls_table_name, where_clause=f'source="{source}"')
+                self.run.info_single(f'{source} ({pp(num_annotations)} annotations)', nl_after = 1 if source == gene_function_sources[-1] else 0)
 
 
     def remove_data_from_db(self, tables_dict):

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3782,6 +3782,11 @@ class ContigsDatabase:
             self.db = None
 
 
+    def __del__(self):
+        if self.db:
+            self.db.disconnect()
+
+
     def get_date(self):
         return time.time()
 
@@ -4289,6 +4294,7 @@ class ContigsDatabase:
 
     def disconnect(self):
         self.db.disconnect()
+        self.db = None
 
 
 class TRNASeqDatabase:

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3866,7 +3866,7 @@ class ContigsDatabase:
 
 
     def list_gene_caller_sources(self):
-        run.warning(None, header="AVAILABLE GENE CALLERS", lc="green")
+        self.run.warning(None, header="AVAILABLE GENE CALLERS", lc="green")
 
         gene_caller_sources = self.meta['gene_callers']
 
@@ -3879,7 +3879,7 @@ class ContigsDatabase:
 
 
     def list_function_sources(self):
-        run.warning(None, header="AVAILABLE FUNCTIONAL ANNOTATION SOURCES", lc="green")
+        self.run.warning(None, header="AVAILABLE FUNCTIONAL ANNOTATION SOURCES", lc="green")
 
         gene_function_sources = self.meta['gene_function_sources']
 

--- a/anvio/docs/programs/anvi-db-info.md
+++ b/anvio/docs/programs/anvi-db-info.md
@@ -31,33 +31,34 @@ Here is an example of what you might see for a %(contigs-db)s.
 DB Info (no touch)
 ===============================================
 Database Path ................................: CONTIGS.db
-Description ..................................: [Not found, but it's OK]
+Description ..................................: No description is given
 Type .........................................: contigs
-Version ......................................: 19
+Variant ......................................: None
+Version ......................................: 20
 
 
 DB Info (no touch also)
 ===============================================
-project_name .................................: TEST
-contigs_db_hash ..............................: hashe451b636
+contigs_db_hash ..............................: d51abf0a
 split_length .................................: 20000
 kmer_size ....................................: 4
-num_contigs ..................................: 1
-total_length .................................: 2089645
-num_splits ...................................: 104
-gene_level_taxonomy_source ...................: None
+num_contigs ..................................: 4189
+total_length .................................: 35766167
+num_splits ...................................: 4784
 genes_are_called .............................: 1
 splits_consider_gene_calls ...................: 1
-creation_date ................................: 1584050598.57349
-scg_taxonomy_was_run .........................: 1
+creation_date ................................: 1466453807.46107
+project_name .................................: Infant Gut Contigs from Sharon et al.
+gene_level_taxonomy_source ...................:
+scg_taxonomy_was_run .........................: 0
 external_gene_calls ..........................: 0
 external_gene_amino_acid_seqs ................: 0
 skip_predict_frame ...........................: 0
-scg_taxonomy_database_version ................: v89
+scg_taxonomy_database_version ................: None
 trna_taxonomy_was_run ........................: 0
 trna_taxonomy_database_version ...............: None
 modules_db_hash ..............................: 72700e4db2bc
-gene_function_sources ........................: KEGG_Module,KOfam,Pfam,Transfer_RNAs,KEGG_Class
+gene_function_sources ........................: KEGG_Module,COG14_CATEGORY,COG14_FUNCTION,KEGG_Class,KOfam
 
 * Please remember that it is never a good idea to change these values. But in some
 cases it may be absolutely necessary to update something here, and a programmer
@@ -66,17 +67,25 @@ extremely careful.
 
 AVAILABLE GENE CALLERS
 ===============================================
-* 'prodigal' (1,678 gene calls)
-* 'Ribosomal_RNAs' (10 gene calls)
+* 'prodigal' (32,265 gene calls)
+* 'Ribosomal_RNAs' (9 gene calls)
+
+
+AVAILABLE FUNCTIONAL ANNOTATION SOURCES
+===============================================
+* COG14_CATEGORY (21,121 annotations)
+* COG14_FUNCTION (21,121 annotations)
+* KEGG_Class (2,760 annotations)
+* KEGG_Module (2,760 annotations)
+* KOfam (14,391 annotations)
 
 
 AVAILABLE HMM SOURCES
 ===============================================
-* 'Bacteria_71' (type: singlecopy; num genes: 71)
-* 'Archaea_76' (type: singlecopy; num genes: 76)
-* 'Protista_83' (type: singlecopy; num genes: 83)
-* 'Ribosomal_RNAs' (type: Ribosomal_RNAs; num genes: 12)
-
+* 'Archaea_76' (type 'singlecopy' with 76 models and 404 hits)
+* 'Bacteria_71' (type 'singlecopy' with 71 models and 674 hits)
+* 'Protista_83' (type 'singlecopy' with 83 models and 100 hits)
+* 'Ribosomal_RNAs' (type 'Ribosomal_RNAs' with 12 models and 9 hits)
 ```
 
 Most of this output is self-explanatory. But one thing that may not be quite obvious to some is that in many cases we use `0` to indicate 'False' and `1` to indicate 'True'. So for this example, you will see that SCG taxonomy was run on this database, but tRNA taxonomy was not.

--- a/anvio/hmmops.py
+++ b/anvio/hmmops.py
@@ -205,26 +205,6 @@ class SequencesForHMMHits:
                               "because it is not yet initialized :/ The programmer could call "
                               "`init_dicts` first, but clearly they didn't care.")
 
-    def list_available_hmm_sources(self, dont_quit=False):
-        self.check_init()
-
-        self.run.warning(None, header="AVAILABLE HMM SOURCES", lc="green")
-
-        hmm_sources_found = list(self.hmm_hits_info.keys())
-
-        if not len(hmm_sources_found):
-            self.run.info_single("This contigs db does not have HMMs :/")
-        else:
-            for source in self.hmm_hits_info:
-                h = self.hmm_hits_info[source]
-                self.run.info_single("'%s' (type: %s; num genes: %d)" % (source, h['search_type'], len(h['genes'].split(','))),
-                                     nl_after = 1 if source == hmm_sources_found[-1] else 0)
-
-        if dont_quit:
-            return
-
-        sys.exit(0)
-
 
     def list_available_gene_names(self, sources=[], dont_quit=False):
         self.check_init()

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -733,7 +733,8 @@ class LocusSplitter:
             self.annotation_sources = self.annotation_sources.split(self.delimiter)
 
         if A('list_hmm_sources'):
-            hmmops.SequencesForHMMHits(self.input_contigs_db_path).list_available_hmm_sources()
+            dbops.ContigsDatabase(self.input_contigs_db_path).list_available_hmm_sources()
+            sys.exit()
 
         # unless we are in debug mode, let's keep things quiet.
         if anvio.DEBUG:

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -102,10 +102,10 @@ def pluralize(word, number, suffix_for_plural="s", suffix_for_singular=None, pre
     """
 
     if number > 1:
-        return f"{number} {word}{suffix_for_plural}"
+        return f"{pretty_print(number)} {word}{suffix_for_plural}"
     else:
         if suffix_for_singular:
-            return f"{number} {word}{suffix_for_singular}"
+            return f"{pretty_print(number)} {word}{suffix_for_singular}"
         else:
             return f"{prefix_for_singular} {word}"
 

--- a/bin/anvi-db-info
+++ b/bin/anvi-db-info
@@ -83,7 +83,16 @@ class DatabaseInfo:
             # broken databases. so if the following code cause issues because the DB is broken
             # this program shouldn't crash.
             try:
+                dbops.ContigsDatabase(self.db_path).list_function_sources()
+            except:
+                pass
+
+            try:
                 dbops.ContigsDatabase(self.db_path).list_gene_caller_sources()
+            except:
+                pass
+
+            try:
                 hmmops.SequencesForHMMHits(self.db_path).list_available_hmm_sources()
             except:
                 pass

--- a/bin/anvi-db-info
+++ b/bin/anvi-db-info
@@ -83,12 +83,12 @@ class DatabaseInfo:
             # broken databases. so if the following code cause issues because the DB is broken
             # this program shouldn't crash.
             try:
-                dbops.ContigsDatabase(self.db_path).list_function_sources()
+                dbops.ContigsDatabase(self.db_path).list_gene_caller_sources()
             except:
                 pass
 
             try:
-                dbops.ContigsDatabase(self.db_path).list_gene_caller_sources()
+                dbops.ContigsDatabase(self.db_path).list_function_sources()
             except:
                 pass
 

--- a/bin/anvi-db-info
+++ b/bin/anvi-db-info
@@ -93,7 +93,7 @@ class DatabaseInfo:
                 pass
 
             try:
-                hmmops.SequencesForHMMHits(self.db_path).list_available_hmm_sources()
+                dbops.ContigsDatabase(self.db_path).list_available_hmm_sources()
             except:
                 pass
 

--- a/bin/anvi-db-info
+++ b/bin/anvi-db-info
@@ -63,10 +63,11 @@ class DatabaseInfo:
                 else:
                     run.info("Description", desc)
             run.info("Type", self.db_type)
+            run.info("Variant", self.db_variant)
             run.info("Version", self.db_version, nl_after=1)
 
             run.warning(None, "DB Info (no touch also)", lc="green")
-            for key in [k for k in self.db_self if k not in ["version", "db_type", "description"]]:
+            for key in [k for k in self.db_self if k not in ["version", "db_type", "description", "db_variant"]]:
                 if key == self.self_key or (self.self_key == 'sample_id' and key == 'samples'):
                     run.info('%s [JUST SET]' % key, self.db_self[key]["value"], mc='green', lc='green')
                 else:
@@ -110,6 +111,8 @@ class DatabaseInfo:
         except Exception as e:
             raise ConfigError("Anvi'o has some concerns regarding '%s' and thinks it may not be a database file "
                               "since some libraries complained about it downstream. Here is what they said: %s." % (self.db_path, e))
+
+        self.db_variant = utils.get_db_variant(self.db_path)
 
 
     def set_key_value(self):

--- a/bin/anvi-delete-hmms
+++ b/bin/anvi-delete-hmms
@@ -9,6 +9,7 @@ import anvio.terminal as terminal
 
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.hmmhits import TablesForHMMHits
+from anvio.dbops import ContigsDatabase
 
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
@@ -34,7 +35,8 @@ def main(args):
         sys.exit()
 
     if args.list_hmm_sources:
-        hmmops.SequencesForHMMHits(args.contigs_db).list_available_hmm_sources()
+        ContigsDatabase(args.contigs_db).list_available_hmm_sources()
+        sys.exit()
 
     if not args.hmm_source and not args.just_do_it:
         raise ConfigError("But you should give this program an HMM souce to remove from the database :/ If you "

--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -36,7 +36,6 @@
 
 import os
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.utils as utils
@@ -46,7 +45,8 @@ import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
 import anvio.hmmopswrapper as hmmopswrapper
 
-from anvio.dbops import ContigsSuperclass
+from anvio.dbops import ContigsSuperclass, ContigsDatabase
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 
 
@@ -75,6 +75,10 @@ def main(args):
 
     if not (args.internal_genomes or args.external_genomes or args.contigs_db or args.profile_db):
         raise ConfigError("You gotta give this program some input files :/ Come on.")
+
+    if args.list_hmm_sources:
+        ContigsDatabase(args.contigs_db).list_available_hmm_sources()
+        sys.exit()
 
     if args.concatenate_genes:
         if not args.return_best_hit:
@@ -125,9 +129,6 @@ def main(args):
             if(missing_hmm_sources):
                 raise ConfigError("At least one of the HMM sources you requested are missing form the HMMs the contigs database "
                                   "knows about :/ Here they are: '%s'" % (', '.join(missing_hmm_sources)))
-
-        if args.list_hmm_sources:
-            hmmops.SequencesForHMMHits(args.contigs_db).list_available_hmm_sources()
 
         if args.list_available_gene_names:
             hmmops.SequencesForHMMHits(args.contigs_db).list_available_gene_names(sources=list(hmm_sources))


### PR DESCRIPTION
With the changes in this PR, `anvi-db-info` will list sources of functional annotation when it is run on contigs databases, `db_variant`, and HMM sources along with number of hits.

The PR also includes some under-the-hood improvements, such as making the `ContigsDatabase` class a bit more talented so all these are possible through a single class rather than initializing classes from other modules:

``` python
dbops.ContigsDatabase(self.db_path).list_gene_caller_sources()
dbops.ContigsDatabase(self.db_path).list_function_sources()
dbops.ContigsDatabase(self.db_path).list_available_hmm_sources()
```


Here is what it shows for IGD:

```
DB Info (no touch)
===============================================
Database Path ................................: CONTIGS.db
Description ..................................: No description is given
Type .........................................: contigs
Variant ......................................: None
Version ......................................: 20


DB Info (no touch also)
===============================================
contigs_db_hash ..............................: d51abf0a
split_length .................................: 20000
kmer_size ....................................: 4
num_contigs ..................................: 4189
total_length .................................: 35766167
num_splits ...................................: 4784
genes_are_called .............................: 1
splits_consider_gene_calls ...................: 1
creation_date ................................: 1466453807.46107
project_name .................................: Infant Gut Contigs from Sharon et al.
gene_level_taxonomy_source ...................:
scg_taxonomy_was_run .........................: 0
external_gene_calls ..........................: 0
external_gene_amino_acid_seqs ................: 0
skip_predict_frame ...........................: 0
scg_taxonomy_database_version ................: None
trna_taxonomy_was_run ........................: 0
trna_taxonomy_database_version ...............: None
modules_db_hash ..............................: 72700e4db2bc
gene_function_sources ........................: KEGG_Module,COG14_CATEGORY,COG14_FUNCTION,KEGG_Class,KOfam

* Please remember that it is never a good idea to change these values. But in some
cases it may be absolutely necessary to update something here, and a programmer
may ask you to run this program and do it. But even then, you should be
extremely careful.

AVAILABLE GENE CALLERS
===============================================
* 'prodigal' (32,265 gene calls)
* 'Ribosomal_RNAs' (9 gene calls)


AVAILABLE FUNCTIONAL ANNOTATION SOURCES
===============================================
* COG14_CATEGORY (21,121 annotations)
* COG14_FUNCTION (21,121 annotations)
* KEGG_Class (2,760 annotations)
* KEGG_Module (2,760 annotations)
* KOfam (14,391 annotations)


AVAILABLE HMM SOURCES
===============================================
* 'Archaea_76' (type 'singlecopy' with 76 models and 404 hits)
* 'Bacteria_71' (type 'singlecopy' with 71 models and 674 hits)
* 'Protista_83' (type 'singlecopy' with 83 models and 100 hits)
* 'Ribosomal_RNAs' (type 'Ribosomal_RNAs' with 12 models and 9 hits)
```