### PR TITLE
Ability to run `anvi-run-hmms` with multiple installed HMM profiles

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2179,7 +2179,7 @@ D = {
                 ),
     'installed-hmm-profile': (
             ['-I', '--installed-hmm-profile'],
-            {'metavar': 'HMM PROFILE NAME'}
+            {'metavar': 'HMM PROFILE NAME(S)'}
                 ),
     'min-contig-length': (
             ['-M', '--min-contig-length'],

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -65,7 +65,7 @@ def remove_spaces(text):
     return text
 
 
-def pluralize(word, number, suffix_for_plural="s", suffix_for_singular=None, prefix_for_singular="a single"):
+def pluralize(word, number, suffix_for_plural="s", suffix_for_singular=None, prefix_for_singular="a single", alt=None):
     """Pluralize a given word mindfully.
 
     We often run into a situation where the word of choice depends on the number of items
@@ -86,6 +86,11 @@ def pluralize(word, number, suffix_for_plural="s", suffix_for_singular=None, pre
 
     >>> f"You have {pluralize('sequence', num_sequences_in_fasta_file)} in your FASTA file."
 
+    Alternatively, you can provide this function an `alt`, in which case it would return `word` for singular
+    and `alt` for plural cases:
+
+    >>> f"{pluralize('these do not', number, alt='this does not')}."
+
     Voila.
 
 
@@ -99,15 +104,24 @@ def pluralize(word, number, suffix_for_plural="s", suffix_for_singular=None, pre
         The character that needs to be added to the end of the `word` if plural.
     suffix_for_singular: str, None
         The same for `suffix_for_plural` for singular case.
+    alternative: str, None
+        If you provide an alternative, pluralize will discard every other parameter
+        and will simply return `word` for singular, and `alt` for plural case.
     """
 
     if number > 1:
-        return f"{pretty_print(number)} {word}{suffix_for_plural}"
-    else:
-        if suffix_for_singular:
-            return f"{pretty_print(number)} {word}{suffix_for_singular}"
+        if alt:
+            return alt
         else:
-            return f"{prefix_for_singular} {word}"
+            return f"{pretty_print(number)} {word}{suffix_for_plural}"
+    else:
+        if alt:
+            return word
+        else:
+            if suffix_for_singular:
+                return f"{pretty_print(number)} {word}{suffix_for_singular}"
+            else:
+                return f"{prefix_for_singular} {word}"
 
 
 class Progress:

--- a/bin/anvi-run-hmms
+++ b/bin/anvi-run-hmms
@@ -34,6 +34,7 @@ __resources__ = [("Another description as part of the metagenomic workflow", "ht
 
 run = terminal.Run()
 progress = terminal.Progress()
+P = terminal.pluralize
 
 
 @time_program
@@ -58,15 +59,23 @@ def main(args):
                                                           ', '.join(['%s (%d genes)' % (s, len(sources[s]['genes']))\
                                                                                                     for s in sources])))
     elif args.installed_hmm_profile:
-        if args.installed_hmm_profile == "Transfer_RNAs":
+        args.installed_hmm_profile = [p.strip() for p in args.installed_hmm_profile.split(',') if p.strip()]
+
+        if "Transfer_RNAs" in args.installed_hmm_profile:
             raise ConfigError("Sorry, it is not you, it is anvi'o :/ Transfer RNAs behave identically to HMMs, but "
                               "to run transfer RNA profiles on a contigs database you must use the program "
-                              "`anvi-scan-trnas`.")
-        if args.installed_hmm_profile not in available_hmm_sources:
-            raise ConfigError("You managed to find a profile that is not actually installed :/ Available ones are "
-                              "these: %s." % (', '.join(available_hmm_sources)))
+                              "`anvi-scan-trnas` and not provide it as an installed HMM source to `anvi-run-hmms`.")
 
-        sources = {args.installed_hmm_profile: hmm_data.sources[args.installed_hmm_profile]}
+        missing_installed_hmm_profiles = [p for p in args.installed_hmm_profile if p not in available_hmm_sources]
+        if len(missing_installed_hmm_profiles):
+            n = len(missing_installed_hmm_profiles)
+            m = ', '.join([f'"{p}"' for p in missing_installed_hmm_profiles])
+            raise ConfigError(f"You managed to hit {P('profile', n)} that {P('is', n, alt='are')} not actually installed "
+                              f"({m}) :/ Here are the available profiles: {', '.join(available_hmm_sources)}.")
+
+        sources = {}
+        for profile in args.installed_hmm_profile:
+            sources[profile] = hmm_data.sources[profile]
     else:
         # sources will be loaded from defaults.
         pass

--- a/bin/anvi-run-hmms
+++ b/bin/anvi-run-hmms
@@ -89,8 +89,11 @@ def main(args):
 
 
 if __name__ == '__main__':
+    available_hmm_sources_pretty = '; '.join([f"'{s}' (type: {hmm_data.sources[s]['kind']})" for s in available_hmm_sources])
+
     from anvio.argparse import ArgumentParser
     parser = ArgumentParser(description=__description__)
+
 
     groupA = parser.add_argument_group("DB", "An anvi'o contigs adtabase to populate with HMM hits")
     groupA.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
@@ -99,13 +102,13 @@ if __name__ == '__main__':
                                                       "default anvi'o HMM profiles rather than running them all, this is "
                                                       "your stop.")
     groupB.add_argument(*anvio.A('hmm-profile-dir'), **anvio.K('hmm-profile-dir'))
-    groupB.add_argument(*anvio.A('installed-hmm-profile'), **anvio.K('installed-hmm-profile', {'help': "When you run this\
-                                  program without any parameter, it runs all %d HMM profiles installed on your system. If\
-                                  you want only a specific one to run, you can select it by using this parameter. These\
-                                  are the currently available ones: %s." % \
-                                                (len(available_hmm_sources),
-                                                 ', '.join(['"%s" (type: %s)' % (s, hmm_data.sources[s]['kind']) \
-                                                                                    for s in available_hmm_sources]))}))
+    groupB.add_argument(*anvio.A('installed-hmm-profile'), **anvio.K('installed-hmm-profile',
+                            {'help': f"When you run this program without any parameter, it will run all {len(available_hmm_sources)} "
+                                     f"HMM profiles installed on your system. Using this parameter, you can instruct anvi'o to run "
+                                     f"only one or more of the specific profiles of you choose. You can provide a comma-separated list "
+                                     f"of names for multiple profiles (but in that case don't put a space between each profile name). "
+                                     f"Here is the list of installed profiles available to you: are the currently available ones: "
+                                     f"{available_hmm_sources_pretty}."}))
     groupC = parser.add_argument_group("tRNAs", "Through this program you can also scan Transfer RNA sequences in your "
                                                 "contigs database for free (instead of running `anvi-scan-trnas` later).")
     groupC.add_argument(*anvio.A('also-scan-trnas'), **anvio.K('also-scan-trnas'))


### PR DESCRIPTION
This PR enables this use of `anvi-run-hmms`:

```
anvi-run-hmms -c CONTIGS.db --just-do-it -I Ribosomal_RNA_16S,Protista_83,Bacteria_71
```

Which was limited to a single source at a time.

This is a seamless change that does not affect anything, including our Snakemake workflows.