### PR TITLE
1719 submodule check

### DIFF
--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -20,7 +20,7 @@
     <script type="text/javascript" src="lib/bootstrap/dist/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="css/main.css" type="text/css" />
 
-    <script type="text/javascript" src="lib/jquery-svgpan/jquery-svgpan.js"></script>
+    <script type="text/javascript" src="libs/jquery-svgpan/jquery-svgpan.js" onerror='alert("jquery dependency failed to load :|")'></script>
     <script type="text/javascript" src="lib/jquery-ui/ui/core.js"></script>
     <script type="text/javascript" src="lib/jquery-ui/ui/widget.js"></script>
     <script type="text/javascript" src="lib/jquery-ui/ui/mouse.js"></script>
@@ -37,8 +37,8 @@
     <script type="text/javascript" src="lib/toastr/build/toastr.min.js"></script>
     <script type="text/javascript" src="lib/JavaScript-MD5/js/md5.js"></script>
 
-    <script type="text/javascript" src="js/utils.js"></script>
     <script type="text/javascript" src="js/main.js"></script>
+    <script type="text/javascript" src="js/utils.js"></script>
     <script type="text/javascript" src="js/tree.js"></script>
     <script type="text/javascript" src="js/mouse-events.js"></script>
     <script type="text/javascript" src="js/constants.js"></script>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -22,25 +22,25 @@
 
     <script type="text/javascript" src="js/error.js"></script>
 
-    <script type="text/javascript" src="libs/jquery-svgpan/jquery-svgpan.js" onerror='alertDependencyError("jquery")''></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/core.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/widget.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/mouse.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/sortable.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/draggable.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/accordion.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/resizable.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/button.js"></script>
-    <script type="text/javascript" src="lib/jquery-ui/ui/position.js"></script>
-    <script type="text/javascript" src="lib/colpick/colpick.js"></script>
-    <script type="text/javascript" src="lib/randomColor/randomColor.js"></script>
-    <script type="text/javascript" src="lib/svg-crowbar/svg-crowbar.js"></script>
-    <script type="text/javascript" src="lib/bootstrap-waitingfor/build/bootstrap-waitingfor.js"></script>
-    <script type="text/javascript" src="lib/toastr/build/toastr.min.js"></script>
-    <script type="text/javascript" src="lib/JavaScript-MD5/js/md5.js"></script>
+    <script type="text/javascript" src="lib/jquery-svgpan/jquery-svgpan.js" onerror='alertDependencyError("jquery-svg")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/core.js" onerror='alertDependencyError("jquery-core")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/widget.js" onerror='alertDependencyError("jquery-widget")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/mouse.js" onerror='alertDependencyError("jquery-mouse")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/sortable.js" onerror='alertDependencyError("jquery-sortable")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/draggable.js" onerror='alertDependencyError("jquery-draggable")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/accordion.js" onerror='alertDependencyError("jquery-accordian")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/resizable.js" onerror='alertDependencyError("jquery-resizable")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/button.js" onerror='alertDependencyError("jquery-button")'></script>
+    <script type="text/javascript" src="lib/jquery-ui/ui/position.js" onerror='alertDependencyError("jquery-position")'></script>
+    <script type="text/javascript" src="lib/randomColor/randomColor.js" onerror='alertDependencyError("random-color")'></script>
+    <script type="text/javascript" src="lib/svg-crowbar/svg-crowbar.js"onerror='alertDependencyError("svg-crowbar")'></script>
+    <script type="text/javascript" src="lib/bootstrap-waitingfor/build/bootstrap-waitingfor.js" onerror='alertDependencyError("bootstrap-waitingfor")'></script>
+    <script type="text/javascript" src="lib/JavaScript-MD5/js/md5.js" onerror='alertDependencyError("md5")'></script>
+    <script type="text/javascript" src="lib/colpick/colpick.js" onerror='alertDependencyError("col-picker")'></script>
+    <script type="text/javascript" src="lib/toastr/build/toastr.min.js" onerror='alertDependencyError("toastr", true)' onload='alertDependencyError(null, true)'></script>
 
-    <script type="text/javascript" src="js/main.js"></script>
     <script type="text/javascript" src="js/utils.js"></script>
+    <script type="text/javascript" src="js/main.js"></script>
     <script type="text/javascript" src="js/tree.js"></script>
     <script type="text/javascript" src="js/mouse-events.js"></script>
     <script type="text/javascript" src="js/constants.js"></script>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -20,7 +20,9 @@
     <script type="text/javascript" src="lib/bootstrap/dist/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="css/main.css" type="text/css" />
 
-    <script type="text/javascript" src="libs/jquery-svgpan/jquery-svgpan.js" onerror='alert("jquery dependency failed to load :|")'></script>
+    <script type="text/javascript" src="js/error.js"></script>
+
+    <script type="text/javascript" src="libs/jquery-svgpan/jquery-svgpan.js" onerror='alertDependencyError("jquery")''></script>
     <script type="text/javascript" src="lib/jquery-ui/ui/core.js"></script>
     <script type="text/javascript" src="lib/jquery-ui/ui/widget.js"></script>
     <script type="text/javascript" src="lib/jquery-ui/ui/mouse.js"></script>

--- a/anvio/data/interactive/js/error.js
+++ b/anvio/data/interactive/js/error.js
@@ -11,7 +11,20 @@
 // * @license GPL-3.0+ <http://opensource.org/licenses/GPL-3.0>
 // */
 
+let ERROR_COUNT = 0
+let FAILED_DEPENDENCIES = []
 
-function alertDependencyError(dependency){
-    alert(`One or more dependencies were unable to be loaded :( The ${dependency} dependency raised this issue.`)
+function alertDependencyError(dependencyError, isFinalDependency){
+
+    if(dependencyError){
+        ERROR_COUNT += 1
+        FAILED_DEPENDENCIES.push(dependencyError)
+    }
+    
+    if(isFinalDependency && ERROR_COUNT){
+        ERROR_COUNT === 1 ? 
+        alert(`${ERROR_COUNT} dependency failed to load :(. The culprit is: ${FAILED_DEPENDENCIES}`)
+        :
+        alert(`${ERROR_COUNT} dependencies failed to load :(. These are the culprits: ${FAILED_DEPENDENCIES}`)
+    }
 }

--- a/anvio/data/interactive/js/error.js
+++ b/anvio/data/interactive/js/error.js
@@ -1,0 +1,17 @@
+// * This file is part of anvi'o (<https://github.com/meren/anvio>).
+// *
+// * Anvi'o is a free software. You can redistribute this program
+// * and/or modify it under the terms of the GNU General Public
+// * License as published by the Free Software Foundation, either
+// * version 3 of the License, or (at your option) any later version.
+// *
+// * You should have received a copy of the GNU General Public License
+// * along with anvi'o. If not, see <http://opensource.org/licenses/GPL-3.0>.
+// *
+// * @license GPL-3.0+ <http://opensource.org/licenses/GPL-3.0>
+// */
+
+
+function alertDependencyError(dependency){
+    alert(`One or more dependencies were unable to be loaded :( The ${dependency} dependency raised this issue.`)
+}

--- a/anvio/data/interactive/js/error.js
+++ b/anvio/data/interactive/js/error.js
@@ -23,8 +23,8 @@ function alertDependencyError(dependencyError, isFinalDependency){
     
     if(isFinalDependency && ERROR_COUNT){ // hacky way of 'iterating' all dependency calls before error messaging  
         ERROR_COUNT === 1 ? 
-        alert(`${ERROR_COUNT} dependency failed to load :(. The culprit is: ${FAILED_DEPENDENCIES}`)
+        alert(`${ERROR_COUNT} dependency failed to load :(. The culprit is: ${FAILED_DEPENDENCIES}. If you are tracking the active codebase, did you remember to run git submodule update --init?`)
         :
-        alert(`${ERROR_COUNT} dependencies failed to load :(. These are the culprits: ${FAILED_DEPENDENCIES}`)
+        alert(`${ERROR_COUNT} dependencies failed to load :(. These are the culprits: ${FAILED_DEPENDENCIES}. If you are tracking the active codebase, did you remember to run git submodule update --init?`)
     }
 }

--- a/anvio/data/interactive/js/error.js
+++ b/anvio/data/interactive/js/error.js
@@ -21,7 +21,7 @@ function alertDependencyError(dependencyError, isFinalDependency){
         FAILED_DEPENDENCIES.push(dependencyError)
     }
     
-    if(isFinalDependency && ERROR_COUNT){
+    if(isFinalDependency && ERROR_COUNT){ // hacky way of 'iterating' all dependency calls before error messaging  
         ERROR_COUNT === 1 ? 
         alert(`${ERROR_COUNT} dependency failed to load :(. The culprit is: ${FAILED_DEPENDENCIES}`)
         :

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -91,10 +91,6 @@ $(window).resize(function() {
     VIEWER_HEIGHT = document.getElementById('svg').clientHeight || document.getElementById('svg').height.baseVal.value;
 });
 
-function alertDependencyError(dependency){
-    alert(`One or more dependencies were unable to be loaded :( The ${dependency} dependency raised this issue.`)
-}
-
 $(document).ready(function() {
 
     $.ajaxPrefilter(function(options) {

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -91,6 +91,10 @@ $(window).resize(function() {
     VIEWER_HEIGHT = document.getElementById('svg').clientHeight || document.getElementById('svg').height.baseVal.value;
 });
 
+function alertDependencyError(dependency){
+    alert(`One or more dependencies were unable to be loaded :( The ${dependency} dependency raised this issue.`)
+}
+
 $(document).ready(function() {
 
     $.ajaxPrefilter(function(options) {


### PR DESCRIPTION
## What 
A basic error messaging framework for dependency load errors for the interactive interface

## Why 
As noted in #1717 , the interactive interface does not currently provide any error messaging prior to all dependencies being loaded, resulting in the user being greeted with an endless 'loading' screen with no context. 

## How 
Anvio attempts to load submodule dependencies in `index.html` before loading any javascript files. A new js file `error.js` has been created (and loaded prior to the submodule calls), which contains the `alertDependencyError` method that each submodule call points to for its `onerror` attribute. `alertDependencyError` keeps track of the total number + names of the failed dependencies, and when the final synchronous submodule call is made, `alertDependencyError` is passed a special argument `isFinalDependency` for either the `onerror` or `onload` attribute, triggering an alert notification for the user. 

## Test
In `index.html`, changing any of the submodule `src` paths and refreshing the interactive interface page wil trigger the alert messaging. 