### PR TITLE
Revamp genbank to anvio

### DIFF
--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -911,6 +911,7 @@ class GenbankToAnvio:
 
         if len(output_gene_calls):
             header_for_external_gene_calls = ["gene_callers_id", "contig", "start", "stop", "direction", "partial", "call_type", "source", "version"]
+            header_for_functions = ['gene_callers_id', 'source', 'accession', 'function', 'e_value']
 
             if aa_sequences_present:
                 header_for_external_gene_calls.append('aa_sequence')
@@ -921,7 +922,7 @@ class GenbankToAnvio:
 
             utils.store_dict_as_TAB_delimited_file(output_functions,
                                                    self.output_functions_path,
-                                                   headers=['gene_callers_id', 'source', 'accession', 'function', 'e_value'])
+                                                   headers=header_for_functions)
 
             self.run.info('External gene calls file', self.output_gene_calls_path)
             self.run.info('TAB-delimited functions', self.output_functions_path)

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -663,6 +663,7 @@ class GenbankToAnvio:
         self.output_gene_calls_path = A('output_gene_calls')
         self.source = A('annotation_source') or 'NCBI_PGAP'
         self.version = A('annotation_version') or 'v4.6'
+        self.omit_aa_sequences_column = A('omit_aa_sequences_column') or False
 
         # gene callers id start from 0. you can change your instance
         # prior to processing the genbank file to start from another
@@ -731,10 +732,14 @@ class GenbankToAnvio:
         num_genbank_records_processed = 0
         num_genes_found = 0
         num_genes_reported = 0
+        num_genes_with_AA_sequences = 0
+        num_partial_genes = 0
         num_genes_with_functions = 0
 
+        num_genes_excluded = 0
+        genes_excluded = set([])
 
-        for genbank_record in genbank_file_object:
+
         # The main loop to go through all records forreals.
         for genbank_record in self.get_genbank_file_object():
             num_genbank_records_processed += 1

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -16,7 +16,6 @@ from Bio import SeqIO
 from collections import OrderedDict
 
 import anvio
-import anvio.tables as t
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.constants as constants
@@ -710,6 +709,19 @@ class GenbankToAnvio:
                               "file names, or delete these files and come back: '%s'" % (', '.join(files_already_exist)))
 
 
+    def get_genbank_file_object(self):
+        try:
+            if self.input_genbank_path.endswith('.gz'):
+                genbank_file_object = SeqIO.parse(io.TextIOWrapper(gzip.open(self.input_genbank_path, 'r')), "genbank")
+            else:
+                genbank_file_object = SeqIO.parse(open(self.input_genbank_path, "r"), "genbank")
+        except Exception as e:
+            raise ConfigError("Someone didn't like your unput 'genbank' file :/ Here's what they said "
+                              "about it: '%s'." % e)
+
+        return genbank_file_object
+
+
     def process(self):
         self.sanity_check()
 
@@ -721,16 +733,10 @@ class GenbankToAnvio:
         num_genes_reported = 0
         num_genes_with_functions = 0
 
-        try:
-            if self.input_genbank_path.endswith('.gz'):
-                genbank_file_object = SeqIO.parse(io.TextIOWrapper(gzip.open(self.input_genbank_path, 'r')), "genbank")
-            else:
-                genbank_file_object = SeqIO.parse(open(self.input_genbank_path, "r"), "genbank")
-        except Exception as e:
-            raise ConfigError("Someone didn't like your unput 'genbank' file :/ Here's what they said "
-                              "about it: '%s'." % e)
 
         for genbank_record in genbank_file_object:
+        # The main loop to go through all records forreals.
+        for genbank_record in self.get_genbank_file_object():
             num_genbank_records_processed += 1
             output_fasta[genbank_record.name] = str(genbank_record.seq)
 

--- a/sandbox/anvi-script-process-genbank
+++ b/sandbox/anvi-script-process-genbank
@@ -51,6 +51,12 @@ if __name__ == '__main__':
                              source (default: "NCBI_PGAP")')
     groupC.add_argument("--annotation-version", action="store", default="v4.6", help='Annotation \
                              source version to be stored in the database (default: "v4.6")')
+    groupC.add_argument("--omit-aa-sequences-column", default=False, action="store_true", help="If amino acid sequences for "
+                            "gene calls are present in the GFF file, anvi'o by default will include an `aa_sequences` column "
+                            "in the external gene calls output file. This is good because then anvi-gen-contigs-database can "
+                            "use that information directly, instead of trying to predict the translated sequences itself. "
+                            "If you would like this program to not report amino acid sequences even when they present and use "
+                            "anvi'o to predict translated sequences later, you can use this flag.")
 
     args = parser.get_args(parser)
 


### PR DESCRIPTION
This PR is to address #1768.

* Instead of excluding partial gene calls, it reports them as partial.
* Does a better job tracking and reporting excluded gene calls (only applies to 'split' genes that go through multiple contigs).
* Makes use of existing amino acid sequences in GFFs (if and when `translated` feature is present).