### PR TITLE
patch for state processing, skipping layers and removing scary toastr warns

### DIFF
--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2464,7 +2464,8 @@ function processState(state_name, state) {
         modifiedItems.push('views')
     }
 
-    if (state.hasOwnProperty('layers') && state['layers'] === serializedState['layers']) { //check if user provides incomplete data against serialized data
+    // if (state.hasOwnProperty('layers') && state['layers'] === serializedState['layers']) { //check if user provides incomplete data against serialized data
+    if (state.hasOwnProperty('layers')) { 
         layers = {};
         for (let key in state['layers'])
         {
@@ -2480,9 +2481,9 @@ function processState(state_name, state) {
         state['layers-order'] = serializedState['layers-order']
     } 
     else {
-        traverseNestedData(serializedState['layers'], state['layers'])
-        state['layers-order'] = serializedState['layers-order']
-        modifiedItems.push('layers, layer order')
+        // traverseNestedData(serializedState['layers'], state['layers'])
+        // state['layers-order'] = serializedState['layers-order']
+        // modifiedItems.push('layers, layer order')
     }
 
     if (state.hasOwnProperty('categorical_data_colors')) {
@@ -2738,10 +2739,9 @@ function processState(state_name, state) {
     buildLegendTables();
 
     current_state_name = state_name;
-
-    if(modifiedItems){
-        toastr.warning(`You can export this updated state as json and see what's been changed :)`)
-        toastr.warning(`It appears the state file (${current_state_name}) you provided may have been missing some key elements. Anvio has done its best to fill in the blanks for you. How nice!`)
+    if(modifiedItems.length > 0){
+        // toastr.warning(`You can export this updated state as json and see what's been changed :)`)
+        // toastr.warning(`It appears the state file (${current_state_name}) you provided may have been missing some key elements. Anvio has done its best to fill in the blanks for you. How nice!`)
     } else {
         toastr.success("State '" + current_state_name + "' successfully loaded.");
     }

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2464,7 +2464,6 @@ function processState(state_name, state) {
         modifiedItems.push('views')
     }
 
-    // if (state.hasOwnProperty('layers') && state['layers'] === serializedState['layers']) { //check if user provides incomplete data against serialized data
     if (state.hasOwnProperty('layers')) { 
         layers = {};
         for (let key in state['layers'])
@@ -2480,11 +2479,6 @@ function processState(state_name, state) {
         state['layers'] = serializedState['layers']
         state['layers-order'] = serializedState['layers-order']
     } 
-    else {
-        // traverseNestedData(serializedState['layers'], state['layers'])
-        // state['layers-order'] = serializedState['layers-order']
-        // modifiedItems.push('layers, layer order')
-    }
 
     if (state.hasOwnProperty('categorical_data_colors')) {
         for (let key in state['categorical_data_colors'])
@@ -2739,12 +2733,8 @@ function processState(state_name, state) {
     buildLegendTables();
 
     current_state_name = state_name;
-    if(modifiedItems.length > 0){
-        // toastr.warning(`You can export this updated state as json and see what's been changed :)`)
-        // toastr.warning(`It appears the state file (${current_state_name}) you provided may have been missing some key elements. Anvio has done its best to fill in the blanks for you. How nice!`)
-    } else {
-        toastr.success("State '" + current_state_name + "' successfully loaded.");
-    }
+    toastr.success("State '" + current_state_name + "' successfully loaded.");
+    
 }
 
 


### PR DESCRIPTION
This is a quick patch to remedy the immediate issues caused by new state processing methods. The main issues addressed here are 
- Anvio's default generated state doesn't provide `layers` names, creating an inherent mismatch against user's `layers` data and causing user's `layers` data to be ignored. This `layers` portion of `processState()` has been removed for now. 

- Current Toastr warning messages relating to state are overly dramatic and potentially wrong. Currently anvio warns users when missing data has been added to state, or when certain elements of user state are compared against anvio's generated state and found to be different. My working assumption had been that if these state elements were different, it was because the user's state data was incomplete. In retrospect it is often the case that user's state elements may contain **more** data than the generated default, and users should not be warned of anything if that's the case. Toastr warnings have been disabled in this patch. 