### PR TITLE
sort locus by gene start position

### DIFF
--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -1006,7 +1006,9 @@ class LocusSplitter:
         # Query for gene_call, contig_name, and genes_in_contig_sorted
         gene_call = self.contigs_db.genes_in_contigs_dict[gene_callers_id]
         contig_name = self.contigs_db.genes_in_contigs_dict[gene_callers_id]['contig']
-        genes_in_contig_sorted = sorted(list(self.contigs_db.contig_name_to_genes[contig_name]))
+
+        # Sort by gene start position
+        genes_in_contig_sorted = sorted(list(self.contigs_db.contig_name_to_genes[contig_name]), key=lambda tup: tup[1])
 
         D = lambda: 1 if gene_call['direction'] == 'f' else -1
         premature = False


### PR DESCRIPTION
Hey @meren and @ekiefl, please check out this important change I am making to `anvi-export-locus` to address #1841.

Sorting by gene start position will allow for all gene-callers to be considered at once.

Shoutout to @ivagljiva for helping me come up with a solution!