### PR TITLE
Unique genes for HMM hits

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1042,10 +1042,18 @@ D = {
             ['--return-best-hit'],
             {'default': False,
              'action': 'store_true',
-             'help': "A bin may contain more than one hit for a gene name in a given HMM source. For instance, there may "
+             'help': "A bin (or genome) may contain more than one hit for a gene name in a given HMM source. For instance, there may "
                      "be multiple RecA hits in a genome bin from Campbell et al.. Using this flag, will go through all of "
                      "the gene names that appear multiple times, and remove all but the one with the lowest e-value. Good "
                      "for whenever you really need to get only a single copy of single-copy core genes from a genome bin."}
+                ),
+    'unique-genes': (
+            ['--unique-genes'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "An HMM source may contain multiple models that can hit the same gene in a given bin or genome. "
+                     "Using this flag, you can ask anvi'o to go through all genes, identify those with multiple hits "
+                     "and report only the most significant hit for each unique gene."}
                 ),
     'max-num-genes-missing-from-bin': (
             ['--max-num-genes-missing-from-bin'],

--- a/anvio/hmmops.py
+++ b/anvio/hmmops.py
@@ -408,6 +408,33 @@ class SequencesForHMMHits:
             return hmm_sequences_dict_for_splits
 
 
+    def filter_hmm_sequences_dict_to_keep_only_unique_gene_hits(self, hmm_sequences_dict_for_splits):
+        """This takes the output of `get_sequences_dict_for_hmm_hits_in_splits`, and goes through every hit
+           to remove hits that resolve to the same gene, and only keeps the one with the smallest e-value.
+
+           Say, if there are multipe HMMs hitting the same gene, this filter will only keep the one that is the
+           most significant.
+        """
+
+        hits_per_gene_caller_id = {}
+        for hit_id in hmm_sequences_dict_for_splits:
+            hit = hmm_sequences_dict_for_splits[hit_id]
+
+            if hit['gene_callers_id'] in hits_per_gene_caller_id:
+                hits_per_gene_caller_id[hit['gene_callers_id']].add(hit_id)
+            else:
+                hits_per_gene_caller_id[hit['gene_callers_id']] = set([hit_id])
+
+        for gene_callers_id in hits_per_gene_caller_id:
+            if len(hits_per_gene_caller_id[gene_callers_id]) > 1:
+                hit_ids_to_remove = [tpl[1] for tpl in sorted([(hmm_sequences_dict_for_splits[hit]['e_value'], hit) \
+                                                                    for hit in hits_per_gene_caller_id[gene_callers_id]])[1:]]
+                for hit_id_to_remove in hit_ids_to_remove:
+                    hmm_sequences_dict_for_splits.pop(hit_id_to_remove)
+
+        return hmm_sequences_dict_for_splits
+
+
     def filter_hmm_sequences_dict_for_splits_to_keep_only_best_hits(self, hmm_sequences_dict_for_splits):
         """This takes the output of `get_sequences_dict_for_hmm_hits_in_splits`, and goes through every hit\
            to identify for each bin_id hits with the same gene name and source. If there are multiple gene\

--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -216,7 +216,17 @@ def main(args):
         hmm_sequences_dict = s.filter_hmm_sequences_dict_for_splits_to_keep_only_best_hits(hmm_sequences_dict)
         CHK()
 
-        run.info('Filtered hits', '%d hits remain after removing weak hits for multiple hits' % (len(hmm_sequences_dict)))
+        run.info('Filtered hits', '%d hits remain after removing weak hits for multiple genes' % (len(hmm_sequences_dict)))
+
+    if args.unique_genes:
+        run.warning("You asked anvi'o for each gene that has multiple hits to report only the best hit, which means, if, "
+                    "say, there are multiple models in your HMM source that match to a single gene, only the one with the "
+                    "lowest e-value will be kept, and others will be removed from your final results.")
+
+        hmm_sequences_dict = s.filter_hmm_sequences_dict_to_keep_only_unique_gene_hits(hmm_sequences_dict)
+        CHK()
+
+        run.info('Filtered hits', '%d hits remain after removing weak hits for multiple models' % (len(hmm_sequences_dict)))
 
     if args.separator:
         separator = args.separator
@@ -301,6 +311,7 @@ if __name__ == '__main__':
 
     groupG = parser.add_argument_group('OPTIONAL', "Everything is optional, but some options are more optional than others.")
     groupG.add_argument(*anvio.A('return-best-hit'), **anvio.K('return-best-hit'))
+    groupG.add_argument(*anvio.A('unique-genes'), **anvio.K('unique-genes'))
     groupG.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     args = parser.get_args(parser)


### PR DESCRIPTION
Working with Roux et al DGR models, @FlorianTrigodet realized that distinct models can hit the same gene multiple times. This PR introduces new functionality for `anvi-get-sequences-for-hmm-hits` so anvi'o can report unique genes.