### PR TITLE
Inverse bug fix

### DIFF
--- a/anvio/data/interactive/js/bin.js
+++ b/anvio/data/interactive/js/bin.js
@@ -863,7 +863,7 @@ Bins.prototype.DrawInvertedNodes = function(leaf_list, rect_width){
                 calculatedRectX, // new variable calculated above 
                 p.xy.y,
                 p.size, 
-                rect_width
+                rect_width,
                 inverse_color,
                 inverse_fill_opacity,
                 true


### PR DESCRIPTION

This PR addresses a bug when utilizing inverse-shading in rectophylograms, as caught by @watsonar (thanks!). The bug caused inverse-shaded segments to vary in length based on branch height.

The solution is to calculate the largest x value across all nodes, and apply that value for each shaded area when drawn. 
