### PR TITLE
adding aa_seq to external-gene-calls output

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1135,7 +1135,7 @@ class ContigsSuperclass(object):
         if output_file_path_external_gene_calls:
             utils.store_dict_as_TAB_delimited_file(sequences_dict,
                                                    output_file_path_external_gene_calls,
-                                                   headers=['gene_callers_id', 'contig', 'start', 'stop', 'direction', 'partial', 'call_type', 'source', 'version'])
+                                                   headers=['gene_callers_id', 'contig', 'start', 'stop', 'direction', 'partial', 'call_type', 'source', 'version', 'aa_sequence'])
             self.run.info('Output external gene calls', output_file_path_external_gene_calls)
 
         if len(skipped_gene_calls):

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -987,7 +987,7 @@ class ContigsSuperclass(object):
         if not len(self.contig_sequences) or not set(gene_caller_ids_list).issubset(self.gene_caller_ids_included_in_contig_sequences_initialized):
             self.init_contig_sequences(gene_caller_ids_of_interest=set(gene_caller_ids_list))
 
-        if include_aa_sequences or report_aa_sequences:
+        if include_aa_sequences or report_aa_sequences or output_file_path_external_gene_calls:
             contigs_db = ContigsDatabase(self.contigs_db_path)
             aa_sequences_dict = contigs_db.db.get_table_as_dict(t.gene_amino_acid_sequences_table_name)
             contigs_db.disconnect()
@@ -1062,7 +1062,7 @@ class ContigsSuperclass(object):
             gene_call['length'] = gene_call['stop'] - gene_call['start']
             gene_call['rev_compd'] = rev_compd
 
-            if include_aa_sequences or report_aa_sequences:
+            if include_aa_sequences or report_aa_sequences or output_file_path_external_gene_calls:
                 if gene_callers_id in aa_sequences_dict:
                     gene_call['aa_sequence'] = aa_sequences_dict[gene_callers_id]['sequence']
                 else:


### PR DESCRIPTION
Hey everyone,

I added the amino acid sequence to the `external-gene-calls.txt` that is exported from `anvi-get-sequences-for-gene-calls --external-gene-calls`. IMO I don't think it hurts to always include it in the `external-gene-calls.txt` in this context. Looking forward to your thoughts!

Here is a reproducible example below demonstrating that whether or not the `--get-aa-sequences` parameter is called or not with ` --external-gene-calls` the `external-gene-calls.txt` will report the associated aa sequence:

Download infant gut
```
# Download and decompress infant gut tutorial
wget https://ndownloader.figshare.com/files/26218961 -O INFANT-GUT-TUTORIAL.tar.gz
tar -zxvf INFANT-GUT-TUTORIAL.tar.gz && cd INFANT-GUT-TUTORIAL
anvi-migrate --migrate-dbs-safely *.db

# make some random gene-caller-ids
echo -e "3\n77\n365" > gene_callers_ids.txt
```

Get aa sequences with external-gene-calls:
```
$ anvi-get-sequences-for-gene-calls -c CONTIGS.db -o seq.fasta \
		                    --external-gene-calls external_gene_calls.txt  \
				   --gene-caller-ids gene_callers_ids.txt \
				   --get-aa-sequences

$ cat seq.fasta
>Day17a_QCcontig1_365
MAPVKTNIEQALETMKASGLKYTKKRELLMSYLIKRNRYVSAREVYEFMNETFKGVSYDTVYRNLHDFERLELLEKTELNGEQKFRFRCCQEVEHHHHFICTVCGKTEEIHMCPMNFFEE
QLKGCSIEGHRFEILGRCADCCEK
>Day17a_QCcontig1_3
MSKIGFIGTGVMGKSIIRNMMKNNLSVNVYNRTKSKTDDLVAEGAVWYDTPKAIAEASDIIFTMVGFPSDVEGVYFNETGIFQADLTGKIVVDLTTSTPTLAEKIAKKAAEVGAHALDAP
VSGGDLGAKNGTLTIMVGGDQESYETVLPIFKTFGKTFMLHGSAGKGQHTKMANQLMIAGTMTGLTEMLVYANATGLTLEKVLETVGGGSAANWSLSNYGPRILKEDYTPGFFVKHFIKD
LKIALDEAKKLDLPLPATQKATELYESLADKGFENDGTQALIKLWWTDGKQPTNKN
>Day17a_QCcontig1_77
MSNLLRAEGVSYQVNGRSILSDIDLSFETGSNTTIVGPSGSGKSTFLKILSSLLSPTEGEIFYQEAPITTMPIETYRQKVSYCFQQPTLFGETVYDNLLFPFTVRQEAFNQEKVVALLQQ
VKLPAAYLEKKIAELSGGERQRVALLRNIIFVPDVLLLDEVTTGLDEESKQIVNQLLNQLNKEQGVTLVRVTHDTEEIQQAQQVIRIVAGKVAPTDGFSS

$ cat external_gene_calls.txt
gene_callers_id	contig	start	stop	direction	partial	call_type	source	version	aa_sequence
3	Day17a_QCcontig1_3	0	891	f	0	1	prodigal	v2.60	MSKIGFIGTGVMGKSIIRNMMKNNLSVNVYNRTKSKTDDLVAEGAVWYDTPKAIAEASDIIFTMVGFPSDVEGVYFNETGIFQADLTGKIVVDLTTSTPTLAEKIAKKAAEVGAHALDAPVSGGDLGAKNGTLTIMVGGDQESYETVLPIFKTFGKTFMLHGSAGKGQHTKMANQLMIAGTMTGLTEMLVYANATGLTLEKVLETVGGGSAANWSLSNYGPRILKEDYTPGFFVKHFIKDLKIALDEAKKLDLPLPATQKATELYESLADKGFENDGTQALIKLWWTDGKQPTNKN
77	Day17a_QCcontig1_77	0	663	f	0	1	prodigal	v2.60	MSNLLRAEGVSYQVNGRSILSDIDLSFETGSNTTIVGPSGSGKSTFLKILSSLLSPTEGEIFYQEAPITTMPIETYRQKVSYCFQQPTLFGETVYDNLLFPFTVRQEAFNQEKVVALLQQVKLPAAYLEKKIAELSGGERQRVALLRNIIFVPDVLLLDEVTTGLDEESKQIVNQLLNQLNKEQGVTLVRVTHDTEEIQQAQQVIRIVAGKVAPTDGFSS
365	Day17a_QCcontig1_365	0	435	f	0	1	prodigal	v2.60	MAPVKTNIEQALETMKASGLKYTKKRELLMSYLIKRNRYVSAREVYEFMNETFKGVSYDTVYRNLHDFERLELLEKTELNGEQKFRFRCCQEVEHHHHFICTVCGKTEEIHMCPMNFFEEQLKGCSIEGHRFEILGRCADCCEK
```

Get nt sequences with external-gene-calls:
```
$ anvi-get-sequences-for-gene-calls -c CONTIGS.db -o seq.fasta \
		                    --external-gene-calls external_gene_calls.txt  \
				   --gene-caller-ids gene_callers_ids.txt 

$ cat seq.fasta
>Day17a_QCcontig1_3
ATGTCTAAAATCGGCTTTATTGGAACGGGTGTCATGGGGAAATCAATTATTCGTAACATGATGAAAAACAATTTATCTGTCAATGTTTACAATCGAACAAAAAGTAAAACAGATGATTTA
GTTGCTGAAGGAGCAGTTTGGTATGATACGCCAAAAGCAATTGCGGAAGCGAGTGATATCATTTTTACAATGGTTGGCTTTCCTTCAGATGTTGAAGGCGTGTATTTTAATGAAACAGGG
ATTTTTCAAGCAGATCTTACAGGTAAAATAGTAGTAGATTTAACCACAAGTACGCCGACCTTGGCTGAAAAGATTGCCAAAAAAGCAGCAGAAGTGGGTGCTCATGCGTTGGATGCGCCA
GTTTCTGGTGGTGACTTAGGTGCTAAAAATGGTACTTTAACAATTATGGTTGGTGGCGATCAAGAAAGTTATGAGACCGTCTTACCAATTTTCAAAACATTTGGTAAAACGTTTATGCTA
CACGGCTCAGCTGGAAAAGGGCAACACACTAAGATGGCGAATCAGTTAATGATTGCAGGCACAATGACCGGTTTGACTGAAATGCTCGTTTATGCAAATGCGACAGGATTAACTTTAGAA
AAAGTTCTGGAAACAGTCGGTGGTGGTAGTGCTGCGAACTGGTCATTAAGTAATTATGGTCCGCGTATTTTAAAAGAAGATTATACGCCAGGCTTTTTTGTTAAACATTTTATCAAAGAT
TTAAAGATTGCGTTAGATGAAGCAAAAAAACTTGACCTTCCATTGCCAGCGACGCAAAAAGCGACAGAATTATATGAAAGCCTTGCAGATAAAGGGTTTGAAAATGATGGCACACAGGCC
TTAATTAAGCTTTGGTGGACAGATGGCAAGCAACCAACGAATAAAAATTAA
>Day17a_QCcontig1_77
ATGAGTAATTTATTGCGAGCAGAAGGCGTGTCTTATCAAGTAAATGGTCGTAGCATTCTTTCTGATATTGATTTGTCATTTGAAACAGGCAGCAATACAACAATTGTTGGTCCTTCAGGT
AGCGGGAAAAGTACATTTTTAAAAATTTTATCTTCATTATTAAGTCCTACAGAAGGCGAAATTTTTTATCAAGAAGCGCCAATTACTACAATGCCAATCGAAACATACCGCCAAAAGGTT
TCTTATTGTTTTCAGCAGCCAACTTTATTTGGTGAAACCGTGTATGATAATTTGTTATTTCCATTTACCGTCAGACAAGAAGCGTTTAATCAGGAAAAAGTCGTGGCATTACTCCAACAA
GTGAAATTGCCCGCTGCTTATCTTGAAAAGAAAATAGCCGAACTCTCTGGTGGTGAGCGACAACGGGTTGCTTTGCTACGAAACATTATTTTTGTACCAGATGTTTTATTATTAGACGAA
GTTACAACGGGATTAGATGAAGAAAGCAAACAGATTGTCAATCAATTGTTAAACCAATTAAACAAAGAGCAAGGAGTCACGCTGGTTCGTGTCACGCATGATACCGAAGAAATTCAGCAA
GCACAGCAAGTGATTCGTATTGTAGCAGGAAAGGTGGCGCCGACAGATGGATTTAGCAGTTAA
>Day17a_QCcontig1_365
ATGGCACCAGTAAAAACCAATATTGAACAAGCCTTAGAAACCATGAAAGCCAGTGGATTAAAATATACTAAAAAACGAGAATTACTGATGAGCTATTTGATTAAGCGAAATCGGTATGTT
TCTGCACGTGAAGTGTATGAATTTATGAATGAAACCTTTAAAGGAGTCAGTTATGATACGGTTTATCGTAACTTGCATGACTTTGAGCGCTTGGAATTGCTGGAAAAAACAGAATTAAAT
GGCGAGCAAAAGTTTCGCTTCCGTTGTTGCCAAGAGGTGGAACATCATCATCACTTTATTTGTACGGTTTGTGGCAAAACGGAAGAAATTCACATGTGTCCGATGAATTTTTTTGAAGAA
CAGTTAAAAGGTTGTTCAATTGAAGGACATCGCTTTGAAATACTTGGTCGTTGTGCCGATTGTTGCGAAAAATAG

$ cat external_gene_calls.txt
gene_callers_id	contig	start	stop	direction	partial	call_type	source	version	aa_sequence
3	Day17a_QCcontig1_3	0	891	f	0	1	prodigal	v2.60	MSKIGFIGTGVMGKSIIRNMMKNNLSVNVYNRTKSKTDDLVAEGAVWYDTPKAIAEASDIIFTMVGFPSDVEGVYFNETGIFQADLTGKIVVDLTTSTPTLAEKIAKKAAEVGAHALDAPVSGGDLGAKNGTLTIMVGGDQESYETVLPIFKTFGKTFMLHGSAGKGQHTKMANQLMIAGTMTGLTEMLVYANATGLTLEKVLETVGGGSAANWSLSNYGPRILKEDYTPGFFVKHFIKDLKIALDEAKKLDLPLPATQKATELYESLADKGFENDGTQALIKLWWTDGKQPTNKN
77	Day17a_QCcontig1_77	0	663	f	0	1	prodigal	v2.60	MSNLLRAEGVSYQVNGRSILSDIDLSFETGSNTTIVGPSGSGKSTFLKILSSLLSPTEGEIFYQEAPITTMPIETYRQKVSYCFQQPTLFGETVYDNLLFPFTVRQEAFNQEKVVALLQQVKLPAAYLEKKIAELSGGERQRVALLRNIIFVPDVLLLDEVTTGLDEESKQIVNQLLNQLNKEQGVTLVRVTHDTEEIQQAQQVIRIVAGKVAPTDGFSS
365	Day17a_QCcontig1_365	0	435	f	0	1	prodigal	v2.60	MAPVKTNIEQALETMKASGLKYTKKRELLMSYLIKRNRYVSAREVYEFMNETFKGVSYDTVYRNLHDFERLELLEKTELNGEQKFRFRCCQEVEHHHHFICTVCGKTEEIHMCPMNFFEEQLKGCSIEGHRFEILGRCADCCEK
```