### PR TITLE
Codon freqs

### DIFF
--- a/bin/anvi-get-codon-frequencies
+++ b/bin/anvi-get-codon-frequencies
@@ -43,6 +43,7 @@ class ReportCodonFrequencies:
         self.return_AA_frequencies_instead = A('return_AA_frequencies_instead')
         self.percent_normalize = A('percent_normalize')
         self.merens_codon_normalization = A('merens_codon_normalization')
+        self.collapse_genes = A('collapse_genes')
         self.output_file_path = A('output_file')
 
         filesnpaths.is_output_file_writable(self.output_file_path)
@@ -86,8 +87,10 @@ class ReportCodonFrequencies:
         else:
             self.c.init_contig_sequences()
 
-        residue_frequencies = {}
         noncoding_genes_skipped = set([])
+        residue_frequencies = {}
+        if self.collapse_genes:
+            residue_frequencies['all'] = Counter()
 
         F = utils.get_list_of_AAs_for_gene_call if self.return_AA_frequencies_instead else utils.get_list_of_codons_for_gene_call
 
@@ -98,7 +101,12 @@ class ReportCodonFrequencies:
                 noncoding_genes_skipped.add(gene_callers_id)
                 continue
 
-            residue_frequencies[gene_callers_id] = Counter(F(gene_call, self.c.contig_sequences))
+            gene_counts = Counter(F(gene_call, self.c.contig_sequences))
+            if self.collapse_genes:
+                residue_frequencies['all'] += gene_counts
+            else:
+                residue_frequencies[gene_callers_id] = gene_counts
+
 
         if self.percent_normalize:
             for gene_callers_id in residue_frequencies:

--- a/bin/anvi-get-codon-frequencies
+++ b/bin/anvi-get-codon-frequencies
@@ -148,6 +148,10 @@ if __name__ == '__main__':
                                                                 which case anvi'o would only return results for a single gene call. If you don't declare\
                                                                 anything, well, you must be prepared to brace yourself if you are working with a very\
                                                                 large contigs database with hundreds of thousands of genes."}))
+    groupC.add_argument('--collapse-genes', default=False, action="store_true", help="By default, codon frequencies are reported on a per-gene basis, meaning "
+                                                                                     "that a frequency is reported for each gene-codon pairing. If you provide "
+                                                                                     "this flag, codon frequencies will instead be collapsed across genes, "
+                                                                                     "such that a single frequency is reported for each codon.")
 
     groupC.add_argument(*anvio.A('return-AA-frequencies-instead'), **anvio.K('return-AA-frequencies-instead'))
     groupC.add_argument(*anvio.A('output-file'), **anvio.K('output-file', {'required': True}))


### PR DESCRIPTION
Here's a little feature addition to `anvi-get-codon-frequencies` called `--collapse-genes` that reports the summed counts across genes, as opposed to the default behavior which is to report counts for each gene.

For example,

`▶▶ anvi-get-codon-frequencies -c HIMB083/CONTIGS.db --merens-codon-normalization -o codon_freqs.txt --collapse`

Yields

```
gene_callers_id	Ala-GCA	Ala-GCC	Ala-GCG	Ala-GCT	Arg-AGA	Arg-AGG	Arg-CGA	Arg-CGC	Arg-CGG	Arg-CGT	Asn-AAC	Asn-AAT	Asp-GAC	Asp-GAT	Cys-TGC	Cys-TGT	Gln-CAA	Gln-CAG	Glu-GAA	Glu-GAG	Gly-GGA	Gly-GGC	Gly-GGG	Gly-GGT	His-CAC	His-CAT	Ile-ATA	Ile-ATC	Ile-ATT	Leu-CTA	Leu-CTC	Leu-CTG	Leu-CTT	Leu-TTA	Leu-TTG	Lys-AAA	Lys-AAG	Met-ATG	Phe-TTC	Phe-TTT	Pro-CCA	Pro-CCC	Pro-CCG	Pro-CCT	STP-TAA	STP-TAG	STP-TGA	Ser-AGC	Ser-AGT	Ser-TCA	Ser-TCC	Ser-TCG	Ser-TCT	Thr-ACA	Thr-ACC	Thr-ACG	Thr-ACT	Trp-TGG	Tyr-TAC	Tyr-TAT	Val-GTA	Val-GTC	Val-GTG	Val-GTT
all	46.46	5.98	5.345	42.215	81.442	7.591	5.445	0.479	0.535	4.508	19.093	80.907	16.72	83.28	19.995	80.005	84.685	15.315	78.259	21.741	43.425	8.044	6.027	42.504	22.631	77.369	32.448	9.36458.188	9.907	1.808	2.057	17.516	57.62	11.091	88.111	11.889	100.0	12.457	87.543	52.21	4.94	4.085	38.764	74.268	12.457	13.274	6.717	21.379	35.105	3.274	3.372	30.153	44.792	7.941	4.49	42.777100.0	21.256	78.744	33.724	5.437	7.509	53.33
```