### PR TITLE
1770 support value fixes

### DIFF
--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -298,6 +298,12 @@
                                             <input type="number" id="support_font_size" style="width: 60px;" value='15' max='100' min='1'>
                                         </div>
                                     </div>
+                                    <div class="form-group form-margin" id='support_text_rotation'>
+                                        <label class="col-md-4 settings-label" for="support_text_rotation" data-help="support-text-rotation">Text Rotation:</label>
+                                        <div class="col-md-8">
+                                            <input type="number" id="support_text_rotation" style="width: 60px;" value='0' max='359' min='-359'>
+                                        </div>
+                                    </div>
                                 </div>
 
                                 <span class="settings-header">Selections</span>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -292,7 +292,7 @@
                                             <input type="number" id="support_font_size" style="width: 60px;" value='15' max='100' min='1'>
                                         </div>
                                     </div>
-                                    <div class="form-group form-margin" id='support_text_rotation'>
+                                    <div class="form-group form-margin" id='show_text_rotation'>
                                         <label class="col-md-4 settings-label" for="support_text_rotation" data-help="support-text-rotation">Text Rotation:</label>
                                         <div class="col-md-8">
                                             <input type="number" id="support_text_rotation" style="width: 60px;" value='0' max='359' min='-359'>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -247,7 +247,7 @@
                                     <div class="form-group form-margin">
                                         <label class="col-md-4 settings-label" for="support_value_floating_precision" data-help="support-value-floating-precision">Floating Precision:</label>
                                         <div class="col-md-8">
-                                            <input type="number" id="support_floating_precision"style="width: 40px;" value='1' step='1' max='4' min='0'>
+                                            <input type="number" id="support_floating_precision"style="width: 40px;" value='4' step='1' max='4' min='0'>
                                         </div>
                                     </div>
                                     <div class="form-group form-margin">

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -244,7 +244,12 @@
                                             <input type="number" id="support_range_high"style="width: 60px;" value='1' step='.1' max='1' min='0'>
                                         </div>
                                     </div>
-
+                                    <div class="form-group form-margin">
+                                        <label class="col-md-4 settings-label" for="support_value_floating_precision" data-help="support-value-floating-precision">Floating Precision:</label>
+                                        <div class="col-md-8">
+                                            <input type="number" id="support_floating_precision"style="width: 40px;" value='1' step='1' max='4' min='0'>
+                                        </div>
+                                    </div>
                                     <div class="form-group form-margin">
                                         <label class="col-md-4 settings-label" for="support_display_symbol" data-help="support-value-checkbox">Symbols:</label>
                                         <div class="col-md-8">

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -240,8 +240,8 @@
                                     <div class="form-group form-margin">
                                         <label class="col-md-4 settings-label" for="support_value_checkbox" data-help="support-value-checkbox">Display Value Range:</label>
                                         <div class="col-md-8">
-                                            <input type="number" id="support_range_low" style="width: 60px;" value='0' max='100' min='0'> to
-                                            <input type="number" id="support_range_high"style="width: 60px;" value='100' max='100' min='0'>
+                                            <input type="number" id="support_range_low" style="width: 60px;" value='0' step='.1' max='1' min='0'> to
+                                            <input type="number" id="support_range_high"style="width: 60px;" value='1' step='.1' max='1' min='0'>
                                         </div>
                                     </div>
 

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -240,14 +240,8 @@
                                     <div class="form-group form-margin">
                                         <label class="col-md-4 settings-label" for="support_value_checkbox" data-help="support-value-checkbox">Display Value Range:</label>
                                         <div class="col-md-8">
-                                            <input type="number" id="support_range_low" style="width: 60px;" value='0' step='.1' max='1' min='0'> to
-                                            <input type="number" id="support_range_high"style="width: 60px;" value='1' step='.1' max='1' min='0'>
-                                        </div>
-                                    </div>
-                                    <div class="form-group form-margin">
-                                        <label class="col-md-4 settings-label" for="support_value_floating_precision" data-help="support-value-floating-precision">Floating Precision:</label>
-                                        <div class="col-md-8">
-                                            <input type="number" id="support_floating_precision"style="width: 40px;" value='4' step='1' max='4' min='0'>
+                                            <input type="number" id="support_range_low" style="width: 60px;" value='0' step='1' max='100' min='0'> to
+                                            <input type="number" id="support_range_high"style="width: 60px;" value='100' step='1' max='100' min='0'>
                                         </div>
                                     </div>
                                     <div class="form-group form-margin">

--- a/anvio/data/interactive/js/drawer.js
+++ b/anvio/data/interactive/js/drawer.js
@@ -783,7 +783,8 @@ Drawer.prototype.draw_internal_node = function(p) {
         invertSymbol : this.settings['support-symbol-invert'],
         maxRadius : this.settings['support-symbol-size'],
         symbolColor : this.settings['support-symbol-color'],
-        fontSize : this.settings['support-font-size']
+        fontSize : this.settings['support-font-size'],
+        textRotation : this.settings['support-text-rotation']
     }
 
     if (this.settings['tree-type'] == 'circlephylogram')

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -1487,6 +1487,7 @@ function serializeSettings(use_layer_names) {
     state['support-symbol-color'] = $('#support_symbol_color').attr('color')
     state['support-font-size'] = $('#support_font_size').val()
     state['support-floating-precision'] = $('#support_floating_precision').val()
+    state['support-text-rotation'] = $('#support_text_rotation').val()
 
     // sync views object and layers table
     syncViews();
@@ -2712,6 +2713,9 @@ function processState(state_name, state) {
     }
     if (state.hasOwnProperty('support-floating-precision')){
         $('#support_floating_precision').val(state['support-floating-precision'])
+    }
+    if(state.hasOwnProperty('support-text-rotation')){
+        $('#support_text_rotation').val(state['support-text-rotation'])
     }
 
     // reload layers

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -1486,6 +1486,7 @@ function serializeSettings(use_layer_names) {
     state['support-symbol-size'] = $('#support_symbol_size').val()
     state['support-symbol-color'] = $('#support_symbol_color').attr('color')
     state['support-font-size'] = $('#support_font_size').val()
+    state['support-floating-precision'] = $('#support_floating_precision').val()
 
     // sync views object and layers table
     syncViews();
@@ -2708,6 +2709,9 @@ function processState(state_name, state) {
     }
     if (state.hasOwnProperty('support-font-size')){
         $('#support_font_size').val(state['support-font-size'])
+    }
+    if (state.hasOwnProperty('support-floating-precision')){
+        $('#support_floating_precision').val(state['support-floating-precision'])
     }
 
     // reload layers

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2711,9 +2711,6 @@ function processState(state_name, state) {
     if (state.hasOwnProperty('support-font-size')){
         $('#support_font_size').val(state['support-font-size'])
     }
-    if (state.hasOwnProperty('support-floating-precision')){
-        $('#support_floating_precision').val(state['support-floating-precision'])
-    }
     if(state.hasOwnProperty('support-text-rotation')){
         $('#support_text_rotation').val(state['support-text-rotation'])
     }

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -1486,7 +1486,6 @@ function serializeSettings(use_layer_names) {
     state['support-symbol-size'] = $('#support_symbol_size').val()
     state['support-symbol-color'] = $('#support_symbol_color').attr('color')
     state['support-font-size'] = $('#support_font_size').val()
-    state['support-floating-precision'] = $('#support_floating_precision').val()
     state['support-text-rotation'] = $('#support_text_rotation').val()
 
     // sync views object and layers table

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -257,7 +257,11 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
     }
 
     if( supportValueData.showNumber && checkInRange()){ // only render text if in range AND selected by user
-        drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+        if($('#tree_type').val() == 'circlephylogram'){
+            drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+        } else {
+            drawRotatedText(svg_id, p.xy, p.branch_support, -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+        }
     }
     if(supportValueData.showSymbol && checkInRange()){ // only render symbol if in range AND selected by user
         drawSymbol()

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -247,7 +247,6 @@ function drawLayerLegend(_layers, _view, _layer_order, top, left) {
 }
 
 function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
-
     function checkInRange(){ // check to see if SV data point is within user specified range
         if(p.branch_support >= supportValueData.numberRange[0] * 100 && p.branch_support <= supportValueData.numberRange[1] * 100){
             return true
@@ -260,7 +259,8 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         if($('#tree_type').val() == 'circlephylogram'){
             drawText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), supportValueData.fontSize, 'right', 'black', 'baseline', true)
         } else {
-            drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            // drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
         }
     }
     if(supportValueData.showSymbol && checkInRange()){ // only render symbol if in range AND selected by user
@@ -431,7 +431,7 @@ function drawRotatedText(svg_id, p, string, angle, align, font_size, font_family
     text.appendChild(textNode);
     var svg = document.getElementById(svg_id);
     svg.appendChild(text);
-
+    
     // trim long text
 
     if (maxLength > 0)

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -259,7 +259,6 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         if($('#tree_type').val() == 'circlephylogram'){
             drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
         } else {
-            // drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
             drawRotatedText(svg_id, p.xy, p.branch_support, -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
         }
     }

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -286,8 +286,8 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         function makeCircle(){ // time to make the gravy
             setDetails(calculatePercentile())
 
-            circle.setAttribute('cx', p0.x)
-            circle.setAttribute('cy', p0.y)
+            circle.setAttribute('cx', p.xy.x)
+            circle.setAttribute('cy', p.xy.y)
             circle.setAttribute('r', radius)
             circle.setAttribute('id', p.id)
             circle.setAttribute('fill', supportValueData.symbolColor )

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -257,10 +257,10 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
 
     if( supportValueData.showNumber && checkInRange()){ // only render text if in range AND selected by user
         if($('#tree_type').val() == 'circlephylogram'){
-            drawText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
         } else {
             // drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
-            drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            drawRotatedText(svg_id, p.xy, p.branch_support, -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
         }
     }
     if(supportValueData.showSymbol && checkInRange()){ // only render symbol if in range AND selected by user

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -248,7 +248,7 @@ function drawLayerLegend(_layers, _view, _layer_order, top, left) {
 
 function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
     function checkInRange(){ // check to see if SV data point is within user specified range
-        if(p.branch_support >= supportValueData.numberRange[0] * 100 && p.branch_support <= supportValueData.numberRange[1] * 100){
+        if(p.branch_support >= supportValueData.numberRange[0] && p.branch_support <= supportValueData.numberRange[1]){
             return true
         } else {
             return false

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -258,9 +258,9 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
 
     if( supportValueData.showNumber && checkInRange()){ // only render text if in range AND selected by user
         if($('#tree_type').val() == 'circlephylogram'){
-            drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            drawText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), supportValueData.fontSize, 'right', 'black', 'baseline', true)
         } else {
-            drawRotatedText(svg_id, p.xy, p.branch_support, -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            drawRotatedText(svg_id, p.xy, parseFloat(p.branch_support / 100).toFixed($('#support_floating_precision').val()), -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
         }
     }
     if(supportValueData.showSymbol && checkInRange()){ // only render symbol if in range AND selected by user

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -277,18 +277,19 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         }
 
         function setDetails(percentile){
-            if(percentile > 67){
-                supportValueData.invertSymbol ? radius = maxRadius * 4 : radius = maxRadius
-            } else if (percentile < 67 && percentile > 33){
-                radius = maxRadius * 7
+            if(percentile > .67){
+                supportValueData.invertSymbol ? radius = maxRadius * .4 : radius = maxRadius
+            } else if (percentile < .67 && percentile > .33){
+                radius = maxRadius * .7
             } else {
-                supportValueData.invertSymbol ? radius = maxRadius : radius = maxRadius * 4
+                supportValueData.invertSymbol ? radius = maxRadius : radius = maxRadius * .4
             }
 
         }
 
         function makeCircle(){ // time to make the gravy
             setDetails(calculatePercentile())
+            console.log(calculatePercentile())
 
             circle.setAttribute('cx', p.xy.x)
             circle.setAttribute('cy', p.xy.y)

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -277,12 +277,12 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         }
 
         function setDetails(percentile){
-            if(percentile > .67){
-                supportValueData.invertSymbol ? radius = maxRadius * .4 : radius = maxRadius
-            } else if (percentile < .67 && percentile > .33){
-                radius = maxRadius * .7
+            if(percentile > 67){
+                supportValueData.invertSymbol ? radius = maxRadius * 4 : radius = maxRadius
+            } else if (percentile < 67 && percentile > 33){
+                radius = maxRadius * 7
             } else {
-                supportValueData.invertSymbol ? radius = maxRadius : radius = maxRadius * .4
+                supportValueData.invertSymbol ? radius = maxRadius : radius = maxRadius * 4
             }
 
         }

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -249,7 +249,7 @@ function drawLayerLegend(_layers, _view, _layer_order, top, left) {
 function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
 
     function checkInRange(){ // check to see if SV data point is within user specified range
-        if(p.branch_support >= supportValueData.numberRange[0] && p.branch_support <= supportValueData.numberRange[1]){
+        if(p.branch_support >= supportValueData.numberRange[0] * 100 && p.branch_support <= supportValueData.numberRange[1] * 100){
             return true
         } else {
             return false

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -257,9 +257,17 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
 
     if( supportValueData.showNumber && checkInRange()){ // only render text if in range AND selected by user
         if($('#tree_type').val() == 'circlephylogram'){
-            drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            if(supportValueData.textRotation == '0'){
+                drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            } else {
+                drawRotatedText(svg_id, p.xy, p.branch_support, parseInt(supportValueData.textRotation), supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            }
         } else {
-            drawRotatedText(svg_id, p.xy, p.branch_support, -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            if(supportValueData.textRotation == '0'){
+                drawRotatedText(svg_id, p.xy, p.branch_support, -90, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            } else {
+                drawRotatedText(svg_id, p.xy, p.branch_support, parseInt(supportValueData.textRotation), supportValueData.fontSize, 'right', 'black', 'baseline', true)
+            }
         }
     }
     if(supportValueData.showSymbol && checkInRange()){ // only render symbol if in range AND selected by user


### PR DESCRIPTION
this PR addresses fixes/feature noted in issue #1770 

## fixes
- support value symbols now render in the correct place when tree == phylogram (previously, they had shifted to the next node to the right)
- for legibility, support value text is shifted 90deg when tree = phylogram
- Display value range is now set with min/max val of 0.0 and 1.0, respectively

## features
- a new UI element, 'floating point precision' is available for users to set, with the corresponding value being implemented upon render
- this value is hooked into the interactive interface state