### PR TITLE
anvi-script-gen-genome-files updates

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2537,6 +2537,12 @@ D = {
                      "By providing a directory for this parameter you will get, in addition to the structure "
                      "database, a directory containing the raw output for everything."}
                 ),
+    'include-subdirs': (
+            ['--include-subdirs'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Also search subdirectories for files."}
+                ),
     'workflow': (
             ['-w', '--workflow'],
             {'required': False,

--- a/anvio/dbinfo.py
+++ b/anvio/dbinfo.py
@@ -185,6 +185,12 @@ class DBInfo(ABC):
             return database.get_meta_value('version', return_none_if_not_in_table=True)
 
 
+    @property
+    def project_name(self):
+        with self.load_db() as database:
+            return database.get_meta_value('project_name', return_none_if_not_in_table=True)
+
+
     def load_db(self):
         return DB(self.path, None, ignore_version=True)
 

--- a/anvio/dbinfo.py
+++ b/anvio/dbinfo.py
@@ -173,7 +173,6 @@ class DBInfo(ABC):
         with self.load_db() as database:
             return database.get_meta_value('db_variant', return_none_if_not_in_table=True)
 
-
     @property
     def hash(self):
         with self.load_db() as database:
@@ -193,7 +192,6 @@ class DBInfo(ABC):
     def get_self_table(self):
         with DB(self.path, None, ignore_version=True) as database:
             return dict(database.get_table_as_list_of_tuples('self'))
-
 
 
 class ContigsDBInfo(DBInfo):
@@ -291,16 +289,17 @@ class FindAnvioDBs(object):
         this.
     """
 
-    def __init__(self, search_path='.', max_files_and_dirs_to_process=50000, run=Run(), progress=Progress()):
+    def __init__(self, search_path='.', max_files_and_dirs_to_process=50000, depth=3, run=Run(), progress=Progress()):
         self.run = run
         self.progress = progress
 
+        self.depth = int(depth)
         self.search_path = search_path
         self.max_files_and_dirs_to_process = max_files_and_dirs_to_process
 
         self.anvio_dbs = {}
 
-        for db_path, level in self.walk(depth=3):
+        for db_path, level in self.walk():
             db_info = DBInfo(db_path, dont_raise=True)
 
             if db_info is not None:
@@ -323,12 +322,12 @@ class FindAnvioDBs(object):
             yield os.path.join(path, filename)
 
 
-    def walk(self, depth=None):
+    def walk(self):
         self.progress.new('Searching files and directories')
 
         total_file_and_directory_names = 0
 
-        if depth and depth == 1:
+        if self.depth and self.depth == 1:
             filenames = list(self.listdir(self.search_path))
 
             total_file_and_directory_names += len(filenames)
@@ -348,7 +347,7 @@ class FindAnvioDBs(object):
                 self.progress.update(f"processing {total_file_and_directory_names} ...")
 
                 dirlevel = dirpath[top_pathlen:].count(os.path.sep)
-                if depth and dirlevel >= depth - 1:
+                if self.depth and dirlevel >= self.depth - 1:
                     dirnames[:] = []
                 else:
                     for filename in [f for f in filenames if f.endswith('.db')]:

--- a/anvio/docs/programs/anvi-script-gen-genomes-file.md
+++ b/anvio/docs/programs/anvi-script-gen-genomes-file.md
@@ -1,19 +1,36 @@
-This script can automatically generate an external or internal genomes file.
+The primary purpose of this script is to reduce the amount of labor required to generate %(external-genomes)s or %(internal-genomes)s files anvi'o typically uses to learn about your bins and/or genomes.
 
 ## Generating an external genomes file
+
 If you provide an input directory and a name for the output file, then every %(contigs-db)s in that directory will get a line in the resulting %(external-genomes)s file:
 
 ```
-anvi-script-gen-genomes-file --input-dir path/to/dir -e external_genomes.txt
+anvi-script-gen-genomes-file --input-dir path/to/dir \
+                             --output-file external_genomes.txt
 ```
 
-The name of each database will be whatever string is in front of the `*.db` extension, and the `contigs_db_path` column will contain absolute paths.
+Names for genomes in the the resulting external genomes file will be set based on the `project_name` variable, and the `contigs_db_path` column will contain absolute paths.
+
+{:.notice}
+You can learn the current `project_name` and/or change it for a given %(contigs-db)s using the program %(anvi-db-info)s. This variable is set by the program %(anvi-gen-contigs-database)s.
+
+You can also instruct `anvi-script-gen-genomes-file` to include all subdirectories under a given directory path:
+
+```
+anvi-script-gen-genomes-file --input-dir path/to/dir \
+                             --output-file external_genomes.txt \
+                             --include-subdirs
+```
 
 ## Generating an internal genomes file
+
 To get an %(internal-genomes)s file containing all bins from a collection, provide a %(profile-db)s, its corresponding %(contigs-db)s, and the %(collection)s name:
 
-```
-anvi-script-gen-genomes-file -i internal_genomes.txt -c CONTIGS.db -p PROFILE.db -C default
-```
+{{ codestart }}
+anvi-script-gen-genomes-file -c %(contigs-db)s \
+                             -p %(profile-db)s \
+                             -C %(collection)s \
+                             --output-file internal-genomes.txt
+{{ codestop }}
 
 The name of each internal genome will be the same as the bin name, and the path columns will contain absolute paths.

--- a/sandbox/anvi-script-gen-genomes-file
+++ b/sandbox/anvi-script-gen-genomes-file
@@ -31,17 +31,21 @@ __description__ = "Generate an external genomes or internal genomes file"
 
 
 def main(args):
+    if not args.input_dir or args.profile_db:
+        raise ConfigError("You must provide either an input directory (for an external genomes file) or a "
+                          "profile db/contigs db/collection name set (for an internal genomes file). Also, "
+                          "just so you don't forget, we also need an output file path in either case.")
 
     if args.profile_db:
         if not (args.contigs_db and args.collection_name):
             raise ConfigError("Since you provided a profile db, we think you want an internal genomes file, but "
                               "anvi'o needs the corresponding contigs db and a collection name, as well.")
-        if not args.internal_genomes:
+        if not args.output_file:
             raise ConfigError("Please provide an output file path for your internal genomes file using the -i parameter.")
 
-        if filesnpaths.is_file_exists(args.internal_genomes, dont_raise=True):
-            raise ConfigError(f"The internal genomes file path that you provided already exists, and anvi'o will not overwrite "
-                              f"it. Please either remove the existing file or provide a different file path.")
+        if filesnpaths.is_file_exists(args.output_file, dont_raise=True):
+            raise ConfigError("The internal genomes file path that you provided already exists, and anvi'o will not overwrite "
+                              "it. Please either remove the existing file or provide a different file path.")
 
         utils.is_pan_or_profile_db(args.profile_db)
 
@@ -61,7 +65,7 @@ def main(args):
 
         if args.collection_name not in collections.collections_dict:
             raise ConfigError(f"The collection you requested, {args.collection_name}, does not appear to be a "
-                              "valid collection in this profile database.")
+                              f"valid collection in this profile database.")
 
         contig_db_path = os.path.abspath(args.contigs_db)
         profile_db_path = os.path.abspath(args.profile_db)
@@ -74,20 +78,20 @@ def main(args):
             int_genomes_dict[bin_name]['profile_db_path'] = profile_db_path
             int_genomes_dict[bin_name]['contigs_db_path'] = contig_db_path
 
-        utils.store_dict_as_TAB_delimited_file(int_genomes_dict, args.internal_genomes, key_header='name')
+        utils.store_dict_as_TAB_delimited_file(int_genomes_dict, args.output_file, key_header='name')
 
-        run.info("Internal genomes file", args.internal_genomes)
+        run.info("Internal genomes file", args.output_file)
 
     elif args.input_dir:
-        if not args.external_genomes:
+        if not args.output_file:
             raise ConfigError("Please provide an output file path for your external genomes file using the -e parameter.")
 
         if not filesnpaths.is_file_exists(args.input_dir, dont_raise=True):
             raise ConfigError("The directory you provided does not exist :/")
 
-        if filesnpaths.is_file_exists(args.external_genomes, dont_raise=True):
-            raise ConfigError(f"The external genomes file path that you provided already exists, and anvi'o will not overwrite "
-                              f"it. Please either remove the existing file or provide a different file path.")
+        if filesnpaths.is_file_exists(args.output_file, dont_raise=True):
+            raise ConfigError("The external genomes file path that you provided already exists, and anvi'o will not overwrite "
+                              "it. Please either remove the existing file or provide a different file path.")
 
         ext_genomes_dict = {}
         for file in glob.glob(os.path.join(args.input_dir, '*.db')):
@@ -103,33 +107,29 @@ def main(args):
         if not ext_genomes_dict:
             raise ConfigError("No contigs databases were found in the provided input directory.")
 
-        utils.store_dict_as_TAB_delimited_file(ext_genomes_dict, args.external_genomes, key_header='name')
+        utils.store_dict_as_TAB_delimited_file(ext_genomes_dict, args.output_file, key_header='name')
 
-        run.info("External genomes file", args.external_genomes)
+        run.info("External genomes file", args.output_file)
 
-    else:
-        raise ConfigError("You must provide either an input directory (for an external genomes file) or a "
-                          "profile db/contigs db/collection name set (for an internal genomes file). Also, "
-                          "just so you don't forget, we also need an output file path in either case.")
 
 if __name__ == '__main__':
     from anvio.argparse import ArgumentParser
 
     parser = ArgumentParser(description=__description__)
 
-    groupE = parser.add_argument_group("EXTERNAL GENOMES FILE", "Provide a directory, and anvi'o will provide an external genomes "
-                                                                "file containing all contigs dbs in that directory.")
-    groupE.add_argument(*anvio.A('input-dir'), **anvio.K('input-dir'))
-    groupE.add_argument(*anvio.A('external-genomes'), **anvio.K('external-genomes', {'help': "The desired output file path for "
-                                                                "the external genomes file."}))
+    groupA = parser.add_argument_group("EXTERNAL GENOMES", "Provide a directory, and anvi'o will provide an external genomes "
+                                                           "file containing all contigs dbs in that directory.")
+    groupA.add_argument(*anvio.A('input-dir'), **anvio.K('input-dir'))
 
-    groupI = parser.add_argument_group("INTERNAL GENOMES FILE", "Provide a contigs db, profile db, and collection name and anvi'o "
-                                                                "will bestow upon you an internal genomes file for that collection.")
-    groupI.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db', {'required': False}))
-    groupI.add_argument(*anvio.A('profile-db'), **anvio.K('profile-db', {'required': False}))
-    groupI.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
-    groupI.add_argument(*anvio.A('internal-genomes'), **anvio.K('internal-genomes', {'help': "The desired output file path for "
-                                                                "the internal genomes file."}))
+    groupB = parser.add_argument_group("INTERNAL GENOMES", "Provide a contigs db, profile db, and collection name and anvi'o "
+                                                           "will bestow upon you an internal genomes file for that collection.")
+    groupB.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db', {'required': False}))
+    groupB.add_argument(*anvio.A('profile-db'), **anvio.K('profile-db', {'required': False}))
+    groupB.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
+
+
+    groupC = parser.add_argument_group("OUTPUT", "Path for your internal or external genomes file")
+    groupC.add_argument(*anvio.A('output-file'), **anvio.K('output-file'))
 
     args = parser.get_args(parser)
 

--- a/sandbox/anvi-script-gen-genomes-file
+++ b/sandbox/anvi-script-gen-genomes-file
@@ -5,16 +5,15 @@
 
 import os
 import sys
-import glob
 
 import anvio
 import anvio.utils as utils
-import anvio.filesnpaths as filesnpaths
 import anvio.terminal as terminal
 import anvio.ccollections as ccollections
+import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import ConfigError
-from anvio.dbops import ContigsDatabase
+from anvio.dbinfo import FindAnvioDBs
 
 run = terminal.Run()
 progress = terminal.Progress()
@@ -93,19 +92,22 @@ def main(args):
             raise ConfigError("The external genomes file path that you provided already exists, and anvi'o will not overwrite "
                               "it. Please either remove the existing file or provide a different file path.")
 
+        anvio_dbs = FindAnvioDBs(args.input_dir, depth=(1 if not args.include_subdirs else 5)).anvio_dbs
+        contigs_dbs = anvio_dbs['contigs'] if 'contigs' in anvio_dbs else []
+
+        if not len(contigs_dbs):
+            msg = "No contigs databases were found in the input directory :/ "
+            if not args.include_subdirs:
+                msg += ("If you would like to include subdirectories in your search as well (with a max depth of "
+                        "5) you can re-run the same script with the flag `--include-subdirs`.")
+
+            raise ConfigError(msg)
+        else:
+            run.info("Contigs databases", f"{len(contigs_dbs)} found.", mc="green")
+
         ext_genomes_dict = {}
-        for file in glob.glob(os.path.join(args.input_dir, '*.db')):
-            db_path = os.path.abspath(file)
-            db_type = utils.get_db_type(db_path)
-
-            if db_type == 'contigs':
-                contigs_db = ContigsDatabase(db_path, run=terminal.Run(verbose=False), progress=terminal.Progress(verbose=False))
-                db_name = contigs_db.meta['project_name_str']
-                ext_genomes_dict[db_name] = {}
-                ext_genomes_dict[db_name]['contigs_db_path'] = db_path
-
-        if not ext_genomes_dict:
-            raise ConfigError("No contigs databases were found in the provided input directory.")
+        for contigs_db in contigs_dbs:
+            ext_genomes_dict[contigs_db.project_name] = {'contigs_db_path': os.path.abspath(contigs_db.path)}
 
         utils.store_dict_as_TAB_delimited_file(ext_genomes_dict, args.output_file, key_header='name')
 
@@ -120,6 +122,7 @@ if __name__ == '__main__':
     groupA = parser.add_argument_group("EXTERNAL GENOMES", "Provide a directory, and anvi'o will provide an external genomes "
                                                            "file containing all contigs dbs in that directory.")
     groupA.add_argument(*anvio.A('input-dir'), **anvio.K('input-dir'))
+    groupA.add_argument(*anvio.A('include-subdirs'), **anvio.K('include-subdirs'))
 
     groupB = parser.add_argument_group("INTERNAL GENOMES", "Provide a contigs db, profile db, and collection name and anvi'o "
                                                            "will bestow upon you an internal genomes file for that collection.")


### PR DESCRIPTION
Apart from some refactoring for speed improvements, the most important change here is that the script no longer uses `--external-genomes` or `--internal-genomes` parameters to declare the output file, but it uses `--output-file` like many other anvi'o programs.

FYI, @ivagljiva :)