### PR TITLE
state flexibility 

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -472,10 +472,10 @@ class BottleApplication(Bottle):
                 default_view = self.interactive.default_view
                 default_order = self.interactive.p_meta['default_item_order']
 
-                if state_dict['current-view'] in self.interactive.views:
+                if 'current-view' in state_dict and state_dict['current-view'] in self.interactive.views: # extra checks to accomodate minified states without current-view/order-by data
                     default_view = state_dict['current-view']
 
-                if state_dict['order-by'] in self.interactive.p_meta['item_orders']:
+                if 'order-by' in state_dict and state_dict['order-by'] in self.interactive.p_meta['item_orders']:
                     default_order = state_dict['order-by']
 
                 return json.dumps((state_dict, self.interactive.p_meta['item_orders'][default_order], self.interactive.views[default_view]))

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2360,7 +2360,7 @@ function loadState()
                             console.log(response)
                             alert('looks like the server failed to retrieve your state data :( consider rebooting your interactive session with the --debug flag for additional insights. ')
                         }
-                    }); 
+                    });
             },
         }
     );

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2344,10 +2344,12 @@ function loadState()
                         url: '/state/get/' + state_name,
                         success: function(response) {
                             try{
+                                // console.log('before', response[0])
                                 clusteringData = response[1]['data'];
                                 loadOrderingAdditionalData(response[1]);
                                 changeViewData(response[2]);
                                 processState(state_name, response[0]);
+
                             }catch(e){
                                 console.error("Exception thrown", e.stack);
                                 toastr.error('Failed to parse state data, ' + e);
@@ -2355,8 +2357,11 @@ function loadState()
                                 return;
                             }
                             waitingDialog.hide();
+                        },
+                        error: function(response){
+                            console.log(response)
                         }
-                    });
+                    }); 
             },
         }
     );

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2344,12 +2344,10 @@ function loadState()
                         url: '/state/get/' + state_name,
                         success: function(response) {
                             try{
-                                // console.log('before', response[0])
                                 clusteringData = response[1]['data'];
                                 loadOrderingAdditionalData(response[1]);
                                 changeViewData(response[2]);
                                 processState(state_name, response[0]);
-
                             }catch(e){
                                 console.error("Exception thrown", e.stack);
                                 toastr.error('Failed to parse state data, ' + e);

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2360,6 +2360,7 @@ function loadState()
                         },
                         error: function(response){
                             console.log(response)
+                            alert('looks like the server failed to retrieve your state data :( consider rebooting your interactive session with the --debug flag for additional insights. ')
                         }
                     }); 
             },


### PR DESCRIPTION
this PR updates the bottleroute GET method for state to allow for truly minimal user-supplied state data.  The minimum data required in a `some_state.json` file for the interactive interface to successfully load it is now just `{  "version" : "xx" }`. 

A stopgap alert has also been added for failed state fetch requests. This will eventually be replaced by a more full-featured error landing page. 