### PR TITLE
Add pn and ps to display structure

### DIFF
--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -449,7 +449,8 @@ async function create_single_ngl_view(group, num_rows, num_columns) {
                         tooltip_HTML_variant_body += `<tr><td>Mean BLOSUM90</td><td>${variability[group][residue]['BLOSUM90'].toFixed(1)}</td></tr>`
                     } else {
                         // append to body
-                        tooltip_HTML_variant_body += `<tr><td>Synonymity</td><td>${variability[group][residue]['synonymity'].toFixed(2)}</td></tr>`
+                        tooltip_HTML_variant_body += `<tr><td>log10(pN) [popular consensus])</td><td>${variability[group][residue]['log_pN_popular_consensus'].toFixed(4)}</td></tr>`
+                        tooltip_HTML_variant_body += `<tr><td>log10(pS) [popular consensus])</td><td>${variability[group][residue]['log_pS_popular_consensus'].toFixed(4)}</td></tr>`
                     }
 
                     var tooltip_HTML_variant_freqs_title = `<h5>Variant frequencies</h5>`

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -2119,14 +2119,64 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
                 'max': int(FIND_MAX('coverage', buff=1))
             },
             {
-                'name': 'synonymity',
-                'title': 'Synonymity',
+                'name': 'log_pN_popular_consensus',
+                'title': 'log10(pN) [popular consensus]',
                 'as_view': True,
                 'as_filter': 'slider',
                 'data_type': 'float',
-                'step': 0.01,
-                'min': 0,
-                'max': 1,
+                'step': 1e-3,
+                'min': float(FIND_MIN('log_pN_popular_consensus', buff=1e-3)),
+                'max': float(FIND_MAX('log_pN_popular_consensus', buff=1e-3))
+            },
+            {
+                'name': 'log_pN_consensus',
+                'title': 'log10(pN) [consensus]',
+                'as_view': True,
+                'as_filter': 'slider',
+                'data_type': 'float',
+                'step': 1e-3,
+                'min': float(FIND_MIN('log_pN_consensus', buff=1e-3)),
+                'max': float(FIND_MAX('log_pN_consensus', buff=1e-3))
+            },
+            {
+                'name': 'log_pN_reference',
+                'title': 'log10(pN) [reference]',
+                'as_view': True,
+                'as_filter': 'slider',
+                'data_type': 'float',
+                'step': 1e-3,
+                'min': float(FIND_MIN('log_pN_reference', buff=1e-3)),
+                'max': float(FIND_MAX('log_pN_reference', buff=1e-3))
+            },
+            {
+                'name': 'log_pS_popular_consensus',
+                'title': 'log10(pS) [popular consensus]',
+                'as_view': True,
+                'as_filter': 'slider',
+                'data_type': 'float',
+                'step': 1e-3,
+                'min': float(FIND_MIN('log_pS_popular_consensus', buff=1e-3)),
+                'max': float(FIND_MAX('log_pS_popular_consensus', buff=1e-3))
+            },
+            {
+                'name': 'log_pS_consensus',
+                'title': 'log10(pS) [consensus]',
+                'as_view': True,
+                'as_filter': 'slider',
+                'data_type': 'float',
+                'step': 1e-3,
+                'min': float(FIND_MIN('log_pS_consensus', buff=1e-3)),
+                'max': float(FIND_MAX('log_pS_consensus', buff=1e-3))
+            },
+            {
+                'name': 'log_pS_reference',
+                'title': 'log10(pS) [reference]',
+                'as_view': True,
+                'as_filter': 'slider',
+                'data_type': 'float',
+                'step': 1e-3,
+                'min': float(FIND_MIN('log_pS_reference', buff=1e-3)),
+                'max': float(FIND_MAX('log_pS_reference', buff=1e-3))
             },
             {
                 'name': 'entropy',
@@ -2501,6 +2551,11 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
                 self.args.compute_gene_coverage_stats = True
                 var = variability_engines[engine](self.args, p=terminal.Progress(verbose=verbose), r=terminal.Run(verbose=verbose))
                 var.stealth_filtering = stealth
+
+                if engine == 'CDN':
+                    var.process_functions.append((var.calc_pN_pS, dict(grouping='site', comparison='reference', add_potentials=False, log_transform=True)))
+                    var.process_functions.append((var.calc_pN_pS, dict(grouping='site', comparison='consensus', add_potentials=False, log_transform=True)))
+                    var.process_functions.append((var.calc_pN_pS, dict(grouping='site', comparison='popular_consensus', add_potentials=False, log_transform=True)))
 
                 # we convert counts to frequencies so high-covered samples do not skew averaging
                 # across samples

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -2433,7 +2433,7 @@ class CodonsEngine(dbops.ContigsSuperclass, VariabilitySuper, QuinceModeWrapperF
         """Compute the fraction of synonymous and non-synonymous substitutions relative to a reference"""
 
         self.progress.new('Calculating per-site synonymous fraction')
-        progress.update('...')
+        self.progress.update('...')
 
         # Some lookups
         coding_codons = sorted(constants.coding_codons)
@@ -2449,9 +2449,9 @@ class CodonsEngine(dbops.ContigsSuperclass, VariabilitySuper, QuinceModeWrapperF
                     is_synonymous[i, j] = False
 
         # Populate necessary per-site info
-        progress.update('...')
+        self.progress.update('...')
         if comparison == 'popular_consensus':
-            progress.update('Finding popular consensus; You have time for a quick stretch')
+            self.progress.update('Finding popular consensus; You have time for a quick stretch')
             self.data['popular_consensus'] = self.data.\
                 groupby('unique_pos_identifier')\
                 ['consensus'].\

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -2518,7 +2518,7 @@ class CodonsEngine(dbops.ContigsSuperclass, VariabilitySuper, QuinceModeWrapperF
         return potentials
 
 
-    def calc_pN_pS(self, contigs_db=None, grouping='site', comparison='reference', potentials=None, add_potentials=False):
+    def calc_pN_pS(self, contigs_db=None, grouping='site', comparison='reference', potentials=None, add_potentials=False, log_transform=False):
         """Calculate new columns in self.data corresponding to each site's contribution to a grouping
 
         First, this function calculates fN and fS for each SCV relative to a comparison codon (see `comparison`).
@@ -2552,6 +2552,8 @@ class CodonsEngine(dbops.ContigsSuperclass, VariabilitySuper, QuinceModeWrapperF
             passed, it should be a (len(self.data), 2) shaped numpy array. potentials[:,0] and
             potentials[:,1] specify the amount that each SCV's fS and fS values should be divided by
             to yield pS and pN.
+        log_transform : bool, False
+            Log tranforms pN and pS values by log10(x + 1e-4).
 
         Returns
         =======
@@ -2578,8 +2580,15 @@ class CodonsEngine(dbops.ContigsSuperclass, VariabilitySuper, QuinceModeWrapperF
 
         group_tag = (grouping + '_') if grouping != 'site' else ''
         pN_name, pS_name = f"pN_{group_tag}{comparison}", f"pS_{group_tag}{comparison}"
+        if log_transform:
+            pN_name, pS_name = 'log_' + pN_name, 'log_' + pS_name
+
         self.data[pS_name] = frac_syns/potentials[:, 0]
         self.data[pN_name] = frac_nonsyns/potentials[:, 1]
+
+        if log_transform:
+            self.data[pS_name] = np.log10(self.data[pS_name] + 1e-4)
+            self.data[pN_name] = np.log10(self.data[pN_name] + 1e-4)
 
         if add_potentials:
             nN_name, nS_name = f"nN_{group_tag}{comparison}", f"nS_{group_tag}{comparison}"


### PR DESCRIPTION
Prior to this PR, `synonymity` was our metric for assessing the synonymity of a site. It was a garbage metric, and has been replaced with several variants of per-site pN and pS. These can now be used in the interactive interface to visualize SCVs, backbones, and surfaces according to measured pN and pS values.

For example:

![image](https://user-images.githubusercontent.com/8688665/132046774-f2f8ca36-e515-434e-a94d-06bb0188cab8.png)

This surface is colored according to log10(pN) [popular_consensus]. Would anyone like to guess where the active site is?