### PR TITLE
Get num genomes simplified

### DIFF
--- a/anvio/docs/artifacts/contigs-db.md
+++ b/anvio/docs/artifacts/contigs-db.md
@@ -38,3 +38,40 @@ If you wish to run programs like %(anvi-cluster-contigs)s, %(anvi-estimate-metab
 ## Variants
 
 Contigs databases, like %(profile-db)ss, are allowed have different variants, though the only currently implemented variant, the %(trnaseq-contigs-db)s, is for tRNA transcripts from tRNA-seq experiments. The default variant stored for "standard" contigs databases is `unknown`. Variants should indicate that substantially different information is stored in the database. For instance, open reading frames are applicable to protein-coding genes but not tRNA transcripts, so ORF data is not recorded for the `trnaseq` variant. The $(trnaseq-workflow)s generates %(trnaseq-contigs-db)ss using a very different approach to %(anvi-gen-contigs-database)s.
+
+## For programmers
+
+Tips and use cases for programmers. Send us your questions so we can extend this section with useful examples.
+
+### Get number of approximate number of genomes
+
+You can get the number of genomes once %(anvi-run-hmms)s is run on an contigs database. Here are some examples:
+
+``` python
+from anvio.hmmops import NumGenomesEstimator
+
+# the raw data, where each key is one of the HMM collections
+# of type `singlecopy` run on the contigs-db
+NumGenomesEstimator('CONTIGS.db').estimates_dict
+>>> {'Bacteria_71': {'num_genomes': 9, 'domain': 'bacteria'},
+     'Archaea_76': {'num_genomes': 1, 'domain': 'archaea'},
+     'Protista_83': {'num_genomes': 1, 'domain': 'eukarya'}}
+
+# slightly fancier output with a single integer for
+# estimated number of genomes summarized, along with
+# domains used
+num_genomes, domains_included = NumGenomesEstimator('CONTIGS.db').num_genomes()
+print(num_genomes)
+>>> 11
+
+print(domains_included)
+>>> ['bacteria', 'archaea', 'eukarya']
+
+# limiting the domains
+num_genomes, domains_included = NumGenomesEstimator('CONTIGS.db').num_genomes(for_domains=['archaea', 'eukarya'])
+print(num_genomes)
+>>> 2
+
+print(domains_included)
+>>> ['archaea', 'eukarya']
+```

--- a/anvio/hmmops.py
+++ b/anvio/hmmops.py
@@ -818,3 +818,62 @@ class SequencesForHMMHits:
             self.__store_concatenated_hmm_sequences_into_FASTA(hmm_sequences_dict_for_splits, output_file_path, partition_file_path, wrap, separator, genes_order, align_with, just_do_it)
         else:
             self.__store_individual_hmm_sequences_into_FASTA(hmm_sequences_dict_for_splits, output_file_path, wrap, separator, genes_order, align_with)
+
+
+class NumGenomesEstimator(SequencesForHMMHits):
+    """A simple interface to get estimated number of genomes from a contigs database.
+
+    Notes for programmers
+    =====================
+    - Major changes in this class should consdier the use case example
+      in `anvio/docs/artifacts/contigs-db.md`.
+    """
+    def __init__(self, contigs_db_path, run=terminal.Run(verbose=False), progress=terminal.Progress(verbose=False)):
+        self.run = run
+        self.progress = progress
+        self.contigs_db_path = contigs_db_path
+
+        SequencesForHMMHits.__init__(self, self.contigs_db_path, run=self.run, progress=self.progress)
+
+        self.estimates_dict = self.get_num_genomes_from_SCG_sources_dict()
+
+        self.per_domain_totals = {}
+        for entry in self.estimates_dict.values():
+            if entry['domain'] not in self.per_domain_totals:
+                self.per_domain_totals[entry['domain']] = 0
+
+            self.per_domain_totals[entry['domain']] += entry['num_genomes']
+
+
+    def num_genomes(self, for_domains=[]):
+        """Higher-order estimate for the number of genomes
+
+        Parameters
+        ==========
+        for_domains, list:
+            The SCG domains you wish the get a tally for. By default, the function will return number of
+            genomes found in all domains.
+
+        Returns
+        =======
+            <num_genomes, domains>, tuple:
+                This function will return a tuple with two items. The first is the total number of genomes
+                estimated, and the second is the domains used for this estimate.
+        """
+
+        if for_domains:
+            missing_domains = [d for d in for_domains if d not in self.per_domain_totals]
+            if len(missing_domains):
+                raise ConfigError(f"One of more of the domains you have requested do not seem to be among those that "
+                                  f"anvi'o knows about \"{', '.join(missing_domains)}\". If what you are seeing is not "
+                                  f"due to a typo, this can happen if you don't have the single-copy core gene set "
+                                  f"to estimate number of genomes that belong to this domain. You perhaps do not have "
+                                  f"them because you didn't run the program `anvi-run-hmms` on your contigs-db with all "
+                                  f"the default HMM collections, or you are a dreamer who wishes some domain you are "
+                                  f"working with is total news to anvi'o. If it is the latter, please get in touch with "
+                                  f"us.")
+
+        if not for_domains:
+            for_domains = list(self.per_domain_totals.keys())
+
+        return (sum([self.per_domain_totals[d] for d in for_domains]), for_domains)


### PR DESCRIPTION
Simple, very simple:

``` python
from anvio.hmmops import NumGenomesEstimator

# the raw data, where each key is one of the HMM collections
# of type `singlecopy` run on the contigs-db
NumGenomesEstimator('CONTIGS.db').estimates_dict
>>> {'Bacteria_71': {'num_genomes': 9, 'domain': 'bacteria'},
     'Archaea_76': {'num_genomes': 1, 'domain': 'archaea'},
     'Protista_83': {'num_genomes': 1, 'domain': 'eukarya'}}

# slightly fancier output with a single integer for
# estimated number of genomes summarized, along with
# domains used
num_genomes, domains_included = NumGenomesEstimator('CONTIGS.db').num_genomes()
print(num_genomes)
>>> 11

print(domains_included)
>>> ['bacteria', 'archaea', 'eukarya']

# limiting the domains
num_genomes, domains_included = NumGenomesEstimator('CONTIGS.db').num_genomes(for_domains=['archaea', 'eukarya'])
print(num_genomes)
>>> 2

print(domains_included)
>>> ['archaea', 'eukarya']
```