### PR TITLE
--display-db-calls flag

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -27,6 +27,7 @@ QUIET = '--quiet' in sys.argv
 NO_PROGRESS = '--no-progress' in sys.argv
 AS_MARKDOWN = '--as-markdown' in sys.argv
 FIX_SAD_TABLES = '--fix-sad-tables' in sys.argv
+DISPLAY_DB_CALLS = '--display-db-calls' in sys.argv
 DOCS_PATH = os.path.join(os.path.dirname(__file__), 'docs')
 TMP_DIR = None
 

--- a/anvio/argparse.py
+++ b/anvio/argparse.py
@@ -187,7 +187,7 @@ class ArgumentParser(argparse.ArgumentParser):
         to see can still be sorted out.
         """
 
-        allowed_ad_hoc_flags = ['--version', '--debug', '--force', '--fix-sad-tables', '--quiet', '--no-progress', '--as-markdown', '--tmp-dir']
+        allowed_ad_hoc_flags = ['--version', '--debug', '--force', '--fix-sad-tables', '--quiet', '--no-progress', '--as-markdown', '--tmp-dir', '--display-db-calls']
 
         args, unknown = parser.parse_known_args()
 

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -308,6 +308,10 @@ class DB:
           to the DB using this method, even with self.read_only = True
         """
 
+        if anvio.DISPLAY_DB_CALLS:
+            self.progress.reset()
+            self.run.info_single(f"Executing SQL command: '{sql_query}'", nl_before=1)
+
         if value:
             ret_val = self.cursor.execute(sql_query, value)
         else:
@@ -329,11 +333,10 @@ class DB:
 
         chunk_counter = 0
         for chunk in get_list_in_chunks(values):
-            if anvio.DEBUG:
+            if anvio.DISPLAY_DB_CALLS:
                 self.progress.reset()
-                self.run.info_single("Adding the chunk %d with %d entries of %d total is being added to the db with "
-                                     "the SQL command '%s'." \
-                                    % (chunk_counter, len(chunk), len(values), sql_query), nl_before=1)
+                self.run.info_single(f"Adding the chunk {chunk_counter} with {len(chunk)} entries of {len(values)} "
+                                     f"total is being added to the db with the SQL command '{sql_query}'.", nl_before=1)
 
             self.cursor.executemany(sql_query, chunk)
 

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -309,13 +309,17 @@ class DB:
         """
 
         if anvio.DISPLAY_DB_CALLS:
-            self.progress.reset()
-            self.run.info_single(f"Executing SQL command: '{sql_query}'", nl_before=1)
+            self.run.warning(None, header='EXECUTING SQL', progress=self.progress, lc='yellow', nl_before=1)
+            self.run.info_single(f"{sql_query}", cut_after=None, level=0, mc='yellow', nl_after=1)
+            sql_exec_timer = terminal.Timer()
 
         if value:
             ret_val = self.cursor.execute(sql_query, value)
         else:
             ret_val = self.cursor.execute(sql_query)
+
+        if anvio.DISPLAY_DB_CALLS:
+            self.run.info("exec", f"{sql_exec_timer.time_elapsed()}", mc='yellow')
 
         self.commit()
         return ret_val
@@ -334,11 +338,15 @@ class DB:
         chunk_counter = 0
         for chunk in get_list_in_chunks(values):
             if anvio.DISPLAY_DB_CALLS:
-                self.progress.reset()
-                self.run.info_single(f"Adding the chunk {chunk_counter} with {len(chunk)} entries of {len(values)} "
-                                     f"total is being added to the db with the SQL command '{sql_query}'.", nl_before=1)
+                header = f"MULTI SQL // {chunk_counter} of {len(values)} with {len(chunk)} {len(chunk)} entries"
+                self.run.warning(None, header=header, progress=self.progress, lc='yellow')
+                self.run.info_single(f"{sql_query}", nl_after=1, cut_after=None, level=0, mc='yellow')
+                sql_exec_timer = terminal.Timer()
 
             self.cursor.executemany(sql_query, chunk)
+
+            if anvio.DISPLAY_DB_CALLS:
+                self.run.info("exec", f"{sql_exec_timer.time_elapsed()}", mc='yellow')
 
             chunk_counter += 1
 

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -142,6 +142,7 @@ class Progress:
 
         self.get_terminal_width()
 
+        self.msg = None
         self.current = None
 
         self.progress_total_items = None

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -427,9 +427,10 @@ class Run:
                                              c(str(aligned_value_str), mc), '\n' * nl_after)
 
         if progress:
-            progress.clear()
+            progress.reset()
             self.write(info_line, overwrite_verbose=False, quiet=quiet)
-            progress.update(progress.msg)
+            if progress.msg and progress.pid:
+                progress.update(progress.msg)
         else:
             self.write(info_line, quiet=quiet, overwrite_verbose=overwrite_verbose)
 
@@ -449,14 +450,15 @@ class Run:
         message_line = ('\n' * nl_before) + message_line + ('\n' * nl_after)
 
         if progress:
-            progress.clear()
+            progress.reset()
             self.write(message_line, overwrite_verbose=False)
-            progress.update(progress.msg)
+            if progress.msg and progress.pid:
+                progress.update(progress.msg)
         else:
             self.write(message_line, overwrite_verbose=False)
 
 
-    def warning(self, message, header='WARNING', lc='red', raw=False, overwrite_verbose=False, nl_before=0, nl_after=0):
+    def warning(self, message, header='WARNING', lc='red', raw=False, overwrite_verbose=False, nl_before=0, nl_after=0, progress=None):
         if isinstance(message, str):
             message = remove_spaces(message)
 
@@ -468,7 +470,13 @@ class Run:
         else:
             message_line = c("%s\n\n%s" % (textwrap.fill(str(message), 80), '\n' * nl_after), lc)
 
-        self.write((header_line + message_line) if message else header_line, overwrite_verbose=overwrite_verbose)
+        if progress:
+            progress.clear()
+            self.write((header_line + message_line) if message else header_line, overwrite_verbose=overwrite_verbose)
+            if progress.msg and progress.pid:
+                progress.update(progress.msg)
+        else:
+            self.write((header_line + message_line) if message else header_line, overwrite_verbose=overwrite_verbose)
 
 
     def store_info_dict(self, destination, strip_prefix=None):

--- a/anvio/tests/run_mini_test.sh
+++ b/anvio/tests/run_mini_test.sh
@@ -37,7 +37,8 @@ do
                  -o $output_dir/SAMPLE-$f \
                  -c $output_dir/CONTIGS.db \
                  --cluster \
-                 --profile-SCVs
+                 --profile-SCVs \
+                 --display-db-calls
 
     INFO "Importing short-read-level taxonomy for SAMPLE-$f"
     anvi-import-taxonomy-for-layers -p $output_dir/SAMPLE-$f/PROFILE.db \


### PR DESCRIPTION
Hey @meren, here the new ad-hoc flag we discussed earlier :)

Now, instead of using `--debug` for printing the SQL database queries (executed in `db.py`), we use `--display-db-calls` instead. 

It seems to be working, but if you have some time, could you please fix how long queries are being printed in `terminal.run`? Right now they look like this:
```
* Executing SQL command: 'SELECT gene_callers_id, split FROM genes_in_splits WHERE
split IN ('c_000000000001_split_00043','c_000000000001_split_00046','c_000000000
001_split_00011','c_000000000001_split_00004','c_000000000001_split_00069','c_00
0000000001_split_00082','c_000000000001_split_00079','c_000000000001_split_00023
','c_000000000001_split_00031','c_000000000001_split_00035','c_000000000001_spli
t_00052','c_000000000001_split_00059','c_000000000001_split_00028','c_0000000000
```
but each query needs to be on one line for easy copy-pasting. Perhaps you could add a parameter to, ie `terminal.run.info_single` with the option to skip line-wrapping?

Thank you so much for your help with this!