### PR TITLE
Fix metabolism coverage bug

### DIFF
--- a/anvio/docs/artifacts/kegg-metabolism.md
+++ b/anvio/docs/artifacts/kegg-metabolism.md
@@ -108,6 +108,10 @@ Here are the descriptions of any new columns not yet discussed in the previous s
 - `modules_with_ko`: the KEGG modules (if any) that this KO belongs to
 - `definition`: the function of this KO (typically the enzyme name and EC number)
 
+**Coverage and detection values in the output**
+
+If you use the flag `--add-coverage` and provide a profile database, you will get the same additional columns per row as described above in for `kofam_hits_in_modules` mode. That is, you will get one column per sample for coverage (containing the coverage value of the KO hit in the sample) and one column per sample for detection (containing the detection value of the KO hit in the sample). 
+
 ### Custom Mode (for module data)
 
 The `modules_custom` output mode will have user-defined content and the suffix `modules_custom.txt` (we currently only support output customization for modules data). See %(anvi-estimate-metabolism)s for an example command to work with this mode. The output file will look similar to the `modules` mode output, but with a different (sub)set of columns.

--- a/anvio/docs/programs/anvi-estimate-metabolism.md
+++ b/anvio/docs/programs/anvi-estimate-metabolism.md
@@ -251,10 +251,10 @@ anvi-estimate-metabolism -c %(contigs-db)s --include-zeros
 If you have a profile database associated with your contigs database and you would like to include coverage and detection data in the metabolism estimation output files, you can use the `--add-coverage` flag. You will need to provide the profile database as well, of course. :)
 
 {{ codestart }}
-anvi-estimate-metabolism -c %(contigs-db)s -p %(profile-db)s --kegg-output-modes modules,kofam_hits_in_modules --add-coverage
+anvi-estimate-metabolism -c %(contigs-db)s -p %(profile-db)s --kegg-output-modes modules,kofam_hits_in_modules,kofam_hits --add-coverage
 {{ codestop }}
 
-For `kofam_hits_in_modules` mode output files, in which each row describes one KOfam hit to a gene in the contigs database, the output will contain two additional columns per sample in the profile database. One column will contain the mean coverage of that particular gene call by reads from that sample and the other will contain the detection of that gene in the sample.
+For `kofam_hits_in_modules` and `kofam_hits` mode output files, in which each row describes one KOfam hit to a gene in the contigs database, the output will contain two additional columns per sample in the profile database. One column will contain the mean coverage of that particular gene call by reads from that sample and the other will contain the detection of that gene in the sample.
 
 For `modules` mode output files, in which each row describes a KEGG module, the output will contain _four_ additional columns per sample in the profile database. One column will contain comma-separated mean coverage values for each gene call in the module, in the same order as the corresponding gene calls in the `gene_caller_ids_in_module` column. Another column will contain the average of these gene coverage values, which represents the average coverage of the entire module. Likewise, the third and fourth columns will contain comma-separated detection values for each gene call and the average detection, respectively.
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -3243,8 +3243,8 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
                             gene_coverages_in_mod = []
                             gene_detection_in_mod = []
                             for gc in gcids_in_mod:
-                                gene_coverages_in_mod.append(c_dict["genes_to_coverage"][s][gc])
-                                gene_detection_in_mod.append(c_dict["genes_to_detection"][s][gc])
+                                gene_coverages_in_mod.append(c_dict["genes_to_coverage"][s][int(gc)])
+                                gene_detection_in_mod.append(c_dict["genes_to_detection"][s][int(gc)])
 
                             d[self.modules_unique_id][sample_cov_header] = ",".join([str(c) for c in gene_coverages_in_mod])
                             d[self.modules_unique_id][sample_det_header] = ",".join([str(d) for d in gene_detection_in_mod])


### PR DESCRIPTION
This PR addresses the bugs described in #1798 and #1799. 

It really was a very stupid bug. The gene caller id variable which was being used to access the gene coverage information was of type string, when it needed to be an integer, and that was causing KeyErrors. But now it is fixed, and I have tested that all modes are working with the `--add-coverage` flag (this includes multi-mode as well!).

Additionally, while I was at it, I added the `--add-coverage` functionality to the `kofam_hits` output mode (it strangely was not available before; I suppose I forgot it when I was initially coding this). This mode now gets the same coverage and detection columns added as in `kofam_hits_in_modules` mode. I have updated the relevant documentation pages to reflect this.

Sorry for the inconvenience this bug has caused :)