### PR TITLE
Inspect page speedup (more than 50X for large splits)

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -553,18 +553,12 @@ class BottleApplication(Bottle):
         data['sequence'] = self.interactive.split_sequences[split_name]['sequence']
 
         ## get the variability information dict for split:
-        progress.new('Variability', discard_previous_if_exists=True)
-        progress.update('Collecting info for "%s"' % split_name)
         split_variability_info_dict = self.interactive.get_variability_information_for_split(split_name, skip_outlier_SNVs=self.args.hide_outlier_SNVs)
 
         ## get the indels information dict for split:
-        progress.new('Indels', discard_previous_if_exists=True)
-        progress.update('Collecting info for "%s"' % split_name)
         split_indels_info_dict = self.interactive.get_indels_information_for_split(split_name)
 
-
         for layer in layers:
-            progress.update('Formatting variability data: "%s"' % layer)
             data['layers'].append(layer)
             data['competing_nucleotides'].append(split_variability_info_dict[layer]['competing_nucleotides'])
             data['variability'].append(split_variability_info_dict[layer]['variability'])
@@ -626,8 +620,6 @@ class BottleApplication(Bottle):
 
             data['genes'].append(p)
 
-        progress.end()
-
         return json.dumps(data)
 
 
@@ -643,7 +635,6 @@ class BottleApplication(Bottle):
         for candidate_entry_id in self.interactive.split_name_to_genes_in_splits_entry_ids[split_name]:
             if int(gene_callers_id) == int(self.interactive.genes_in_splits[candidate_entry_id]['gene_callers_id']):
                 entry_id = candidate_entry_id
-
 
         if not entry_id:
             raise ConfigError("Can not find this gene_callers_id in any splits.")

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -605,7 +605,6 @@ class BottleApplication(Bottle):
             p['length'] = p['stop_in_contig'] - p['start_in_contig']
             p['functions'] =  self.interactive.gene_function_calls_dict[gene_callers_id] if gene_callers_id in  self.interactive.gene_function_calls_dict else None
 
-            run.info_single(f"Learned basic properties ({timer.time_elapsed()}). Recovering the AA sequene...")
             # get amino acid sequence for the gene call:
             p['aa_sequence'] = gene_aa_sequences_dict[gene_callers_id]
 

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -102,14 +102,14 @@ function loadAll() {
 
     var endpoint = (gene_mode ? 'charts_for_single_gene' : 'charts');
 
-    info("Sending ajax request for state data");
+    info("Sending ajax request to gather split data");
     $.ajax({
             type: 'POST',
             cache: false,
             url: '/data/' + endpoint + '/' + state['order-by'] + '/' + contig_id,
             data: {'state': JSON.stringify(state)},
             success: function(contig_data) {
-                info("Recieved CONTIGS data from the server");
+                info("Received split data from the server");
                 state = contig_data['state'];
                 page_header = contig_data.title;
                 layers = contig_data.layers;

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -943,6 +943,33 @@ class ContigsSuperclass(object):
         return output
 
 
+    def get_gene_amino_acid_sequence(self, gene_caller_ids):
+        """A much faster way to get back amino acid sequences for genes.
+
+        Paremeters
+        ==========
+        gene_caller_ids : list
+            A list of one or more gene caller ids.
+        """
+
+        if not isinstance(gene_callers_id, list):
+            raise ConfigError("Anvi'o is disappoint. Gene caller ids sent to this function must "
+                              "be of type `list`.")
+
+        contigs_db = ContigsDatabase(self.contigs_db_path)
+        d = contigs_db.db.smart_get(t.gene_amino_acid_sequences_table_name, 'gene_callers_id', gene_caller_ids)
+        contigs_db.disconnect()
+
+        sequences = {}
+        for gene_callers_id in gene_caller_ids:
+            if gene_callers_id in d:
+                sequences[gene_callers_id] = d[gene_callers_id]['sequence']
+            else:
+                sequences[gene_callers_id] = None
+
+        return sequences
+
+
     def get_sequences_for_gene_callers_ids(self, gene_caller_ids_list=[], output_file_path=None, reverse_complement_if_necessary=True, include_aa_sequences=False, flank_length=0,
                                            output_file_path_external_gene_calls=None, simple_headers=False, report_aa_sequences=False, wrap=120, rna_alphabet=False):
 

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -952,7 +952,7 @@ class ContigsSuperclass(object):
             A list of one or more gene caller ids.
         """
 
-        if not isinstance(gene_callers_id, list):
+        if not isinstance(gene_caller_ids, list):
             raise ConfigError("Anvi'o is disappoint. Gene caller ids sent to this function must "
                               "be of type `list`.")
 


### PR DESCRIPTION
While working on some large splits with many genes, I realized that things were working extremely slowly. Thanks to @isaacfink21's logs with timestamps, I found out that the problem was at this stage:

```
(...)
* Sending ajax request to gather split data (2:55:15).
* Received split data from the server (2:56:38).
(...)
```

This one split for instance took 85 seconds to draw. I found out the performance bottleneck was due to the slow recovery of amino acid sequences from the contigs database. Not only there was a function that was very slow at gathering amino acid sequences for genes, but also for each gene anvi'o gathered amino acid sequences one by one, rather than all at once. Changes in this PR solves this problem by implementing a more straightforward function to recover amino acid sequences and doing it all at once for all genes in a given split.

After these changes the sam split took 1 second rather than 85 seconds:

```
(...)
* Sending ajax request to gather split data (3:01:16).
* Received split data from the server (3:01:17).
(...)
```

Well. Unfortunately `v7` suffers from the same issue. So I suggest we release a `v7.1` package :/