### PR TITLE
Fixes https://github.com/merenlab/anvio/issues/1821

### DIFF
--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -250,11 +250,14 @@ class BAMFileObject(pysam.AlignmentFile):
         """
 
         for read in self.fetch_only(contig_name, start, end, *args, **kwargs):
-            if read.cigartuples is None or read.query_sequence is None:
+            if read.is_unmapped or read.cigartuples is None or read.query_sequence is None:
                 # This read either has no associated cigar string or no query sequence. If cigar
                 # string is None, this means it did not align but is in the BAM file anyways, or the
                 # mapping software decided it did not want to include a cigar string for this read.
-                # The origin of why query sequence would be None is unkown.
+                # The origin of why query sequence would be None is unkown. Alternatively, this read
+                # has a query sequence, has a cigar string (and therefore mapped), but for some
+                # reason pysam has given the read the attribute read.is_unmapped == True. We choose
+                # not to work with such a read (see https://github.com/merenlab/anvio/issues/1821)
                 continue
 
             read = Read(read)
@@ -298,11 +301,14 @@ class BAMFileObject(pysam.AlignmentFile):
         """
 
         for read in self.fetch_only(contig_name, start, end, *args, **kwargs):
-            if read.cigartuples is None or read.query_sequence is None:
+            if read.is_unmapped or read.cigartuples is None or read.query_sequence is None:
                 # This read either has no associated cigar string or no query sequence. If cigar
                 # string is None, this means it did not align but is in the BAM file anyways, or the
                 # mapping software decided it did not want to include a cigar string for this read.
-                # The origin of why query sequence would be None is unkown.
+                # The origin of why query sequence would be None is unkown. Alternatively, this read
+                # has a query sequence, has a cigar string (and therefore mapped), but for some
+                # reason pysam has given the read the attribute read.is_unmapped == True. We choose
+                # not to work with such a read (see https://github.com/merenlab/anvio/issues/1821)
                 continue
 
             read = Read(read)


### PR DESCRIPTION
This is my proposed fix to https://github.com/merenlab/anvio/issues/1821

There was two viable solutions. The first was to ignore reads where `reference_end` is `None`, since that is the ultimate cause for error. However, in each instance where `reference_end` was `None`, `is_unmapped` was set to `True`. To be proactive in catching more weird fringe cases, I figure if `pysam` sets `is_unmapped` to `True`, we better just leave the read alone.

I tested this successfully on @SCarrSuperstar's dataset running pysam 0.16.0.1.

If you agree with this PR I will merge it @meren.