### PR TITLE
A new program: anvi-delete-functions

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -988,7 +988,9 @@ class ContigsSuperclass(object):
             self.init_contig_sequences(gene_caller_ids_of_interest=set(gene_caller_ids_list))
 
         if include_aa_sequences or report_aa_sequences:
-            aa_sequences_dict = ContigsDatabase(self.contigs_db_path).db.get_table_as_dict(t.gene_amino_acid_sequences_table_name)
+            contigs_db = ContigsDatabase(self.contigs_db_path)
+            aa_sequences_dict = contigs_db.db.get_table_as_dict(t.gene_amino_acid_sequences_table_name)
+            contigs_db.disconnect()
         else:
             aa_sequences_dict = None
 

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -137,7 +137,9 @@ class GenomeDescriptions(object):
         # since we know hmm sources in `hmm_sources_in_all_genomes` are common to all genomes,
         # we could use any of those genomes to learn about the specifics of them. here we take
         # the first one from `self.genomes`
-        hmm_sources_info = dbops.ContigsDatabase(list(self.genomes.values())[0]['contigs_db_path']).db.get_table_as_dict(t.hmm_hits_info_table_name)
+        contigs_db = dbops.ContigsDatabase(list(self.genomes.values())[0]['contigs_db_path'])
+        hmm_sources_info = contigs_db.db.get_table_as_dict(t.hmm_hits_info_table_name)
+        contigs_db.disconnect()
 
         if self.list_hmm_sources or self.list_available_gene_names:
             if not len(hmm_sources_in_all_genomes):

--- a/anvio/tables/genefunctions.py
+++ b/anvio/tables/genefunctions.py
@@ -87,7 +87,8 @@ class TableForGeneFunctions(Table):
         self.run.warning(f"Dropping {P('functional annotation source', len(sources_to_drop))} yo: {', '.join(sources_to_drop)}.")
 
         # remove the functions
-        database._exec(f'''DELETE FROM {t.gene_function_calls_table_name} WHERE source IN ({','.join(['"s"' for s in sources_to_drop])})''')
+        sources = ','.join([f'"{s}"' for s in sources_to_drop])
+        database._exec(f'''DELETE FROM {t.gene_function_calls_table_name} WHERE source IN ({sources})''')
 
         # update the self table
         database.remove_meta_key_value_pair('gene_function_sources')

--- a/anvio/tests/run_all_tests.sh
+++ b/anvio/tests/run_all_tests.sh
@@ -124,6 +124,14 @@ anvi-import-functions -c $output_dir/CONTIGS.db \
                       -i $files/example_interpro_output.tsv \
                       -p interproscan
 
+INFO "Listing all available function call sources in the contigs database"
+anvi-export-functions -c $output_dir/CONTIGS.db \
+                      --list-annotation-sources
+
+INFO "Deleting gene functions that do not exist along with those that do"
+anvi-delete-functions -c $output_dir/CONTIGS.db \
+                      --annotation-sources PRINTS,XXX,PIRSF,YYY
+
 INFO "Importing gene function calls INCREMENTALLY using a TAB-delimited default input matrix"
 anvi-import-functions -c $output_dir/CONTIGS.db \
                       -i $files/example_gene_functions_input_matrix.txt
@@ -132,10 +140,6 @@ INFO "REPLACING gene function calls using a TAB-delimited default input matrix"
 anvi-import-functions -c $output_dir/CONTIGS.db \
                       -i $files/example_gene_functions_input_matrix.txt \
                       --drop-previous-annotations
-
-INFO "Listing all available function call sources in the contigs database"
-anvi-export-functions -c $output_dir/CONTIGS.db \
-                      --list-annotation-sources
 
 INFO "Export all functional annotations"
 anvi-export-functions -c $output_dir/CONTIGS.db \

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3498,7 +3498,12 @@ def get_genes_database_path_for_bin(profile_db_path, collection_name, bin_name):
 
 def get_db_type_and_variant(db_path):
     filesnpaths.is_file_exists(db_path)
-    database = db.DB(db_path, None, ignore_version=True)
+
+    try:
+        database = db.DB(db_path, None, ignore_version=True)
+    except Exception as e:
+        raise ConfigError(f"Someone downstream doesn't like your so called database, '{db_path}'. They say "
+                          f"\"{e}\". Awkward :(")
 
     tables = database.get_table_names()
     if 'self' not in tables:

--- a/bin/anvi-delete-functions
+++ b/bin/anvi-delete-functions
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+
+import anvio
+import anvio.utils as utils
+import anvio.terminal as terminal
+
+from anvio.dbops import ContigsDatabase
+from anvio.errors import ConfigError, FilesNPathsError
+from anvio.tables.genefunctions import TableForGeneFunctions
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2021, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "A. Murat Eren"
+__email__ = "a.murat.eren@gmail.com"
+__requires__ = ["contigs-db", "functions"]
+__description__ = "Remove functional annotation sources from an anvi'o contigs database"
+
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+
+def main(args):
+    A = lambda x: args.__dict__[x] if x in args.__dict__ else None
+    contigs_db_path = A('contigs_db')
+    annotation_sources = A('annotation_sources')
+    list_annotation_sources = A('list_annotation_sources')
+
+    utils.is_contigs_db(contigs_db_path)
+
+    if list_annotation_sources:
+        ContigsDatabase(contigs_db_path).list_function_sources()
+        sys.exit()
+
+    if not annotation_sources:
+        raise ConfigError("You must provide this program with some functional annotation sources to drop :/")
+
+    sources_to_drop = [s.strip() for s in annotation_sources.split(',')]
+
+    functions_table = TableForGeneFunctions(contigs_db_path)
+
+    contigs_db = ContigsDatabase(contigs_db_path)
+    functions_table.drop_functions(database=contigs_db.db, sources_to_drop=sources_to_drop)
+    contigs_db.disconnect()
+
+
+if __name__ == '__main__':
+    from anvio.argparse import ArgumentParser
+    parser = ArgumentParser(description=__description__)
+
+    parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+    parser.add_argument(*anvio.A('annotation-sources'), **anvio.K('annotation-sources', {'help': "One or more functional annotations sources "
+                                        "to drop. If you wish to remove more than one, separate them from each other using a comma character "
+                                        "without a space. For example: 'SOURCE_1,SOURCE_2,SOURCE_3'."}))
+    parser.add_argument(*anvio.A('list-annotation-sources'), **anvio.K('list-annotation-sources'))
+
+    args = parser.get_args(parser)
+
+    try:
+        main(args)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)
+    except FilesNPathsError as e:
+        print(e)
+        sys.exit(-2)

--- a/bin/anvi-export-functions
+++ b/bin/anvi-export-functions
@@ -80,6 +80,9 @@ def main(args):
     output.write('\t'.join(t.gene_function_calls_table_structure) + '\n')
     num_entries_reported = 0
     for entry in list(functions_dict.values()):
+        if entry['e_value'] == None:
+            entry['e_value'] = 0.0
+
         output.write('\t'.join([str(entry[key]) for key in t.gene_function_calls_table_structure]) + '\n')
         num_entries_reported += 1
     output.close()


### PR DESCRIPTION
This PR includes a new program that's been needed for a while, `anvi-delete-functions`, that removes one or more functional annotation sources from a contigs database.

Related to #1633.