### PR TITLE
Update snakemake to v6.9.1

### DIFF
--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -21,7 +21,7 @@ __email__ = "alon.shaiber@gmail.com"
 
 run = terminal.Run()
 
-this_workflow_is_inherited_by_another = False if 'workflows/contigs' in workflow.included[0] else True
+this_workflow_is_inherited_by_another = False if 'workflows/contigs' in str(workflow.included[0]) else True
 if not this_workflow_is_inherited_by_another:
     # don't be confused, child. when things come to this point, the variable `config`
     # is already magically filled in by snakemake:
@@ -493,7 +493,7 @@ rule gen_external_genome_file:
                 f.write("%s\t%s\n" % (name, path))
 
 
-if 'workflows/contigs' in workflow.included[0]:
+if 'workflows/contigs' in str(workflow.included[0]):
     # check if all program dependencies are met. for this line to be effective,
     # there should be an initial dry run step (which is the default behavior of
     # the `WorkflowSuperClass`, so you are most likely covered).


### PR DESCRIPTION
For historical reasons, anvi'o enforces the use of snakemake version `5.10.0`, even though snakemake is at version `6.9.1`.

In this branch I did something crazy, and run the following commands in my anvi'o environment,

```
pip uninstall snakemake
pip install snakemake

python -c "import snakemake; print(snakemake.__version__)"
6.9.1
```

And then started running the contigs workflow test:

```
cd anvio/tests
./run_workflow_tests_for_contigs.sh
```

https://github.com/merenlab/anvio/commit/0362d63ccee85bf363234576900fb7feffd7eedb fixed the only crash, but right after that the `./run_workflow_tests_for_contigs.sh` fails with the following message:

> Error: you need to specify the maximum number of CPU cores to be used at the same time. If you want to use N cores, say --cores N or -cN. For all cores on your system (be sure that this is appropriate) use --cores all. For no parallelization use --cores 1 or -c1.

So I went to the temporary output files directory,

```
cd sandbox/test-output/workflow_test
```

and run this to make sure I continue to get the error:

```
anvi-run-workflow -w contigs -c default-config.json
```

Then, I run this and could confirm that it addressed the problem like a glove:

```
anvi-run-workflow -w contigs -c default-config.json --additional-params --cores 1
```

I can also confirm that when I made the following change, things worked without `--additional-params --cores 1`:

``` diff
@@ -190,11 +190,13 @@ class WorkflowSuperClass:
             sys.argv.extend(self.additional_params)

         if self.list_dependencies:
-            sys.argv.extend(['--dryrun', '--printshellcmds'])
+            sys.argv.extend(['--dryrun', '--printshellcmds', '--cores', 'all'])
             snakemake.main()
             sys.exit(0)
         else:
-            sys.argv.extend(['-p'])
+            sys.argv.extend(['-p', '--cores', 'all'])
             snakemake.main()
```

Clearly we need to do something smart here. Perhaps somewhere in `anvio/workflows/__init__.py` we should add the `--cores` parameter into its rightful place along with the proper value for it, or we should enforce the user to pass it as an additional parameter to snakemake.

What do you think would be the best way? 

I feel like the best way to do this would be to,

* Let the user declare it in the default config file,
* If they haven't, automatically set the maximum number of threads assigned to any of the rules as `--cores` to be passed to Snakemake via `sys.args`,
* And let the user overwrite that via the `--additional-params --cores X` mechanism.

What do you think?