### PR TITLE
Refactor get primer matches

### DIFF
--- a/anvio/docs/__init__.py
+++ b/anvio/docs/__init__.py
@@ -124,6 +124,12 @@ ANVIO_ARTIFACTS ={
         "provided_by_anvio": False,
         "provided_by_user":True
     },
+    "primers-txt": {
+        "name": "PRIMERS TXT",
+        "type": "TXT",
+        "provided_by_anvio": False,
+        "provided_by_user":True
+    },
     "fasta-txt": {
         "name": "FASTA TXT",
         "type": "TXT",

--- a/anvio/docs/artifacts/primers-txt.md
+++ b/anvio/docs/artifacts/primers-txt.md
@@ -1,0 +1,18 @@
+A **TAB-delimited** file to describe primer sequences. A primer sequence can be exact (such as `ATCG`), or fuzzy (such as `AT.G`, which would match any combination of `ATAG`, `ATTG`, `ATCG`, or `ATGG`). Fuzzy primers are defined by regular expressions, properties of which are explained best in [the Python documentation](https://docs.python.org/3/library/re.html), or cheatsheets like [this one](https://www.debuggex.com/cheatsheet/regex/python).
+
+This file type includes two required and any number of user-defined optional columns.
+
+The following three columns are **required** for this file type:
+
+* `name`: a single-word name for a given primer,
+* `primer_sequence`: the primer sequence.
+
+### An example primers-txt file
+
+Here is an example file with three primers:
+
+|name|primer_sequence|
+|:--|:--|
+|PR01|AA.A..G..G..G.CCG.C.A.C|
+|PR02|AACACCGCAGTCCATGAGA|
+|PR03|A[TC]A[CG]T[ATC]TCGAGC|

--- a/anvio/docs/programs/anvi-script-get-primer-matches.md
+++ b/anvio/docs/programs/anvi-script-get-primer-matches.md
@@ -1,8 +1,6 @@
-This program finds all reads in a given set of FASTQ files based on user-provided primer sequences.
+This program finds all reads in a given set of FASTQ files provided as %(samples-txt)s based on user-provided primer sequences as %(primers-txt)s.
 
-The primary utility of this program is to get back short reads that may be extending into hypervariable regions of genomes that often suffer from significant drops in coverage in conventional read-recruitment analyses, thus preventing any meaningful insights into coverage or variability patterns.
-
-In these situations, one can identify downstream conserved sequences (typically 15 to 25 nucleotides long) using the anvi'o interactive interface or through other means, and then provide those sequences to this program so it can find all matching sequences in a set of FASTQ files without any mapping.
+One of many potential uses of this program is to get back short reads that may be extending into hypervariable regions of genomes that often suffer from significant drops in coverage in conventional read-recruitment analyses, thus preventing any meaningful insights into coverage or variability patterns. In such situations, one can identify downstream conserved sequences (typically 15 to 25 nucleotides long) using the anvi'o interactive interface or through other means, and then provide those sequences to this program so it can find all matching sequences in a set of FASTQ files without any mapping.
 
 {:.notice}
 To instead get short reads mapping to a gene, use %(anvi-get-short-reads-mapping-to-a-gene)s.
@@ -10,17 +8,19 @@ To instead get short reads mapping to a gene, use %(anvi-get-short-reads-mapping
 Here is a typical command line to run it:
 
 {{ codestart }}
-anvi-script-get-primer-matches --%(samples-txt)s samples.txt  \
-                               --primer-sequences sequences.txt \
+anvi-script-get-primer-matches --samples-txt %(samples-txt)s \
+                               --primers-txt %(primers-txt)s \
                                --output-dir OUTPUT
 {{ codestop }}
 
-The %(samples-txt)s file is to list all the samples one is interested in, and the primer sequences file lists each primer sequence of interest. Each of these files can contain a single entry, or multiple ones.
+The %(samples-txt)s file is to list all the samples one is interested in, and the %(primers-txt)s file lists each primer sequence of interest, and their user-defined names. Each of these files can contain a single entry, or multiple ones.
 
 This will output all of the matching sequences into three %(fasta)s files in the directory `OUTPUT`. These %(fasta)s files differ in their format and will include those that describe,
 
-* Raw sequences: sequences from the FASTQ files that matched to a primer where each sequence reported as is with no processing.
-* Trimmed sequences: Raw sequences where the upstream of the primer sequence trimmed, as a result all matching sequences will start at the same position, and
-* Gapped sequences: Trimmed sequences padded with gap characters to eliminate length variation artificially.
+* **Raw sequences**: sequences from the FASTQ files that matched to a primer where each sequence reported as is with no processing.
+* **Trimmed sequences**: Raw sequences where the upstream of the primer sequence trimmed, as a result all matching sequences will start at the same position, and
+* **Gapped sequences**: Trimmed sequences padded with gap characters to eliminate length variation artificially.
 
-The last two formats provide downstream possibilities to generate %(oligotypes)s and cluster short reads from an hypervariable region to estimate their diversity and oligotype proportion. 
+The last two formats provide downstream possibilities to generate %(oligotypes)s and cluster short reads from an hypervariable region to estimate their diversity and oligotype proportion.
+
+There will only be a single FASTA file in the output directory for raw sequences if the user asked only the primer matches to be reported with the flag `--only-report-primer-matches`.

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3323,6 +3323,36 @@ def get_samples_txt_file_as_dict(file_path, run=run, progress=progress):
     return samples_txt
 
 
+def get_primers_txt_file_as_dict(file_path, run=run, progress=progress):
+    """Primers-txt is an anvi'o artifact for primer sequencs."""
+
+    filesnpaths.is_file_tab_delimited(file_path)
+
+    columns_found = get_columns_of_TAB_delim_file(file_path, include_first_column=True)
+
+    if 'name' not in columns_found:
+        progress.reset()
+        raise ConfigError("A primers-txt file should have a column that is called `name` for the primer name.")
+
+    if 'primer_sequence' not in columns_found:
+        progress.reset()
+        raise ConfigError("A primers-txt file should have a column that is called `primer_sequence` for the primer sequence.")
+
+    if len(columns_found) < 2:
+        progress.reset()
+        raise ConfigError("A primers-txt file should have at least two columns - one for primer names, and one for primer sequences.")
+
+    item_column = columns_found[0]
+    if item_column != 'name':
+        progress.reset()
+        raise ConfigError("The first column in your primers-txt file does not seem to be `name`. Anvi'o expects the first "
+                          "column to have sequence names.")
+
+    primers_txt = get_TAB_delimited_file_as_dictionary(file_path)
+
+    return primers_txt
+
+
 def get_groups_txt_file_as_dict(file_path, run=run, progress=progress):
     """Groups-txt is an anvi'o artifact associating items with groups. This function extracts this file into a set of dictionaries.
 

--- a/sandbox/anvi-script-get-primer-matches
+++ b/sandbox/anvi-script-get-primer-matches
@@ -2,6 +2,7 @@
 # -*- coding: utf-8
 
 import os
+import re
 import sys
 
 import anvio
@@ -20,9 +21,9 @@ __license__ = "GPL 3.0"
 __version__ = anvio.__version__
 __authors__ = ['meren']
 __provides__ = ["short-reads-fasta"]
-__requires__ = ["samples-txt"]
-__description__ = ("You provide this program with FASTQ files for one or more samples AND one or more short sequences, "
-                   "and it collects reads from FASTQ files that matches to your sequences. This tool can be "
+__requires__ = ["samples-txt", "primers-txt"]
+__description__ = ("You provide this program with FASTQ files for one or more samples AND one or more primer sequences, "
+                   "and it collects reads from FASTQ files that matches to your primers. This tool can be "
                    "most powerful if you want to collect all short reads from one or more metagenomes that are "
                    "downstream to a known sequence. Using the comprehensive output files you can analyze the "
                    "diversity of seuqences visually, manually, or using established strategies such as oligotyping.")
@@ -37,44 +38,42 @@ P = terminal.pluralize
 def main(args):
     A = lambda x: args.__dict__[x] if x in args.__dict__ else None
     samples_txt = A('samples_txt')
-    primers_file_path = A('primer_sequences')
+    primers_file_path = A('primers_txt')
     output_directory_path = A('output_dir') or os.path.abspath('./MATCHING_SEQUENCES')
     min_remainder_length = A('min_remainder_length') or 60
-    report_raw = A('report_raw')
     stop_after = A('stop_after')
+    only_report_primer_matches = A('only_report_primer_matches')
+
+    if only_report_primer_matches:
+        min_remainder_length = 0
 
     filesnpaths.check_output_directory(output_directory_path)
 
-    filesnpaths.is_file_tab_delimited(samples_txt)
-    filesnpaths.is_file_plain_text(primers_file_path)
-
     samples_dict = utils.get_samples_txt_file_as_dict(samples_txt, run=run)
-    primers = [s.strip().upper() for s in open(primers_file_path).readlines() if s[0] != '#']
+    primers_dict = utils.get_primers_txt_file_as_dict(primers_file_path)
 
     run.info("Samples found", f"({len(samples_dict)}) {' '.join(samples_dict.keys())}")
-    run.info("Match sequences found", f"({len(primers)}) {' '.join(primers)}")
+    run.info("Primers found", f"({len(primers_dict)}) {'; '.join(primers_dict.keys())}")
+    run.info('Output directory', output_directory_path, nl_after=1)
     run.info('Min remainder length', min_remainder_length)
-    run.info('Output directory', output_directory_path)
-    run.info('Report raw', report_raw)
     if stop_after:
-        run.info('Stop after', stop_after, mc='red')
+        run.info('Only report primer matches', only_report_primer_matches)
+        run.info('Stop after', stop_after, mc='red', nl_after=1)
+    else:
+        run.info('Only report primer matches', only_report_primer_matches, nl_after=1)
 
     filesnpaths.gen_output_directory(output_directory_path)
 
     for sample_name in samples_dict:
         samples_dict[sample_name]['hits'] = {}
 
-    primers_dict = {}
-    for m in primers:
-        primers_dict[m] = {'matching_sequences': {},
-                           'primer_length': len(m),
-                           'primer_sequence': m,
-                           'primer_sequence_rc': utils.rev_comp(m)}
+    for primer_name in primers_dict:
+        primers_dict[primer_name]['matching_sequences'] = {}
+        primers_dict[primer_name]['primer_length'] = len(primers_dict[primer_name]['primer_sequence'])
 
         for sample_name in samples_dict:
-            samples_dict[sample_name]['hits'][m] = 0
-            primers_dict[m]['matching_sequences'][sample_name] = []
-
+            samples_dict[sample_name]['hits'][primer_name] = 0
+            primers_dict[primer_name]['matching_sequences'][sample_name] = []
 
     total_read_counter = 0
     total_hit_counter = 0
@@ -87,6 +86,7 @@ def main(args):
         read_counter = 0
         hit_counter = 0
         hit_in_rc = 0
+        removed_due_to_remainder_length = 0
         for pair in ['r1', 'r2']:
             input_fastq_file_path = samples_dict[sample_name][pair]
             input_fastq = u.FastQSource(input_fastq_file_path, compressed=input_fastq_file_path.endswith('.gz'))
@@ -99,36 +99,41 @@ def main(args):
 
                 found_in_RC = False
 
-                for v in primers_dict.values():
+                for primer_name in primers_dict:
+                    v = primers_dict[primer_name]
                     seq = input_fastq.entry.sequence
-                    pos = seq.find(v['primer_sequence'])
+                    match = re.search(v['primer_sequence'], seq)
 
-                    if pos < 0:
-                        # it not in it. how about the the reverse complement of it?
-                        if seq.find(v['primer_sequence_rc']) >= 0:
+                    if not match:
+                        # no match here. but how about the the reverse complement of it?
+                        seq = utils.rev_comp(seq)
+
+                        match = re.search(v['primer_sequence'], seq)
+
+                        if match:
                             # aha. the reverse complement sequence that carries our match found.
-                            # now we will reverse complement the long sequence and update the pos
-                            # and will continue as if nothing happened
+                            # will continue as if nothing happened
                             found_in_RC = True
-                            hit_in_rc += 1
-                            seq = utils.rev_comp(seq)
-                            pos = seq.find(v['primer_sequence'])
 
-                    if pos < 0:
+                    if not match:
                         continue
 
-                    if len(seq[pos + v['primer_length']:]) < min_remainder_length:
+                    if len(seq) - match.end() < min_remainder_length:
+                        removed_due_to_remainder_length += 1
                         continue
 
-                    v['matching_sequences'][sample_name].append((pos, seq), )
+                    v['matching_sequences'][sample_name].append((match.start(), match.end(), seq), )
 
                     hit_counter += 1
 
-                    samples_dict[sample_name]['hits'][v['primer_sequence']] += 1
+                    if found_in_RC:
+                        hit_in_rc += 1
+
+                    samples_dict[sample_name]['hits'][primer_name] += 1
 
                     if anvio.DEBUG:
                         progress.end()
-                        print("\n%s -- %s| %s [%s] %s" % (sample_name, 'RC ' if found_in_RC else '   ', seq[:pos], v['primer_sequence'], seq[pos+v['primer_length']:]))
+                        print("\n%s -- %s -- %s| %s [%s] %s" % (sample_name, pair, 'RC ' if found_in_RC else '   ', seq[:match.start()], v['primer_sequence'], seq[match.end():]))
                         progress.new("Tick tock")
                         progress.update(f"{sample_name} ({i + 1} of {len(samples_dict)}) / {pair} / Reads: {pp(read_counter)} / Hits: {pp(hit_counter)} (in RC: {pp(hit_in_rc)})")
 
@@ -143,17 +148,18 @@ def main(args):
 
     run.warning(None, header="HITS PER SAMPLE", lc='yellow')
     run.info('Summary', "", nl_after=1)
-    run.info_single(f"After processing {pp(total_read_counter)} reads in {P('sample', len(samples_dict))}, anvi'o found "
-                    f"{P('hit', total_hit_counter)} for your {P('sequence', len(primers_dict), pfs='only')} "
+    run.info_single(f"After processing {pp(total_read_counter)} individual reads in {P('sample', len(samples_dict))}, anvi'o "
+                    f"found {P('hit', total_hit_counter)} for your {P('sequence', len(primers_dict), pfs='only')} in the"
                     f"in the primer sequences file. What is shown below breaks these numbers down per sample because that's how "
-                    f"anvi'o rolls (SAM: Shortest sequence after match; LAM: Longest sequence after match; ALAM: Average length after match).", nl_after=1)
+                    f"anvi'o rolls (SAM: Shortest sequence after match; LAM: Longest sequence after match; ALAM: Average length "
+                    f"after match).", nl_after=1)
 
     for sample_name in samples_dict:
         run.info(f"{sample_name}", f"{pp(samples_dict[sample_name]['num_reads'])} total reads", nl_before=1, lc="green", mc="green")
         for primer_sequence in primers_dict:
             matching_sequence_hits = primers_dict[primer_sequence]['matching_sequences'][sample_name]
             primer_length = primers_dict[primer_sequence]['primer_length']
-            seq_lengths_after_match = [len(s[1][s[0]+primer_length:]) for s in matching_sequence_hits]
+            seq_lengths_after_match = [len(sequence[end:]) for start, end, sequence in matching_sequence_hits]
 
             if len(seq_lengths_after_match):
                 run.info(f"    {primer_sequence}", f"{pp(samples_dict[sample_name]['hits'][primer_sequence])} hits / SAM: {min(seq_lengths_after_match)} / LAM: {max(seq_lengths_after_match)} / ALAM: {sum(seq_lengths_after_match) / len(primers_dict[primer_sequence]['matching_sequences']):.2f}")
@@ -173,13 +179,13 @@ def main(args):
             output_file_path = os.path.join(output_directory_path, '%s-%s-HITS.fa' % (sample_name, primer_sequence))
             with open(output_file_path, 'w') as output:
                 counter = 1
-                for hit in matching_sequence_hits:
-                    output.write(f'>{sample_name}_{primer_sequence}_{counter:05d}\n{hit[1]}\n')
+                for start, end, sequence in matching_sequence_hits:
+                    output.write(f'>{sample_name}_{primer_sequence}_{counter:05d}\n{sequence[start:end]}\n')
                     counter += 1
     progress.end()
 
-    if report_raw:
-        run.info_single(f"Output files for raw sequences are ready in {output_directory_path}")
+    if only_report_primer_matches:
+        run.info_single(f"Someone asked anvi'o to only report primer matches. And they are ready in your output directory.")
         sys.exit()
 
     progress.new("Generating the fancy hits files")
@@ -191,14 +197,14 @@ def main(args):
 
             matching_sequence_hits = primers_dict[primer_sequence]['matching_sequences'][sample_name]
             primer_length = primers_dict[primer_sequence]['primer_length']
-            seq_lengths_after_match = [len(s[1][s[0]+primer_length:]) for s in matching_sequence_hits]
+            seq_lengths_after_match = [len(sequence[end:]) for start, end, sequence in matching_sequence_hits]
 
             with open(trimmed_output_file_path, 'w') as trimmed, open(gapped_output_file_path, 'w') as gapped:
                 max_seq_length = (max(seq_lengths_after_match) + primer_length) if len(seq_lengths_after_match) else 0
                 min_seq_length = (min(seq_lengths_after_match) + primer_length) if len(seq_lengths_after_match) else 0
                 counter = 1
-                for hit in matching_sequence_hits:
-                    sequence = hit[1][hit[0]:]
+                for start, end, sequence in matching_sequence_hits:
+                    sequence = sequence[start:]
 
                     sequence = sequence + '-' * (max_seq_length - len(sequence))
                     gapped.write(f'>{sample_name}_{primer_sequence}_{counter:05d}\n{sequence}\n')
@@ -220,16 +226,21 @@ if __name__ == '__main__':
                             "which you are interested to find in those FASTQ files. Each file should have at least one "
                             "entry")
     groupA.add_argument(*anvio.A('samples-txt'), **anvio.K('samples-txt'))
-    groupA.add_argument('--primer-sequences', required=True, metavar='FILE', help="A single-column file that contains one "
-                            "or more short sequences to be searhed.")
+    groupA.add_argument('--primers-txt', required=True, metavar='FILE', help="A two-column file that contains one "
+                            "or more primer sequences. See the primers-txt artifact for details.")
 
-    groupB = parser.add_argument_group('PARAMETERS OF LIFE AND DEATH', "Here you are expected to set appropriate "
-                            "paramters for your search (or you can choose to go with the defaults)")
+    groupB = parser.add_argument_group('PARAMETERS OF LIFE OR DEATH', "Here you are expected to set appropriate "
+                            "parameters for your search (or you can choose to go with the defaults)")
     groupB.add_argument('-m', '--min-remainder-length', metavar='INT', type=int, default=60,
                         help="Minimum length of the remainder of the read after a match. If your short read "
                               "is XXXMMMMMMYYYYYYYYYYYYYY, where Ms indicate the primer sequence, "
                               "min remainder length is equal to the length of nucleotide matching Y. Default is %(default)d.")
-    groupB.add_argument('--report-raw', action="store_true", help="Just report them sequences. Don't bother trimming.")
+    groupB.add_argument('-x', '--only-report-primer-matches', default=False, action="store_true",
+                        help="For a given sequence with a primer match, report only the part of it that matches to the primer. "
+                             "In other words, if your short read is XXXMMMMMMYYYYYYYYYYYYYY, where Ms indicate part of your "
+                             "sequence that matches to the primer, setting this flag will remove all Xs and Ys. Setting "
+                             "this flag will automatically set the `--min-remainder-length` to 0. If you have a problem with "
+                             "that, let us know.")
     groupB.add_argument('--stop-after', metavar='INT', type=int, default=0, help="Stop after X number of hits because "
                                "who needs data.")
 


### PR DESCRIPTION
This PR introduces a new anvi'o artifact `primers-txt`, updates for the program `anvi-script-get-primer-matches` so it can work with regex rather than perfect matches, and updates to the docs.