### PR TITLE
patched threads error in anvi_compute_genome_similarity snakemake rule

### DIFF
--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -55,7 +55,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         self.default_config.update({"fasta_txt": "fasta.txt",
                                     "anvi_gen_contigs_database": {"--project-name": "{group}"},
                                     "centrifuge": {"threads": 2},
-                                    "anvi_run_hmms": {"run": True, "threads": 5},
+                                    "anvi_run_hmms": {"run": True, "threads": 5, "--also-scan-trnas": True},
                                     "anvi_run_kegg_kofams": {"run": True, "threads": 4},
                                     "anvi_run_ncbi_cogs": {"run": True, "threads": 5},
                                     "anvi_run_scg_taxonomy": {"run": True, "threads": 6},

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -59,7 +59,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                     "anvi_run_kegg_kofams": {"run": True, "threads": 4},
                                     "anvi_run_ncbi_cogs": {"run": True, "threads": 5},
                                     "anvi_run_scg_taxonomy": {"run": True, "threads": 6},
-                                    'anvi_run_trna_scan': {"run": True, "threads": 6},
+                                    "anvi_run_trna_scan": {"run": False, "threads": 6},
                                     "anvi_script_reformat_fasta": {"run": True, "--prefix": "{group}", "--simplify-names": True},
                                     "emapper": {"--database": "bact", "--usemem": True, "--override": True},
                                     "anvi_script_run_eggnog_mapper": {"--use-version": "0.12.6"}})

--- a/anvio/workflows/pangenomics/Snakefile
+++ b/anvio/workflows/pangenomics/Snakefile
@@ -181,6 +181,7 @@ rule anvi_compute_genome_similarity:
     resources: nodes = M.T('anvi_compute_genome_similarity')
     shell: " anvi-compute-genome-similarity {params.internal_genomes_argument} \
                                             {params.external_genomes_argument} \
+                                            -T {threads} \
                                             -o {output.output_dir} \
                                             -p {input.pan_db} \
                                             {params.additional_params} >> {log} 2>&1"


### PR DESCRIPTION
I changed the default in the pangenomic workflow `__init.py__` to set `anvi-scan-trnas` in the default snakemake config to `False` per issue #1780. There was also a bug I uncovered that locked the `anvi_compute_genome_similarity` snakemake rule into using a single thread. This is fixed in the `anvi_compute_genome_similarity` snakemake rule `shell` command definition by adding `-T {threads}` to the Snakemake file.  