### PR TITLE
Fix for Issue 1654 (bug with anvi-compute-functional-enrichment on metagenome mode modules.txt)

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -4495,6 +4495,11 @@ class KeggModuleEnrichment(KeggContext):
             samples_with_mod_df = modules_df.query(query_string)
             if samples_with_mod_df.shape[0] == 0:
                 continue
+            # if we are working with module data from metagenomes, we may have multiple complete copies of the module in
+            # the same sample. We drop these duplicates before proceeding.
+            duplicates = samples_with_mod_df.index.duplicated()
+            samples_with_mod_df = samples_with_mod_df[~duplicates]
+            
             mod_name = samples_with_mod_df['module_name'][0]
             output_dict[mod_name] = {}
             output_dict[mod_name]['KEGG_MODULE'] = mod_name


### PR DESCRIPTION
In #1654 I reported a bug causing `anvi-compute-functional-enrichment` to crash when processing input from `anvi-estimate-metabolism --metagenome-mode`. The problem was that multiple contigs in the same metagenome could have the same module complete, resulting in rows with duplicate indices in one of our dataframes, which in turn caused issues when accessing the module name from that data structure.

I fixed it by dropping the duplicate modules - we only need one complete module per metagenome sample to consider that module 'present' in the sample. Tested it and it works - and I also made sure it does not affect the enrichment results for non-metagenomes.

One day when we improve the model behind `anvi-compute-functional-enrichment`, we should consider if we can instead take advantage of these modules which are present in multiple copies in a metagenome, since it makes sense that these modules should be more enriched than those in just one copy.

![Alt Text](https://media.giphy.com/media/zvPijis9AXQ7S/giphy.gif)
