### PR TITLE
Reducing stringency of anvi-run-kegg-kofams with a new annotation heuristic

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2660,8 +2660,8 @@ D = {
                      "will only look at hits with bitscores > the KEGG threshold * this number. (This is Y.) "
                      "It should be a fraction between 0 and 1 (inclusive)."}
                 ),
-    'skip-relaxation-heuristic':(
-            ['--skip-relaxation-heuristic'],
+    'skip-bitscore-heuristic':(
+            ['--skip-bitscore-heuristic'],
             {'default': False,
              'action': 'store_true',
              'help': "If you just want annotations from KOfam hits that are above the KEGG bitscore "

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2660,6 +2660,13 @@ D = {
                      "will only look at hits with bitscores > the KEGG threshold * this number. (This is Y.) "
                      "It should be a fraction between 0 and 1 (inclusive)."}
                 ),
+    'skip-relaxation-heuristic':(
+            ['--skip-relaxation-heuristic'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "If you just want annotations from KOfam hits that are above the KEGG bitscore "
+                     "threshold, use this flag to skip the mumbo-jumbo we do here to relax those thresholds. "}
+                ),
     'include-metadata': (
             ['--include-metadata'],
             {'default': False,

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2643,6 +2643,23 @@ D = {
              'help': "Use this flag to generate a tab-delimited text file containing the bit scores "
                      "of every KOfam hit that is put in the contigs database."}
                 ),
+    'heuristic-e-value': (
+            ['-E', '--heuristic-e-value'],
+            {'default': 1.0e-5,
+             'metavar': 'FLOAT',
+             'type': float,
+             'help': "When considering hits that didn't quite make the bitscore cut-off for a gene, we "
+                     "will only look at hits with e-values <= this number. (This is X.)"}
+                ),
+    'heuristic-bitscore-fraction': (
+            ['-H', '--heuristic-bitscore-fraction'],
+            {'default': 0.50,
+             'metavar': 'FLOAT',
+             'type': float,
+             'help': "When considering hits that didn't quite make the bitscore cut-off for a gene, we "
+                     "will only look at hits with bitscores > the KEGG threshold * this number. (This is Y.) "
+                     "It should be a fraction between 0 and 1 (inclusive)."}
+                ),
     'include-metadata': (
             ['--include-metadata'],
             {'default': False,

--- a/anvio/docs/programs/anvi-run-kegg-kofams.md
+++ b/anvio/docs/programs/anvi-run-kegg-kofams.md
@@ -1,12 +1,26 @@
 Essentially, this program uses the KEGG database to annotate functions and metabolic pathways in a %(contigs-db)s. More specifically, %(anvi-run-kegg-kofams)s annotates a %(contigs-db)s with HMM hits from KOfam, a database of KEGG Orthologs (KOs). You must set up these HMMs on your computer using %(anvi-setup-kegg-kofams)s before you can use this program.
 
+Running this program is a pre-requisite for metabolism estimation with %(anvi-estimate-metabolism)s. Note that if you are planning to run metabolism estimation, it must be run with the same %(kegg-data)s that is used in this program to annotate KOfam hits.
+
+### How does it work?
+**1) Run an HMM search against KOfam**
 Briefly, what this program does is extract all the gene calls from the %(contigs-db)s and checks each one for hits to the KOfam HMM profiles in your %(kegg-data)s. This can be time-consuming given that the number of HMM profiles is quite large, even more so if the number of genes in the %(contigs-db)s is also large. Multi-threading is a good idea if you have the computational capability to do so.
 
-Many HMM hits will be found, most of them weak. The weak hits will by default be eliminated according to the score thresholds provided by KEGG; that is, only hits with scores above the threshold for a given KO profile will be annotated in the %(contigs-db)s. It is perfectly normal to notice that the number of raw hits found is many, many times larger than the number of annotated KO hits in your database.
+**2) Eliminate weak hits based on bitscore**
+Many HMM hits will be found, most of them weak. The weak hits will by default be eliminated according to the bitscore thresholds provided by KEGG; that is, hits with bitscores below the threshold for a given KO profile will be discarded, and those with bitscores above the threshold will be annotated in the %(contigs-db)s. It is perfectly normal to notice that the number of raw hits found is many, many times larger than the number of annotated KO hits in your database.
 
+**3) Add back valid hits that were missed**
+There is one issue with this practice of removing _all_ KOfam hits below the KEGG bitscore threshold for a given profile. We (and others) have noticed that the KEGG thresholds can sometimes be too stringent, eliminating hits that are actually valid annotations. To solve this problem, we
+have implemented the following heuristic for relaxing the bitscore thresholds and annotating genes that would otherwise go without a valid KO annotation:
+
+For every gene without a KOfam annotation, we examine all the hits with an e-value below X and a bitscore above Y% of the threshold. If those hits are all to a unique KOfam profile, then we annotate the gene call with that KO.
+
+X and Y are parameters that can be modified (see below), but by default the e-value threshold (X) is 1e-05 and the bitscore fraction (Y) is 0.5.
+
+Please note that this strategy is just a heuristic. We have tried to pick default parameters that seemed reasonable but by no means have we comprehensively tested and optimized them. This is why X and Y are mutable so that you can explore different values and see how they work for your data. It is always a good idea to double-check your annotations to make sure they are reasonable and as stringent as you'd like them to be. In addition, if you do not feel comfortable using this heuristic at all, you can always turn this behavior off and rely solely on KEGG's bitscore thresholds. :)
+
+**3) Put annotations in the database**
 In the %(contigs-db)s functions table, annotated KO hits (%(kegg-functions)s) will have the source `KOfam`.
-
-Running this program is a pre-requisite for metabolism estimation with %(anvi-estimate-metabolism)s. Note that if you are planning to run metabolism estimation, it must be run with the same %(kegg-data)s that is used in this program to annotate KOfam hits.
 
 ### Standard usage
 

--- a/anvio/docs/programs/anvi-run-kegg-kofams.md
+++ b/anvio/docs/programs/anvi-run-kegg-kofams.md
@@ -59,10 +59,10 @@ anvi-run-kegg-kofams -c CONTIGS.db --keep-all-hits
 As described above, this program does its best to avoid missing valid annotations by relaxing the bitscore threshold for genes without any annotations. For such a gene, hits with e-value <= X and bitscore > (Y * KEGG threshold) that are all hits to the same KOfam profile are used to annotate the gene with that KO.
 
 **Skip this step entirely**
-If you don't want any previously-eliminated hits to be used for annotation, you can skip this heuristic by using the flag `--skip-relaxation-heuristic`. Then, _only_ hits with bitscores above the KEGG-provided threshold for a given KO will be used for annotation.
+If you don't want any previously-eliminated hits to be used for annotation, you can skip this heuristic by using the flag `--skip-bitscore-heuristic`. Then, _only_ hits with bitscores above the KEGG-provided threshold for a given KO will be used for annotation.
 
 {{ codestart }}
-anvi-run-kegg-kofams -c CONTIGS.db --skip-relaxation-heuristic
+anvi-run-kegg-kofams -c CONTIGS.db --skip-bitscore-heuristic
 {{ codestop }}
 
 **Modify the heuristic parameters**

--- a/anvio/docs/programs/anvi-run-kegg-kofams.md
+++ b/anvio/docs/programs/anvi-run-kegg-kofams.md
@@ -54,3 +54,20 @@ Usually, this program parses out weak HMM hits and keeps only those that are abo
 {{ codestart }}
 anvi-run-kegg-kofams -c CONTIGS.db --keep-all-hits
 {{ codestop }}
+
+### Modifying the bitscore relaxation heuristic
+As described above, this program does its best to avoid missing valid annotations by relaxing the bitscore threshold for genes without any annotations. For such a gene, hits with e-value <= X and bitscore > (Y * KEGG threshold) that are all hits to the same KOfam profile are used to annotate the gene with that KO.
+
+**Skip this step entirely**
+If you don't want any previously-eliminated hits to be used for annotation, you can skip this heuristic by using the flag `--skip-relaxation-heuristic`. Then, _only_ hits with bitscores above the KEGG-provided threshold for a given KO will be used for annotation.
+
+{{ codestart }}
+anvi-run-kegg-kofams -c CONTIGS.db --skip-relaxation-heuristic
+{{ codestop }}
+
+**Modify the heuristic parameters**
+If our default values are too stringent or not stringent enough for your tastes, you can change them! The e-value threshold (X, default: 1e-05) can be set using `-E` or `--heuristic-e-value` and the bitscore fraction (Y, default: 0.50) can be set using `-H` or `--heuristic-bitscore-fraction`. Like so:
+
+{{ codestart }}
+anvi-run-kegg-kofams -c CONTIGS.db -E 1e-15 -H 0.90
+{{ codestop }}

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1079,9 +1079,9 @@ class KeggRunHMMs(KeggContext):
         self.hmm_program = A('hmmer_program') or 'hmmsearch'
         self.keep_all_hits = True if A('keep_all_hits') else False
         self.log_bitscores = True if A('log_bitscores') else False
-        self.skip_relaxation_heuristic = True if A('skip_relaxation_heuristic') else False
-        self.heuristic_e_value = A('heuristic_e_value')
-        self.heuristic_bitscore_fraction = A('heuristic_bitscore_fraction')
+        self.skip_bitscore_heuristic = True if A('skip_bitscore_heuristic') else False
+        self.bitscore_heuristic_e_value = A('heuristic_e_value')
+        self.bitscore_heuristic_bitscore_fraction = A('heuristic_bitscore_fraction')
         self.ko_dict = None # should be set up by setup_ko_dict()
 
         # init the base class
@@ -1299,7 +1299,7 @@ class KeggRunHMMs(KeggContext):
             and a bitscore above Y% of the threshold. If those hits are all to a unique KO profile,
             then we annotate the gene call with that KO.
 
-            X is self.heuristic_e_value, Y is self.heuristic_bitscore_fraction
+            X is self.bitscore_heuristic_e_value, Y is self.bitscore_heuristic_bitscore_fraction
 
         For reasons that are hopefully obvious, this function must be called after parse_kofam_hits(),
         which establishes the self.functions_dict attribute.
@@ -1317,10 +1317,10 @@ class KeggRunHMMs(KeggContext):
 
         self.run.warning("Anvi'o will now re-visit genes without KOfam annotations to see if potentially valid "
                          "functional annotations were missed. These genes will be annotated with a KO only if "
-                         f"all KOfam hits to this gene with e-value <= {self.heuristic_e_value} and bitscore > "
-                         f"({self.heuristic_bitscore_fraction} * KEGG threshold) are hits to the same KO. Just "
+                         f"all KOfam hits to this gene with e-value <= {self.bitscore_heuristic_e_value} and bitscore > "
+                         f"({self.bitscore_heuristic_bitscore_fraction} * KEGG threshold) are hits to the same KO. Just "
                          "so you know what is going on here. If this sounds like A Very Bad Idea to you, then please "
-                         "feel free to turn off this behavior with the flag --skip-relaxation-heuristic or to change "
+                         "feel free to turn off this behavior with the flag --skip-bitscore-heuristic or to change "
                          "the e-value/bitscore parameters (see the help page for more info).")
 
         num_annotations_added = 0
@@ -1346,7 +1346,7 @@ class KeggRunHMMs(KeggContext):
                             hit_bitscore = hits_dict[hit_key]['domain_bit_score']
                         elif self.ko_dict[knum]['score_type'] == 'full':
                             hit_bitscore = hits_dict[hit_key]['bit_score']
-                        if hits_dict[hit_key]['e_value'] <= self.heuristic_e_value and hit_bitscore > (self.heuristic_bitscore_fraction * ko_threshold):
+                        if hits_dict[hit_key]['e_value'] <= self.bitscore_heuristic_e_value and hit_bitscore > (self.bitscore_heuristic_bitscore_fraction * ko_threshold):
                             decent_hit_kos.add(knum)
                             # keep track of hit with lowest e-value we've seen so far
                             if hits_dict[hit_key]['e_value'] <= best_e_value:
@@ -1472,7 +1472,7 @@ class KeggRunHMMs(KeggContext):
 
         # add functions and KEGG modules info to database
         next_key_in_functions_dict = self.parse_kofam_hits(search_results_dict)
-        if not self.skip_relaxation_heuristic:
+        if not self.skip_bitscore_heuristic:
             self.update_dict_for_genes_with_missing_annotations(all_gcids_in_contigs_db, search_results_dict, next_key=next_key_in_functions_dict)
         self.store_annotations_in_db()
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1315,9 +1315,12 @@ class KeggRunHMMs(KeggContext):
         """
 
         num_annotations_added = 0
+        total_num_genes = len(hits_dict.values())
+        self.progress.new("Relaxing bitscore threshold", progress_total_items=total_num_genes)
 
         # for each gene call, check for annotation in self.functions_dict
         for gcid in gcids_list:
+            self.progress.update("Adding back decent hits for gene %s [%d of %d]" % (gcid, self.progress.progress_current_item + 1, total_num_genes))
             if gcid not in self.gcids_to_functions_dict:
                 decent_hit_kos = set()
                 best_e_value = 100 # just an arbitrary positive value that will be larger than any evalue
@@ -1388,7 +1391,10 @@ class KeggRunHMMs(KeggContext):
 
                         next_key += 1
                         num_annotations_added += 1
-
+            self.progress.increment()
+            self.progress.reset()
+            
+        self.progress.end()
         self.run.info("Number of decent hits added back after relaxing bitscore threshold", num_annotations_added)
         self.run.info("Total number of hits in annotation dictionary after adding these back", len(self.functions_dict.keys()))
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1184,8 +1184,9 @@ class KeggRunHMMs(KeggContext):
         self.kegg_module_names_dict = {}
         self.kegg_module_classes_dict = {}
         counter = 0
-        for hmm_hit in search_results_dict.values():
+        for hmm_hit in hits_dict.values():
             knum = hmm_hit['gene_name']
+
             self.functions_dict[counter] = {
                 'gene_callers_id': hmm_hit['gene_callers_id'],
                 'source': 'KOfam',

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1079,6 +1079,7 @@ class KeggRunHMMs(KeggContext):
         self.hmm_program = A('hmmer_program') or 'hmmsearch'
         self.keep_all_hits = True if A('keep_all_hits') else False
         self.log_bitscores = True if A('log_bitscores') else False
+        self.skip_relaxation_heuristic = True if A('skip_relaxation_heuristic') else False
         self.heuristic_e_value = A('heuristic_e_value')
         self.heuristic_bitscore_fraction = A('heuristic_bitscore_fraction')
         self.ko_dict = None # should be set up by setup_ko_dict()
@@ -1393,7 +1394,7 @@ class KeggRunHMMs(KeggContext):
                         num_annotations_added += 1
             self.progress.increment()
             self.progress.reset()
-            
+
         self.progress.end()
         self.run.info("Number of decent hits added back after relaxing bitscore threshold", num_annotations_added)
         self.run.info("Total number of hits in annotation dictionary after adding these back", len(self.functions_dict.keys()))
@@ -1463,7 +1464,8 @@ class KeggRunHMMs(KeggContext):
 
         # add functions and KEGG modules info to database
         next_key_in_functions_dict = self.parse_kofam_hits(search_results_dict)
-        self.update_dict_for_genes_with_missing_annotations(all_gcids_in_contigs_db, search_results_dict, next_key=next_key_in_functions_dict)
+        if not self.skip_relaxation_heuristic:
+            self.update_dict_for_genes_with_missing_annotations(all_gcids_in_contigs_db, search_results_dict, next_key=next_key_in_functions_dict)
         self.store_annotations_in_db()
 
         # If requested, store bit scores of each hit in file

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1295,8 +1295,9 @@ class KeggRunHMMs(KeggContext):
 
         # for each gene call, check for annotation in self.functions_dict
         for gcid in gcids_list:
-            pass
-        # if no annotation, get all hits for gene caller id from hits_dict
+            if gcid not in self.gcids_to_hits_dict:
+                # if no annotation, get all hits for gene caller id from hits_dict
+                
         # get set of hits that fit parameters
         # if unique KO, add annotation with best e-value to self.functions_dict
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1210,6 +1210,12 @@ class KeggRunHMMs(KeggContext):
                         mod_name_annotation += "!!!" + names[mod]
                     else:
                         mod_name_annotation = names[mod]
+            if knum not in self.ko_dict:
+                raise ConfigError("Something went wrong while parsing the KOfam HMM hits. It seems that KO "
+                                  f"{knum} is not in the noise cutoff dictionary for KOs. That means we do "
+                                  "not know how to distinguish strong hits from weak ones for this KO. "
+                                  "Anvi'o will fail now :( Please contact a developer about this error to "
+                                  "get this mess fixed. ")
 
                 self.kegg_module_names_dict[counter] = {
                     'gene_callers_id': hmm_hit['gene_callers_id'],

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1264,7 +1264,7 @@ class KeggRunHMMs(KeggContext):
         # If requested, store bit scores of each hit in file
         if self.log_bitscores:
             self.bitscore_log_file = os.path.splitext(os.path.basename(self.contigs_db_path))[0] + "_bitscores.txt"
-            anvio.utils.store_dict_as_TAB_delimited_file(bitscore_dict, self.bitscore_log_file, key_header='entry_id')
+            anvio.utils.store_dict_as_TAB_delimited_file(search_results_dict, self.bitscore_log_file, key_header='entry_id')
             self.run.info("Bit score information file: ", self.bitscore_log_file)
 
         # mark contigs db with hash of modules.db content for version tracking

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1390,6 +1390,7 @@ class KeggRunHMMs(KeggContext):
                         num_annotations_added += 1
 
         self.run.info("Number of decent hits added back after relaxing bitscore threshold", num_annotations_added)
+        self.run.info("Total number of hits in annotation dictionary after adding these back", len(self.functions_dict.keys()))
 
 
     def store_annotations_in_db(self):

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1186,6 +1186,7 @@ class KeggRunHMMs(KeggContext):
         self.kegg_module_names_dict = {}
         self.kegg_module_classes_dict = {}
         self.gcids_to_hits_dict = {}
+        self.gcids_to_functions_dict = {}
         counter = 0
         num_hits_removed = 0
         for hmm_hit in hits_dict.values():
@@ -1224,10 +1225,10 @@ class KeggRunHMMs(KeggContext):
                 }
                 # later, we will need to know if a particular gene call has hits or not. So here we are just saving for each
                 # gene caller id the keys for its corresponding hits in the function dictionary.
-                if gcid not in self.gcids_to_hits_dict:
-                    self.gcids_to_hits_dict[gcid] = [counter]
+                if gcid not in self.gcids_to_functions_dict:
+                    self.gcids_to_functions_dict[gcid] = [counter]
                 else:
-                    self.gcids_to_hits_dict[gcid].append(counter)
+                    self.gcids_to_functions_dict[gcid].append(counter)
 
                 # add associated KEGG module information to database
                 mods = self.kegg_modules_db.get_modules_for_knum(knum)
@@ -1295,9 +1296,9 @@ class KeggRunHMMs(KeggContext):
 
         # for each gene call, check for annotation in self.functions_dict
         for gcid in gcids_list:
-            if gcid not in self.gcids_to_hits_dict:
+            if gcid not in self.gcids_to_functions_dict:
                 # if no annotation, get all hits for gene caller id from hits_dict
-                
+
         # get set of hits that fit parameters
         # if unique KO, add annotation with best e-value to self.functions_dict
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1264,6 +1264,35 @@ class KeggRunHMMs(KeggContext):
         self.run.info("Number of hits remaining in annotation dict ", len(self.functions_dict.keys()))
 
 
+    def update_dict_for_genes_with_missing_annotations(self, gcids_list, hits_dict):
+        """This function adds functional annotations for genes with missing hits to the dictionary.
+
+        The reason this is necessary is that the bitscore thresholds can be too stringent, causing
+        us to miss legitimate annotations. To find these annotations, we adopt the following heuristic:
+            For every gene without a KOfam annotation, we examine all the hits with an e-value below X
+            and a bitscore above Y% of the threshold. If those hits are all to a unique KO profile,
+            then we annotate the gene call with that KO.
+
+        For reasons that are hopefully obvious, this function must be called after parse_kofam_hits(),
+        which establishes the self.functions_dict attribute.
+
+        PARAMETERS
+        ===========
+        gcids_list : list
+            The list of gene caller ids in the contigs database. We will use this to figure out which
+            genes have no annotations
+        hits_dict : dictionary
+            The output from the hmmsearch parser, which should contain all hits (ie, weak hits not yet removed)
+        """
+
+        # for each gene call, check for annotation in self.functions_dict
+        for gcid in gcids_list:
+            pass
+        # if no annotation, get all hits for gene caller id from hits_dict
+        # get set of hits that fit parameters
+        # if unique KO, add annotation with best e-value to self.functions_dict
+
+
     def store_annotations_in_db(self):
         """Takes the dictionary of function annotations (already parsed, if necessary) and puts them in the DB.
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1450,8 +1450,8 @@ class KeggRunHMMs(KeggContext):
         search_results_dict = parser.get_search_results()
 
         # add functions and KEGG modules info to database
-        self.parse_kofam_hits(search_results_dict)
-        self.update_dict_for_genes_with_missing_annotations(all_gcids_in_contigs_db, search_results_dict, next_key=counter)
+        next_key_in_functions_dict = self.parse_kofam_hits(search_results_dict)
+        self.update_dict_for_genes_with_missing_annotations(all_gcids_in_contigs_db, search_results_dict, next_key=next_key_in_functions_dict)
         self.store_annotations_in_db()
 
         # If requested, store bit scores of each hit in file

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1079,6 +1079,8 @@ class KeggRunHMMs(KeggContext):
         self.hmm_program = A('hmmer_program') or 'hmmsearch'
         self.keep_all_hits = True if A('keep_all_hits') else False
         self.log_bitscores = True if A('log_bitscores') else False
+        self.heuristic_e_value = A('heuristic_e_value')
+        self.heuristic_bitscore_fraction = A('heuristic_bitscore_fraction')
         self.ko_dict = None # should be set up by setup_ko_dict()
 
         # init the base class
@@ -1296,6 +1298,8 @@ class KeggRunHMMs(KeggContext):
             and a bitscore above Y% of the threshold. If those hits are all to a unique KO profile,
             then we annotate the gene call with that KO.
 
+            X is self.heuristic_e_value, Y is self.heuristic_bitscore_fraction
+
         For reasons that are hopefully obvious, this function must be called after parse_kofam_hits(),
         which establishes the self.functions_dict attribute.
 
@@ -1330,7 +1334,7 @@ class KeggRunHMMs(KeggContext):
                             hit_bitscore = hits_dict[hit_key]['domain_bit_score']
                         elif self.ko_dict[knum]['score_type'] == 'full':
                             hit_bitscore = hits_dict[hit_key]['bit_score']
-                        if hits_dict[hit_key]['e_value'] <= 1.0e-5 and hit_bitscore > (.50 * ko_threshold):
+                        if hits_dict[hit_key]['e_value'] <= self.heuristic_e_value and hit_bitscore > (self.heuristic_bitscore_fraction * ko_threshold):
                             decent_hit_kos.add(knum)
                             # keep track of hit with lowest e-value we've seen so far
                             if hits_dict[hit_key]['e_value'] <= best_e_value:

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1320,69 +1320,70 @@ class KeggRunHMMs(KeggContext):
                 best_hit_key = None
 
                 # if no annotation, get all hits for gene caller id from hits_dict
-                for hit_key in self.gcids_to_hits_dict[gcid]:
-                    knum = hits_dict[hit_key]['gene_name']
-                    ko_threshold = float(self.ko_dict[knum]['threshold'])
+                if gcid in self.gcids_to_hits_dict:
+                    for hit_key in self.gcids_to_hits_dict[gcid]:
+                        knum = hits_dict[hit_key]['gene_name']
+                        ko_threshold = float(self.ko_dict[knum]['threshold'])
 
-                    # get set of hits that fit specified heuristic parameters
-                    if self.ko_dict[knum]['score_type'] == 'domain':
-                        hit_bitscore = hits_dict[hit_key]['domain_bit_score']
-                    elif self.ko_dict[knum]['score_type'] == 'full':
-                        hit_bitscore = hits_dict[hit_key]['bit_score']
-                    if hits_dict[hit_key]['e_value'] <= 1.0e-5 and hit_bitscore > (.50 * ko_threshold):
-                        decent_hit_kos.add(knum)
-                        # keep track of hit with lowest e-value we've seen so far
-                        if hits_dict[hit_key]['e_value'] <= best_e_value:
-                            best_e_value = hits_dict[hit_key]['e_value']
-                            best_hit_key = hit_key
+                        # get set of hits that fit specified heuristic parameters
+                        if self.ko_dict[knum]['score_type'] == 'domain':
+                            hit_bitscore = hits_dict[hit_key]['domain_bit_score']
+                        elif self.ko_dict[knum]['score_type'] == 'full':
+                            hit_bitscore = hits_dict[hit_key]['bit_score']
+                        if hits_dict[hit_key]['e_value'] <= 1.0e-5 and hit_bitscore > (.50 * ko_threshold):
+                            decent_hit_kos.add(knum)
+                            # keep track of hit with lowest e-value we've seen so far
+                            if hits_dict[hit_key]['e_value'] <= best_e_value:
+                                best_e_value = hits_dict[hit_key]['e_value']
+                                best_hit_key = hit_key
 
-                # if unique KO, add annotation with best e-value to self.functions_dict
-                if len(decent_hit_kos) == 1:
-                    best_knum = hits_dict[best_hit_key]['gene_name']
-                    ## TODO: WE NEED A GENERIC FUNCTION FOR THIS SINCE IT IS SAME AS ABOVE
-                    self.functions_dict[next_key] = {
-                        'gene_callers_id': gcid,
-                        'source': 'KOfam',
-                        'accession': best_knum,
-                        'function': self.get_annotation_from_ko_dict(best_knum, ok_if_missing_from_dict=True),
-                        'e_value': hits_dict[best_hit_key]['e_value'],
-                    }
-                    # we may never access this downstream but let's add to it to be consistent
-                    self.gcids_to_functions_dict[gcid] = [next_key]
-
-                    # add associated KEGG module information to database
-                    mods = self.kegg_modules_db.get_modules_for_knum(best_knum)
-                    names = self.kegg_modules_db.get_module_names_for_knum(best_knum)
-                    classes = self.kegg_modules_db.get_module_classes_for_knum_as_list(best_knum)
-
-                    if mods:
-                        mod_annotation = "!!!".join(mods)
-                        mod_class_annotation = "!!!".join(classes) # why do we split by '!!!'? Because that is how it is done in COGs. So so sorry. :'(
-                        mod_name_annotation = ""
-
-                        for mod in mods:
-                            if mod_name_annotation:
-                                mod_name_annotation += "!!!" + names[mod]
-                            else:
-                                mod_name_annotation = names[mod]
-
-                        self.kegg_module_names_dict[next_key] = {
+                    # if unique KO, add annotation with best e-value to self.functions_dict
+                    if len(decent_hit_kos) == 1:
+                        best_knum = hits_dict[best_hit_key]['gene_name']
+                        ## TODO: WE NEED A GENERIC FUNCTION FOR THIS SINCE IT IS SAME AS ABOVE
+                        self.functions_dict[next_key] = {
                             'gene_callers_id': gcid,
-                            'source': 'KEGG_Module',
-                            'accession': mod_annotation,
-                            'function': mod_name_annotation,
-                            'e_value': None,
+                            'source': 'KOfam',
+                            'accession': best_knum,
+                            'function': self.get_annotation_from_ko_dict(best_knum, ok_if_missing_from_dict=True),
+                            'e_value': hits_dict[best_hit_key]['e_value'],
                         }
-                        self.kegg_module_classes_dict[next_key] = {
-                            'gene_callers_id': gcid,
-                            'source': 'KEGG_Class',
-                            'accession': mod_annotation,
-                            'function': mod_class_annotation,
-                            'e_value': None,
-                        }
+                        # we may never access this downstream but let's add to it to be consistent
+                        self.gcids_to_functions_dict[gcid] = [next_key]
 
-                    next_key += 1
-                    num_annotations_added += 1
+                        # add associated KEGG module information to database
+                        mods = self.kegg_modules_db.get_modules_for_knum(best_knum)
+                        names = self.kegg_modules_db.get_module_names_for_knum(best_knum)
+                        classes = self.kegg_modules_db.get_module_classes_for_knum_as_list(best_knum)
+
+                        if mods:
+                            mod_annotation = "!!!".join(mods)
+                            mod_class_annotation = "!!!".join(classes) # why do we split by '!!!'? Because that is how it is done in COGs. So so sorry. :'(
+                            mod_name_annotation = ""
+
+                            for mod in mods:
+                                if mod_name_annotation:
+                                    mod_name_annotation += "!!!" + names[mod]
+                                else:
+                                    mod_name_annotation = names[mod]
+
+                            self.kegg_module_names_dict[next_key] = {
+                                'gene_callers_id': gcid,
+                                'source': 'KEGG_Module',
+                                'accession': mod_annotation,
+                                'function': mod_name_annotation,
+                                'e_value': None,
+                            }
+                            self.kegg_module_classes_dict[next_key] = {
+                                'gene_callers_id': gcid,
+                                'source': 'KEGG_Class',
+                                'accession': mod_annotation,
+                                'function': mod_class_annotation,
+                                'e_value': None,
+                            }
+
+                        next_key += 1
+                        num_annotations_added += 1
 
         self.run.info("Number of decent hits added back after relaxing bitscore threshold", num_annotations_added)
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1189,11 +1189,18 @@ class KeggRunHMMs(KeggContext):
         self.gcids_to_functions_dict = {}
         counter = 0
         num_hits_removed = 0
-        for hmm_hit in hits_dict.values():
+        for hit_key,hmm_hit in hits_dict.items():
             knum = hmm_hit['gene_name']
+            gcid = hmm_hit['gene_callers_id']
             keep = False
 
             self.progress.update("Removing weak hits for %s [%d of %d]" % (knum, self.progress.progress_current_item + 1, total_num_hits))
+
+            # later, we will need to quickly access the hits for each gene call. So we map gcids to the keys in the raw hits dictionary
+            if gcid not in self.gcids_to_hits_dict:
+                self.gcids_to_hits_dict[gcid] = [hit_key]
+            else:
+                self.gcids_to_hits_dict[gcid].append(hit_key)
 
             if knum not in self.ko_dict:
                 self.progress.reset()
@@ -1215,7 +1222,6 @@ class KeggRunHMMs(KeggContext):
                                   f"is unknown to anvi'o: {self.ko_dict[knum]['score_type']}")
 
             if keep or self.keep_all_hits:
-                gcid = hmm_hit['gene_callers_id']
                 self.functions_dict[counter] = {
                     'gene_callers_id': gcid,
                     'source': 'KOfam',

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1315,6 +1315,14 @@ class KeggRunHMMs(KeggContext):
             The next integer key that is available for adding functions to self.functions_dict
         """
 
+        self.run.warning("Anvi'o will now re-visit genes without KOfam annotations to see if potentially valid "
+                         "functional annotations were missed. These genes will be annotated with a KO only if "
+                         f"all KOfam hits to this gene with e-value <= {self.heuristic_e_value} and bitscore > "
+                         f"({self.heuristic_bitscore_fraction} * KEGG threshold) are hits to the same KO. Just "
+                         "so you know what is going on here. If this sounds like A Very Bad Idea to you, then please "
+                         "feel free to turn off this behavior with the flag --skip-relaxation-heuristic or to change "
+                         "the e-value/bitscore parameters (see the help page for more info).")
+
         num_annotations_added = 0
         total_num_genes = len(hits_dict.values())
         self.progress.new("Relaxing bitscore threshold", progress_total_items=total_num_genes)

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1059,7 +1059,7 @@ class KeggSetup(KeggContext):
             self.setup_kegg_snapshot()
 
 
-class KeggRunHMMs(KeggContext):
+class RunKOfams(KeggContext):
     """Class for running `hmmscan` against the KOfam database and adding the resulting hits to contigs DB for later metabolism prediction.
 
     Parameters

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1195,10 +1195,12 @@ class KeggRunHMMs(KeggContext):
                                   "Anvi'o will fail now :( Please contact a developer about this error to "
                                   "get this mess fixed. ")
             # if hit is above the bitscore threshold, we will keep it
-            if self.ko_dict[knum]['score_type'] == 'domain' and hmm_hit['domain_bit_score'] >= self.ko_dict[knum]['threshold']:
-                keep = True
-            elif self.ko_dict[knum]['score_type'] == 'full' and hmm_hit['bit_score'] >= self.ko_dict[knum]['threshold']:
-                keep = True
+            if self.ko_dict[knum]['score_type'] == 'domain':
+                if hmm_hit['domain_bit_score'] >= float(self.ko_dict[knum]['threshold']):
+                    keep = True
+            elif self.ko_dict[knum]['score_type'] == 'full':
+                if hmm_hit['bit_score'] >= float(self.ko_dict[knum]['threshold']):
+                    keep = True
             else:
                 raise ConfigError(f"The KO noise cutoff dictionary for {knum} has a strange score type which "
                                   f"is unknown to anvi'o: {self.ko_dict[knum]['score_type']}")

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1320,6 +1320,8 @@ class KeggRunHMMs(KeggContext):
 
         tmp_directory_path = filesnpaths.get_temp_directory_path()
         contigs_db = ContigsSuperclass(self.args) # initialize contigs db
+        # we will need the gene caller ids later
+        all_gcids_in_contigs_db = contigs_db.genes_in_contigs_dict.keys()
 
         # safety check for previous annotations so that people don't overwrite those if they don't want to
         self.check_hash_in_contigs_db()
@@ -1355,6 +1357,7 @@ class KeggRunHMMs(KeggContext):
 
         # add functions and KEGG modules info to database
         self.parse_kofam_hits(search_results_dict)
+        self.update_dict_for_genes_with_missing_annotations(all_gcids_in_contigs_db, search_results_dict)
         self.store_annotations_in_db()
 
         # If requested, store bit scores of each hit in file

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1184,6 +1184,7 @@ class KeggRunHMMs(KeggContext):
         self.kegg_module_names_dict = {}
         self.kegg_module_classes_dict = {}
         counter = 0
+        num_hits_removed = 0
         for hmm_hit in hits_dict.values():
             knum = hmm_hit['gene_name']
             keep = False
@@ -1246,6 +1247,11 @@ class KeggRunHMMs(KeggContext):
                     }
 
                 counter += 1
+            else:
+                num_hits_removed += 1
+
+        self.run.info("Number of weak hits removed by KOfam parser", num_hits_removed)
+        self.run.info("Number of hits remaining in annotation dict ", len(self.functions_dict.keys()))
 
 
     def store_annotations_in_db(self):

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1177,7 +1177,13 @@ class KeggRunHMMs(KeggContext):
         PARAMETERS
         ===========
         hits_dict : dictionary
-        The output from the hmmsearch parser, which should contain all hits (ie, weak hits not yet removed)
+            The output from the hmmsearch parser, which should contain all hits (ie, weak hits not yet removed)
+
+        RETURNS
+        ========
+        counter : int
+            The number of functions added to self.functions_dict. Useful for downstream functions that want to
+            add to this dictionary, since it is the next available integer key.
         """
 
         total_num_hits = len(hits_dict.values())
@@ -1278,6 +1284,7 @@ class KeggRunHMMs(KeggContext):
         self.run.info("Number of weak hits removed by KOfam parser", num_hits_removed)
         self.run.info("Number of hits remaining in annotation dict ", len(self.functions_dict.keys()))
 
+        return counter
 
     def update_dict_for_genes_with_missing_annotations(self, gcids_list, hits_dict):
         """This function adds functional annotations for genes with missing hits to the dictionary.

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1164,6 +1164,24 @@ class KeggRunHMMs(KeggContext):
         return self.ko_dict[knum]['definition']
 
 
+    def store_annotations_in_db(self):
+        """Takes the dictionary of function annotations (already parsed, if necessary) and puts them in the DB.
+
+        Should be called after the function that parses the HMM hits and creates self.functions_dict :)
+        """
+
+        if self.functions_dict:
+            gene_function_calls_table.create(self.functions_dict)
+            if self.kegg_module_names_dict:
+                gene_function_calls_table.create(self.kegg_module_names_dict)
+            if self.kegg_module_classes_dict:
+                gene_function_calls_table.create(self.kegg_module_classes_dict)
+        else:
+            self.run.warning("KOfam class has no hits to process. Returning empty handed, but still adding KOfam as "
+                             "a functional source.")
+            gene_function_calls_table.add_empty_sources_to_functional_sources({'KOfam'})
+
+
     def process_kofam_hmms(self):
         """This is a driver function for running HMMs against the KOfam database and processing the hits into the provided contigs DB."""
 
@@ -1252,14 +1270,7 @@ class KeggRunHMMs(KeggContext):
 
             counter += 1
 
-        if functions_dict:
-            gene_function_calls_table.create(functions_dict)
-            gene_function_calls_table.create(kegg_module_names_dict)
-            gene_function_calls_table.create(kegg_module_classes_dict)
-        else:
-            self.run.warning("KOfam class has no hits to process. Returning empty handed, but still adding KOfam as "
-                             "a functional source.")
-            gene_function_calls_table.add_empty_sources_to_functional_sources({'KOfam'})
+        self.store_annotations_in_db()
 
         # If requested, store bit scores of each hit in file
         if self.log_bitscores:

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1255,6 +1255,9 @@ class KeggRunHMMs(KeggContext):
         parse_kofam_hits()
         """
 
+        # get an instance of gene functions table
+        gene_function_calls_table = TableForGeneFunctions(self.contigs_db_path, self.run, self.progress)
+
         if self.functions_dict:
             gene_function_calls_table.create(self.functions_dict)
             if self.kegg_module_names_dict:
@@ -1262,8 +1265,8 @@ class KeggRunHMMs(KeggContext):
             if self.kegg_module_classes_dict:
                 gene_function_calls_table.create(self.kegg_module_classes_dict)
         else:
-            self.run.warning("KOfam class has no hits to process. Returning empty handed, but still adding KOfam as "
-                             "a functional source.")
+            self.run.warning("There are no KOfam hits to add to the database. Returning empty handed, "
+                             "but still adding KOfam as a functional source.")
             gene_function_calls_table.add_empty_sources_to_functional_sources({'KOfam'})
 
 
@@ -1286,9 +1289,6 @@ class KeggRunHMMs(KeggContext):
         hmmer = HMMer(target_files_dict, num_threads_to_use=self.num_threads, program_to_use=self.hmm_program)
         hmm_hits_file = hmmer.run_hmmer('KOfam', 'AA', 'GENE', None, None, len(self.ko_dict), self.kofam_hmm_file_path, None, None)
 
-        # get an instance of gene functions table
-        gene_function_calls_table = TableForGeneFunctions(self.contigs_db_path, self.run, self.progress)
-
         if not hmm_hits_file:
             run.info_single("The HMM search returned no hits :/ So there is nothing to add to the contigs database. But "
                              "now anvi'o will add KOfam as a functional source with no hits, clean the temporary directories "
@@ -1300,6 +1300,7 @@ class KeggRunHMMs(KeggContext):
                 self.run.warning("Because you ran this script with the --debug flag, anvi'o will not clean up the temporary "
                                  "directories located at %s and %s. Please be responsible for cleaning up this directory yourself "
                                  "after you are finished debugging :)" % (tmp_directory_path, ', '.join(hmmer.tmp_dirs)), header="Debug")
+            gene_function_calls_table = TableForGeneFunctions(self.contigs_db_path, self.run, self.progress)
             gene_function_calls_table.add_empty_sources_to_functional_sources({'KOfam'})
             return
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1226,7 +1226,7 @@ class KeggRunHMMs(KeggContext):
                     'gene_callers_id': gcid,
                     'source': 'KOfam',
                     'accession': knum,
-                    'function': self.get_annotation_from_ko_dict(hmm_hit['gene_name'], ok_if_missing_from_dict=True),
+                    'function': self.get_annotation_from_ko_dict(knum, ok_if_missing_from_dict=True),
                     'e_value': hmm_hit['e_value'],
                 }
                 # later, we will need to know if a particular gene call has hits or not. So here we are just saving for each
@@ -1253,14 +1253,14 @@ class KeggRunHMMs(KeggContext):
                             mod_name_annotation = names[mod]
 
                     self.kegg_module_names_dict[counter] = {
-                        'gene_callers_id': hmm_hit['gene_callers_id'],
+                        'gene_callers_id': gcid,
                         'source': 'KEGG_Module',
                         'accession': mod_annotation,
                         'function': mod_name_annotation,
                         'e_value': None,
                     }
                     self.kegg_module_classes_dict[counter] = {
-                        'gene_callers_id': hmm_hit['gene_callers_id'],
+                        'gene_callers_id': gcid,
                         'source': 'KEGG_Class',
                         'accession': mod_annotation,
                         'function': mod_class_annotation,

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1202,17 +1202,7 @@ class KeggRunHMMs(KeggContext):
 
         # parse hmmscan output
         parser = parser_modules['search']['hmmer_table_output'](hmm_hits_file, alphabet='AA', context='GENE', program=self.hmm_program)
-        if self.keep_all_hits:
-            run.info_single("All HMM hits will be kept regardless of score.")
-            if self.log_bitscores:
-                search_results_dict, bitscore_dict = parser.get_search_results(return_bitscore_dict=True)
-            else:
-                search_results_dict = parser.get_search_results()
-        else:
-            if self.log_bitscores:
-                search_results_dict, bitscore_dict = parser.get_search_results(noise_cutoff_dict=self.ko_dict, return_bitscore_dict=True)
-            else:
-                search_results_dict = parser.get_search_results(noise_cutoff_dict=self.ko_dict)
+        search_results_dict = parser.get_search_results()
 
         # add functions and KEGG modules info to database
         functions_dict = {}

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -1185,6 +1185,7 @@ class KeggRunHMMs(KeggContext):
         self.functions_dict = {}
         self.kegg_module_names_dict = {}
         self.kegg_module_classes_dict = {}
+        self.gcids_to_hits_dict = {}
         counter = 0
         num_hits_removed = 0
         for hmm_hit in hits_dict.values():
@@ -1213,13 +1214,20 @@ class KeggRunHMMs(KeggContext):
                                   f"is unknown to anvi'o: {self.ko_dict[knum]['score_type']}")
 
             if keep or self.keep_all_hits:
+                gcid = hmm_hit['gene_callers_id']
                 self.functions_dict[counter] = {
-                    'gene_callers_id': hmm_hit['gene_callers_id'],
+                    'gene_callers_id': gcid,
                     'source': 'KOfam',
                     'accession': knum,
                     'function': self.get_annotation_from_ko_dict(hmm_hit['gene_name'], ok_if_missing_from_dict=True),
                     'e_value': hmm_hit['e_value'],
                 }
+                # later, we will need to know if a particular gene call has hits or not. So here we are just saving for each
+                # gene caller id the keys for its corresponding hits in the function dictionary.
+                if gcid not in self.gcids_to_hits_dict:
+                    self.gcids_to_hits_dict[gcid] = [counter]
+                else:
+                    self.gcids_to_hits_dict[gcid].append(counter)
 
                 # add associated KEGG module information to database
                 mods = self.kegg_modules_db.get_modules_for_knum(knum)

--- a/anvio/parsers/hmmer.py
+++ b/anvio/parsers/hmmer.py
@@ -684,9 +684,10 @@ class HMMERTableOutput(Parser):
                         if hit['dom_bit_score'] < float(threshold):
                             keep = False
                     else:
-                        self.run.warning("Oh dear. The HMM profile %s has a strange score_type value: %s. The only accepted values "
-                                         "for this type are 'full' or 'domain', so anvi'o cannot parse the hits to this profile. All hits "
-                                         "will be kept regardless of bit score. You have been warned." % (hit['gene_name'], score_type))
+                        raise ConfigError(f"Oh dear. The HMM profile {hit['gene_name']} has a strange score_type value: "
+                                          f"'{score_type}'. The only accepted values for this type are 'full' or 'domain', "
+                                          "so anvi'o cannot parse the hits to this profile. Please contact a developer for "
+                                          "help.")
 
                     if keep:
                         entry = {'entry_id': entry_id,
@@ -701,17 +702,10 @@ class HMMERTableOutput(Parser):
 
                 elif noise_cutoff_dict and hit['gene_name'] not in noise_cutoff_dict.keys():
                     # this should never happen, in an ideal world where everything is filled with butterflies and happiness
-                    self.run.warning("Hmm. While parsing your HMM hits, it seems the HMM profile %s was not found in the noise cutoff dictionary. "
-                                     "This should probably not ever happen, and you should contact a developer as soon as possible to figure out what "
-                                     "is going on. But for now, anvi'o is going to keep all hits to this profile. Consider those hits with a grain of salt, "
-                                     "as not all of them may be good." % hit['gene_name'])
-                    entry = {'entry_id': entry_id,
-                             'gene_name': hit['gene_name'],
-                             'gene_hmm_id': hit['gene_hmm_id'],
-                             'gene_callers_id': hit['gene_callers_id'],
-                             'e_value': hit['e_value'],
-                             'bit_score': hit['bit_score'],
-                             'domain_bit_score': hit['dom_bit_score']}
+                    raise ConfigError(f"Hmm. While parsing your HMM hits, it seems the HMM profile {hit['gene_name']} was not "
+                                     "found in the noise cutoff dictionary. This should probably not ever happen, and you should "
+                                     "contact a developer as soon as possible to figure out what is going on. But for now, anvi'o "
+                                     "is going to fail in order to avoid adding many garbage hits to your database.")
 
                 else:
                     entry = {'entry_id': entry_id,

--- a/anvio/parsers/hmmer.py
+++ b/anvio/parsers/hmmer.py
@@ -54,21 +54,21 @@ class HMMERStandardOutput(object):
         | ...           ...         ...    ...     ...  ...    ...   ...           ...
         | 2896  Voltage_CLC  PF00654.19    320       1    !  210.9  29.1  1.700000e-66
         | 2897         YkuD  PF03734.13     30       1    !   48.2   0.2  8.400000e-17
-        | 
+        |
         |           i-evalue  hmm_start  hmm_stop hmm_bounds  ali_start  ali_stop  \
         | 0     6.600000e-22          1       237         [.          4       243
         | 1     1.700000e-07          1        95         [.          4        92
         | ...            ...        ...       ...        ...        ...       ...
         | 2896  7.800000e-64          3       352         ..         61       390
         | 2897  3.800000e-14          2       146         .]        327       459
-        | 
+        |
         |      ali_bounds  env_start  env_stop env_bounds  mean_post_prob  \
         | 0            ..          4       254         ..            0.74
         | 1            ..          4       148         ..            0.72
         | ...         ...        ...       ...        ...             ...
         | 2896         ..         59       392         ..            0.94
         | 2897         ..        326       459         ..            0.78
-        | 
+        |
         |       match_state_align              comparison_align             sequence_align
         | 0     vvtGggGFlGrrivkeLlrl...  +v+Gg+G++G++ v +L++ ...  LVLGGAGYIGSHAVDQLISK...
         | 1     vvtGggGFlGrrivkeLlrl...  ++ Gg+GFlG++i k L+++...  IIFGGSGFLGQQIAKILVQR...

--- a/anvio/parsers/hmmer.py
+++ b/anvio/parsers/hmmer.py
@@ -731,7 +731,7 @@ class HMMERTableOutput(Parser):
                 entry_id += 1
                 annotations_dict[entry_id] = entry
 
-        self.run.info("Number of weak hits removed", num_hits_removed)
+        self.run.info("Number of weak hits removed by HMMER parser", num_hits_removed)
         self.run.info("Number of hits in annotation dict ", len(annotations_dict.keys()))
 
 

--- a/bin/anvi-run-kegg-kofams
+++ b/bin/anvi-run-kegg-kofams
@@ -48,6 +48,7 @@ if __name__ == '__main__':
                                                 " > Y * KEGG's threshold (where Y is a float from 0 to 1). If those hits "
                                                 "are all to a unique KO profile, annotate the gene with that KO. Long story "
                                                 "over, you can set X and Y using the parameters below.")
+    groupH.add_argument(*anvio.A('skip-relaxation-heuristic'), **anvio.K('skip-relaxation-heuristic'))
     groupH.add_argument(*anvio.A('heuristic-e-value'), **anvio.K('heuristic-e-value'))
     groupH.add_argument(*anvio.A('heuristic-bitscore-fraction'), **anvio.K('heuristic-bitscore-fraction'))
 

--- a/bin/anvi-run-kegg-kofams
+++ b/bin/anvi-run-kegg-kofams
@@ -30,19 +30,9 @@ if __name__ == '__main__':
     parser = ArgumentParser(description=__description__)
 
     groupR = parser.add_argument_group('REQUIRED INPUT', 'The stuff you need for this to work.')
-    groupO = parser.add_argument_group('OPTIONAL INPUT', "Optional params for a custom experience.")
-
     groupR.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
-    groupO.add_argument(*anvio.A('profile-db'), **anvio.K('profile-db',
-                                                    {'help': "If you only want to annotate gene calls in a subset "
-                                                    "of sequences, you can provide a path to a profile database with "
-                                                    "this flag. In this case, you must also provide a collection "
-                                                    "name so that we know which sequenes to focus on.",
-                                                    'required': False}))
-    groupO.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name',
-                                                    {'help': "Name of collection you want to focus on. Provide this "
-                                                    "(along with a profile db) if you only want to annotate gene calls "
-                                                    "in a certain set of bins."}))
+    
+    groupO = parser.add_argument_group('OPTIONAL INPUT', "Optional params for a custom experience.")
     groupO.add_argument(*anvio.A('kegg-data-dir'), **anvio.K('kegg-data-dir'))
     groupO.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
     groupO.add_argument(*anvio.A('hmmer-program'), **anvio.K('hmmer-program'))

--- a/bin/anvi-run-kegg-kofams
+++ b/bin/anvi-run-kegg-kofams
@@ -21,7 +21,7 @@ __description__ = "Run KOfam HMMs on an anvi'o contigs database"
 
 @time_program
 def main(args):
-    p = kegg.KeggRunHMMs(args)
+    p = kegg.RunKOfams(args)
     p.process_kofam_hmms()
 
 if __name__ == '__main__':

--- a/bin/anvi-run-kegg-kofams
+++ b/bin/anvi-run-kegg-kofams
@@ -48,7 +48,7 @@ if __name__ == '__main__':
                                                 " > Y * KEGG's threshold (where Y is a float from 0 to 1). If those hits "
                                                 "are all to a unique KO profile, annotate the gene with that KO. Long story "
                                                 "over, you can set X and Y using the parameters below.")
-    groupH.add_argument(*anvio.A('skip-relaxation-heuristic'), **anvio.K('skip-relaxation-heuristic'))
+    groupH.add_argument(*anvio.A('skip-bitscore-heuristic'), **anvio.K('skip-bitscore-heuristic'))
     groupH.add_argument(*anvio.A('heuristic-e-value'), **anvio.K('heuristic-e-value'))
     groupH.add_argument(*anvio.A('heuristic-bitscore-fraction'), **anvio.K('heuristic-bitscore-fraction'))
 

--- a/bin/anvi-run-kegg-kofams
+++ b/bin/anvi-run-kegg-kofams
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
     groupR = parser.add_argument_group('REQUIRED INPUT', 'The stuff you need for this to work.')
     groupR.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
-    
+
     groupO = parser.add_argument_group('OPTIONAL INPUT', "Optional params for a custom experience.")
     groupO.add_argument(*anvio.A('kegg-data-dir'), **anvio.K('kegg-data-dir'))
     groupO.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
@@ -39,6 +39,18 @@ if __name__ == '__main__':
     groupO.add_argument(*anvio.A('keep-all-hits'), **anvio.K('keep-all-hits'))
     groupO.add_argument(*anvio.A('log-bitscores'), **anvio.K('log-bitscores'))
     groupO.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
+
+    groupH = parser.add_argument_group('BITSCORE RELAXATION HEURISTIC', "Sometimes, KEGG-provided bitscore thresholds "
+                                                "are too stringent, causing us to miss valid annotations. We apply the "
+                                                "following heuristic to relax those thresholds and annotate genes that "
+                                                "would otherwise miss a valid annotations: for every gene call that is "
+                                                "not annotated, examine hits to that gene with an evalue <= X and a bitscore "
+                                                " > Y * KEGG's threshold (where Y is a float from 0 to 1). If those hits "
+                                                "are all to a unique KO profile, annotate the gene with that KO. Long story "
+                                                "over, you can set X and Y using the parameters below.")
+    groupH.add_argument(*anvio.A('heuristic-e-value'), **anvio.K('heuristic-e-value'))
+    groupH.add_argument(*anvio.A('heuristic-bitscore-fraction'), **anvio.K('heuristic-bitscore-fraction'))
+
 
     args = parser.get_args(parser)
 


### PR DESCRIPTION
Happy Friday, people. In this PR I'd like to present a heuristic for making `anvi-run-kegg-kofams` a bit less stringent.

**Motivation**
It turns out that KEGG's bitscore thresholds (which we use to get rid of weak HMM hits in `anvi-run-kegg-kofams`) are too stringent sometimes, leading us to miss valid KOfam annotations. This is problematic because downstream code, namely `anvi-estimate-metabolism`, relies on these annotations - if we miss valid annotations, then we will underestimate metabolic capability. 

Here's an example. @meren first noticed this issue when examining a pangenome (of 3 genomes), in which certain core gene clusters contained 2 genes with a KOfam annotation but the 3rd gene was not labeled with the KO, even though all 3 genes were annotated with the same COG. Upon examining one such gene cluster, we found that the  gene with the missing KO was extremely similar to the other genes (99% identity), but its HMM hit to the KO was just barely under the bitscore threshold (a score of 679.7, when the threshold was 680.23). Meren lab members can see more details on this example [here](https://github.com/merenlab/lab-fiesta/issues/1242).

**Heuristic**
We want to make sure we are including valid KO annotations like that, without being so permissible that we add garbage annotations to the database. The heuristic that has been implemented (credits to @meren for the idea :)  is as follows:

> For a given gene: if there is no KOfam hit above the bitscore threshold, we examine all the hits with an e-value <= X and a bitscore > Y% of the threshold. If those hits are all to a unique KOfam profile, then we annotate the gene call with that unique KO.

The current default for the e-value threshold (X) is 1e-05 and the current default bitscore fraction (Y%) is 0.5, or 50%. These parameters can be changed; I'll get to that in a second.

**Relevant parameters**
We apply this heuristic by default, but people who don't like this at all can turn it off with the `--skip-relaxation-heuristic` flag. 

Those who want this to happen, but want the heuristic to be more or less stringent can set the e-value threshold (X) with `-E` or the bitscore fraction (Y) with `-H`. 

**Default parameter values**
As I mentioned, the current defaults are an e-value of 1e-05 and a bitscore fraction of 0.5. I have tested these defaults on the same pangenome in which the issue was discovered, and they seem to perform reasonably well. Here is a summary of that investigation (more details can be found in this frighteningly-long comment [here](https://github.com/merenlab/lab-fiesta/issues/1242#issuecomment-778564871)):
- Of 32 core gene clusters that originally had only 1 out of 3 genomes with a KO-annotated gene, 15 gained 2 KO annotations to become a cluster with 3 out of 3 genomes having a KO-annotated gene. Only 1 gained a single KO annotation to become a cluster with 2/3 genomes having that KO annotation.
- Of 46 core gene clusters that originally had 2 out of 3 genomes with a KO-annotation, 24 gained 1 (or more) KO annotations to become a cluster with 3 out of 3 genomes having at least one KO-annotated gene.
- A gene cluster with multiple different KO annotations could be a marker of garbage. Applying this heuristic with default parameters added 3 such gene clusters to the pangenome. 1 of these was valid, but the other 2 contained garbage KO annotations.

In short, these default values do a decent job of adding valid KO annotations that are below the standard KEGG bitscore thresholds. They do not find everything - I saw a few genes that were still not annotated despite having very good alignments to other KOs in the same cluster (and the same COG annotation) - but it is decent. They also do not add too much garbage, as far as I could tell - the two bad annotations that I found while investigating clusters with multiple KOs were the only ones I saw, though there could be more.

However, my testing so far was not very rigorous, and I have no doubt that we could find better thresholds to serve as our defaults. I am currently running a script to make a bunch of pangenomes using annotations with different combinations of the heuristic parameters, and I will compare those results to see if there is a better set of defaults out there. If I find one, I'll update the defaults. (It's unlikely I'll find the most optimal set even after doing this, so I have added a cautionary note to the `anvi-run-kegg-kofams` docs for users to be aware of). 

I do not mind if we merge this PR before I finish testing different parameter combinations - I know at least one person who is waiting to re-run their analyses using this heuristic. In that case, I can make a different PR later to update the defaults if necessary. But if it is a better idea to set the defaults properly first before merging, that is fine with me, too :)