### PR TITLE
Allow users to specify a temporary directory location with --tmp-dir

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -28,6 +28,25 @@ NO_PROGRESS = '--no-progress' in sys.argv
 AS_MARKDOWN = '--as-markdown' in sys.argv
 FIX_SAD_TABLES = '--fix-sad-tables' in sys.argv
 DOCS_PATH = os.path.join(os.path.dirname(__file__), 'docs')
+TMP_DIR = None
+
+# if the user wants to use a non-default tmp directory, we set it here
+if '--tmp-dir' in sys.argv:
+    try:
+        idx = sys.argv.index('--tmp-dir')
+        TMP_DIR = os.path.abspath(sys.argv[idx+1])
+
+        if not os.path.exists(TMP_DIR):
+            os.makedirs(TMP_DIR)
+        if not os.path.isdir(TMP_DIR):
+            raise OSError(f"The path provided to --tmp-dir, {TMP_DIR}, is not a directory...")
+        if not os.access(TMP_DIR, os.W_OK):
+            raise OSError(f"You do not have permission to generate files in '{TMP_DIR}'")
+
+        os.environ['TMPDIR'] = TMP_DIR
+    except Exception as e:
+        print("OSError: ", e)
+        sys.exit()
 
 def P(d, dont_exit=False):
     """Poor man's debug output printer during debugging."""

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -37,7 +37,11 @@ if '--tmp-dir' in sys.argv:
         TMP_DIR = os.path.abspath(sys.argv[idx+1])
 
         if not os.path.exists(TMP_DIR):
-            os.makedirs(TMP_DIR)
+            parent_dir = os.path.dirname(TMP_DIR)
+            if os.access(parent_dir, os.W_OK):
+                os.makedirs(TMP_DIR)
+            else:
+                raise OSError(f"You do not have permission to generate a directory in '{parent_dir}'")
         if not os.path.isdir(TMP_DIR):
             raise OSError(f"The path provided to --tmp-dir, {TMP_DIR}, is not a directory...")
         if not os.access(TMP_DIR, os.W_OK):

--- a/anvio/argparse.py
+++ b/anvio/argparse.py
@@ -184,7 +184,7 @@ class ArgumentParser(argparse.ArgumentParser):
         to see can still be sorted out.
         """
 
-        allowed_ad_hoc_flags = ['--version', '--debug', '--force', '--fix-sad-tables', '--quiet', '--no-progress', '--as-markdown']
+        allowed_ad_hoc_flags = ['--version', '--debug', '--force', '--fix-sad-tables', '--quiet', '--no-progress', '--as-markdown', '--tmp-dir']
 
         args, unknown = parser.parse_known_args()
 
@@ -192,7 +192,11 @@ class ArgumentParser(argparse.ArgumentParser):
         # we we will make argparse complain about those.
         if len([f for f in unknown if f not in allowed_ad_hoc_flags]):
             for f in allowed_ad_hoc_flags:
-                parser.add_argument(f, action='store_true')
+                # handle non-boolean flags
+                if f in ['--tmp-dir']:
+                    parser.add_argument(f)
+                else:
+                    parser.add_argument(f, action='store_true')
             parser.parse_args()
 
         return args


### PR DESCRIPTION
This PR introduces a new ad-hoc flag to anvi'o, `--tmp-dir`, that enables users to specify where they want temporary output files and folders to be generated.

This is accomplished by setting the `$TMPDIR` environment variable to the specified path in `__init__.py`. (FYI, the `$TMPDIR` environment variable is not permanently changed on your system by using the `--tmp-dir` flag; it is only changed for the running program.)

## Motivation
Why do we need this? Users don't always have access to the default `$TMPDIR`, particularly when working on HPC clusters. For example, batch schedulers like SLURM often delete the temporary files that are generated by a job once the job is finished, even if it finished with an error. This can make debugging difficult for anvi'o programs like `anvi-run-hmms` and `anvi-run-kegg-kofams`, which produce logs and intermediate files in the `$TMPDIR`.

## How to use it
For any anvi'o program, you can provide a path to the temporary directory of your choice using the `--tmp-dir` flag. If the directory you provide does not exist, anvi'o will create it for you. Then any temporary folders and files generated during the run of the program will be generated in that directory.

Here is an example:
```
anvi-run-kegg-kofams -c CONTIGS.db -T 4 --just-do-it --tmp-dir TEMP_KOFAMS --debug
```
When this runs, the folder `TEMP_KOFAMS` is generated in the working directory, and after the program finishes, you can find all of its temporary files in there:
![image](https://user-images.githubusercontent.com/10360586/110687290-f67e6e80-81a5-11eb-9d53-52a09f389aaa.png)

Note that in this case we also need to use the `--debug` flag to keep the temporary files around because `anvi-run-kegg-kofams` cleans them up if that flag is not specified. 

## Possible things to improve
Right now catching errors with the `--tmp-dir` path is a bit ugly. Check it out:
```
$ anvi-run-kegg-kofams -c CONTIGS.db -T 4 --just-do-it --tmp-dir / --debug
OSError:  You do not have permission to generate files in '/'
$ anvi-run-kegg-kofams -c CONTIGS.db -T 4 --just-do-it --tmp-dir kegg-metabolism_modules.txt --debug
OSError:  The path provided to --tmp-dir, /Users/iva/Lab/test-kegg/kegg-metabolism_modules.txt, is not a directory...
```
Since this is being handled in `__init__.py`, which is the first anvi'o file to be imported for any anvi'o program, we aren't able to use our nice error handling from `error.py`. 

If anyone has any ideas on how to improve this, or anything else, I would really appreciate it. :)