### PR TITLE
Filter hm ms update

### DIFF
--- a/anvio/tests/run_workflow_tests_for_ecophylo.sh
+++ b/anvio/tests/run_workflow_tests_for_ecophylo.sh
@@ -12,8 +12,7 @@ cp $files/data/genomes/bacteria/*.db                                    $output_
 cp $files/data/genomes/archaea/*.db                                     $output_dir/workflow_test
 cp $files/data/input_files/metagenomes.txt                              $output_dir/workflow_test
 cp $files/data/input_files/external-genomes.txt                         $output_dir/workflow_test
-cp $files/data/input_files/hmm_list.txt                                 $output_dir/workflow_test
-cp $files/data/input_files/hmm_list_external.txt                        $output_dir/workflow_test
+cp $files/data/input_files/hmm_list*                                    $output_dir/workflow_test
 cd $output_dir/workflow_test
 
 INFO "Creating a default config for ecophylo workflow"
@@ -50,7 +49,7 @@ anvi-run-workflow -w ecophylo -c only-metagenomes-txt-config.json -A --dry-run
 INFO "Running ecophylo workflow with ecophylo dry-run: only external-genomes.txt"
 anvi-run-workflow -w ecophylo -c only-external-genomes-txt-config.json -A --dry-run
 
-INFO "Running ecophylo workflow"
+INFO "EcoPhylo: profiling evolution AND ecology with Ribosomal_L16 on metagenomes and genomes"
 anvi-run-workflow -w ecophylo -c default-config.json
 
 INFO "Running ecophylo workflow interactive"
@@ -63,11 +62,11 @@ rm -rf $output_dir/workflow_test/ECOPHYLO_WORKFLOW/
 INFO "Saving a workflow graph - no samples.txt"
 anvi-run-workflow -w ecophylo -c no-samples-txt-config.json --save-workflow-graph
 
-INFO "Running ecophylo workflow with ecophylo dry-run - no samples.txt"
+INFO "EcoPhylo: profiling just evolution with Ribosomal_L16 and Ribosomal_L2 on metagenomes and genomes - no samples.txt (dry-run)"
 anvi-run-workflow -w ecophylo -c no-samples-txt-config.json -A --dry-run
 
-INFO "Running ecophylo workflow - no samples.txt"
-anvi-run-workflow -w ecophylo -c no-samples-txt-config.json
+INFO "EcoPhylo: profiling just evolution with Ribosomal_L16 and Ribosomal_L2 on metagenomes and genomes - no samples.txt"
+anvi-run-workflow -w ecophylo -c no-samples-txt-config.json 
 
 INFO "Running ecophylo workflow interactive"
 HMM="Ribosomal_L16"
@@ -82,6 +81,5 @@ anvi-run-workflow -w ecophylo -c only-external-genomes-txt-config.json
 
 INFO "Running ecophylo workflow interactive from external HMM"
 HMM="Ribosomal_L16"
-anvi-interactive -t ECOPHYLO_WORKFLOW/05_TREES/"${HMM}"/"${HMM}"_renamed.nwk \
-                 -p ECOPHYLO_WORKFLOW/05_TREES/"${HMM}"/"${HMM}"-PROFILE.db \
-                 --manual
+anvi-interactive -c ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/03_CONTIGS/"${HMM}"-contigs.db \
+                 -p ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/06_MERGED/"${HMM}"/PROFILE.db

--- a/anvio/tests/sandbox/data/input_files/hmm_list-no-samples-txt.txt
+++ b/anvio/tests/sandbox/data/input_files/hmm_list-no-samples-txt.txt
@@ -1,0 +1,3 @@
+name	source	path
+Ribosomal_L16	Bacteria_71	INTERNAL
+Ribosomal_L2	Bacteria_71	INTERNAL

--- a/anvio/tests/sandbox/workflows/ecophylo/no-samples-txt-config.json
+++ b/anvio/tests/sandbox/workflows/ecophylo/no-samples-txt-config.json
@@ -1,7 +1,7 @@
 {
     "metagenomes": "metagenomes.txt",
     "external_genomes": "external-genomes.txt",
-    "hmm_list": "hmm_list.txt",
+    "hmm_list": "hmm_list-no-samples-txt.txt",
     "cluster_representative_method": {
         "method": "mmseqs"
     },

--- a/anvio/workflows/ecophylo/Snakefile
+++ b/anvio/workflows/ecophylo/Snakefile
@@ -121,34 +121,34 @@ rule filter_hmm_hits_by_query_coverage:
         # Check if anvi-run-scg-taxonomy and/or anvi-script-filter-hmm-hits-table has been run already
         contigs_db = ContigsDatabase(contigsDB)
         try:
-            HMM_source_domain_table_was_filtered = contigs_db.meta['HMM_source_domain_table_was_filtered']
-            HMM_source_domain_table_was_filtered_list = ','.split(HMM_source_domain_table_was_filtered)
+            HMM_source_domain_table_was_filtered = contigs_db.meta['HMM_hits_domain_table_was_filtered']
+            HMM_source_domain_table_was_filtered_list = HMM_source_domain_table_was_filtered.split(",")
         except:
             HMM_source_domain_table_was_filtered_list = []
 
         contigs_db.disconnect()
 
         if HMM_source in M.internal_HMM_sources:
-            if HMM_source not in HMM_source_domain_table_was_filtered_list:
+            if HMM_source in HMM_source_domain_table_was_filtered_list:
+                print(f"The HMM source {HMM_source} has already been filtered, skipping filter_hmm_hits_by_query_coverage!")
+                pass
+            else:
                 shell(f"anvi-script-filter-hmm-hits-table -c {contigsDB} \
                                                         --domain-hits-table {domtblout} \
                                                         --hmm-source {HMM_source} \
                                                         --query-coverage {params.query_coverage} \
                                                         {params.additional_params} 2> {log}")
-            else:
-                print(f"HMM source {HMM_source} has already been filtered, skipping!")
-                pass
         else:
-            if HMM_source not in HMM_source_domain_table_was_filtered_list:
+            if HMM_source in HMM_source_domain_table_was_filtered_list:
+                print(f"The HMM source {HMM_source} has already been filtered, skipping filter_hmm_hits_by_query_coverage!")
+                pass
+            else:
                 shell(f"anvi-script-filter-hmm-hits-table -c {contigsDB} \
                                                         --domain-hits-table {domtblout} \
                                                         --hmm-profile-dir {HMM_dir} \
                                                         --hmm-source {HMM_source} \
                                                         --query-coverage {params.query_coverage} \
                                                         {params.additional_params} 2> {log}")
-            else:
-                print(f"HMM source {HMM_source} has already been filtered, skipping!")
-                pass
                 
         shell('touch {output.done}')
 

--- a/anvio/workflows/ecophylo/Snakefile
+++ b/anvio/workflows/ecophylo/Snakefile
@@ -135,6 +135,7 @@ rule filter_hmm_hits_by_query_coverage:
                                                         --query-coverage {params.query_coverage} \
                                                         {params.additional_params} 2> {log}")
             else:
+                print(f"HMM source {HMM_source} has already been filtered, skipping!")
                 pass
         else:
             if HMM_source not in HMM_source_domain_table_was_filtered_list:
@@ -145,6 +146,7 @@ rule filter_hmm_hits_by_query_coverage:
                                                         --query-coverage {params.query_coverage} \
                                                         {params.additional_params} 2> {log}")
             else:
+                print(f"HMM source {HMM_source} has already been filtered, skipping!")
                 pass
                 
         shell('touch {output.done}')

--- a/anvio/workflows/ecophylo/Snakefile
+++ b/anvio/workflows/ecophylo/Snakefile
@@ -44,7 +44,7 @@ rule anvi_run_hmms_hmmsearch:
     log: os.path.join(dirs_dict['LOGS_DIR'], "anvi_run_hmms_hmmsearch-{sample_name}-{HMM}.log")
     input:
     output:
-        done = os.path.join(dirs_dict['EXTRACTED_RIBO_PROTEINS_DIR'], "{sample_name}-{HMM}-dom_hmmsearch/contigs-hmmsearch.done"),
+        done = os.path.join(dirs_dict['EXTRACTED_RIBO_PROTEINS_DIR'], "{sample_name}-{HMM}-contigs-hmmsearch.done"),
     params:
         hmm_source = M.get_param_value_from_config(['anvi_run_hmms_hmmsearch', '--installed-hmm-profile']),
         additional_params = M.get_param_value_from_config(['trim_alignment', 'additional_params'])
@@ -69,14 +69,14 @@ rule anvi_run_hmms_hmmsearch:
             else:
                 pass
 
-                # Load contigsDB
-                contigs_db = ContigsDatabase(contigsDB)
-                # Check if anvi-run-scg-taxonomy has been run
-                scg_taxonomy_was_run_value = contigs_db.meta['scg_taxonomy_was_run']
+            # Load contigsDB
+            contigs_db = ContigsDatabase(contigsDB)
+            # Check if anvi-run-scg-taxonomy has been run
+            scg_taxonomy_was_run_value = contigs_db.meta['scg_taxonomy_was_run']
 
-                if scg_taxonomy_was_run_value != 1:
-                    print(f"Running anvi-run-scg-taxonomy on {contigsDB} since the {wildcards.HMM} is in anvio's collection of SCGs")
-                    shell("anvi-run-scg-taxonomy -c {contigsDB} --num-threads {threads} {params.additional_params}")
+            if scg_taxonomy_was_run_value != 1:
+                print(f"Running anvi-run-scg-taxonomy on {contigsDB} since the {wildcards.HMM} is in anvio's collection of SCGs")
+                shell("anvi-run-scg-taxonomy -c {contigsDB} --num-threads {threads} {params.additional_params}")
         else:
             if not os.path.exists(hmmer_output_dir):
                 print(f"Running external HMM dataset: {wildcards.HMM}")
@@ -115,20 +115,38 @@ rule filter_hmm_hits_by_query_coverage:
         HMM_dir = os.path.join(M.HMM_path_dict[wildcards.HMM])
         HMM_source = M.HMM_source_dict[wildcards.HMM]
         domtblout = os.path.join(dirs_dict['EXTRACTED_RIBO_PROTEINS_DIR'], f"{wildcards.sample_name}-{HMM_source}-dom_hmmsearch/hmm.domtable")
+        hmmer_output_dir = os.path.join(dirs_dict['EXTRACTED_RIBO_PROTEINS_DIR'], f"{wildcards.sample_name}-{HMM_source}-dom_hmmsearch")
+
+        # Check if anvi-run-scg-taxonomy and/or anvi-script-filter-hmm-hits-table has been run already
+        contigs_db = ContigsDatabase(contigsDB)
+        try:
+            HMM_source_domain_table_was_filtered = contigs_db.meta['HMM_source_domain_table_was_filtered']
+            HMM_source_domain_table_was_filtered_list = ','.split(HMM_source_domain_table_was_filtered)
+        except:
+            HMM_source_domain_table_was_filtered_list = []
+
+        contigs_db.disconnect()
 
         if HMM_source in M.internal_HMM_sources:
-            shell(f"anvi-script-filter-hmm-hits-table -c {contigsDB} \
-                                                    --domain-hits-table {domtblout} \
-                                                    --hmm-source {HMM_source} \
-                                                    --query-coverage {params.query_coverage} \
-                                                    {params.additional_params} 2> {log}")
+            if HMM_source not in HMM_source_domain_table_was_filtered_list:
+                shell(f"anvi-script-filter-hmm-hits-table -c {contigsDB} \
+                                                        --domain-hits-table {domtblout} \
+                                                        --hmm-source {HMM_source} \
+                                                        --query-coverage {params.query_coverage} \
+                                                        {params.additional_params} 2> {log}")
+            else:
+                pass
         else:
-            shell(f"anvi-script-filter-hmm-hits-table -c {contigsDB} \
-                                                    --domain-hits-table {domtblout} \
-                                                    --hmm-profile-dir {HMM_dir} \
-                                                    --hmm-source {HMM_source} \
-                                                    --query-coverage {params.query_coverage} \
-                                                    {params.additional_params} 2> {log}")
+            if HMM_source not in HMM_source_domain_table_was_filtered_list:
+                shell(f"anvi-script-filter-hmm-hits-table -c {contigsDB} \
+                                                        --domain-hits-table {domtblout} \
+                                                        --hmm-profile-dir {HMM_dir} \
+                                                        --hmm-source {HMM_source} \
+                                                        --query-coverage {params.query_coverage} \
+                                                        {params.additional_params} 2> {log}")
+            else:
+                pass
+                
         shell('touch {output.done}')
 
 
@@ -967,7 +985,7 @@ if M.samples_txt_file:
             # basics
             state_dict['version'] = '3'
             state_dict['tree-type'] = 'phylogram'
-            state_dict['current-view'] = 'single'
+            state_dict['current-view'] = 'mean_coverage'
 
             # height and width
             # FIXME: It's unclear to me how the interactive interface determines
@@ -1065,22 +1083,23 @@ if M.samples_txt_file:
             # views
             views_dict = {}
 
-            single_dict = {}
+            mean_coverage_dict = {}
 
+            false = False
             percent_identity = {
                 "normalization": "none",
                 "min": {
                     "value": "90",
-                    "disabled": "false"
+                    "disabled": false 
                     },
                 "max": {
                     "value": "100",
-                    "disabled": "false"
+                    "disabled": false
                     }
             }
 
-            single_dict['percent_identity'] = percent_identity 
-            views_dict['single'] = single_dict
+            mean_coverage_dict['percent_identity'] = percent_identity 
+            views_dict['mean_coverage'] = mean_coverage_dict
             state_dict['views'] = views_dict
 
             with open(output.state_file, "w") as outfile:
@@ -1176,40 +1195,17 @@ else:
 
 
             # layer-orders
-            first_layers = ["__parent__", "length", "gc_content"]
-
-            layer_order = first_layers + misc_layers_list 
+            if HMM_source in M.internal_HMM_sources:
+                layer_order = misc_layers_list + scg_taxonomy_layers_list 
+            else:
+                layer_order = misc_layers_list 
 
             state_dict['layer-order'] = layer_order
 
             # layers
             layers_dict = {}
 
-            layer_attributes_parent = {
-                "color": "#000000",
-                "height": "0",
-                "margin": "15",
-                "type": "color",
-                "color-start": "#FFFFFF"
-                }
-
             length = {
-                "color": "#000000",
-                "height": "0",
-                "margin": "15",
-                "type": "color",
-                "color-start": "#FFFFFF"
-                }
-
-            gc_content = {
-                "color": "#000000",
-                "height": "0",
-                "margin": "15",
-                "type": "color",
-                "color-start": "#FFFFFF"
-                }
-
-            identifier = {
                 "color": "#000000",
                 "height": "0",
                 "margin": "15",
@@ -1233,12 +1229,7 @@ else:
                 "color-start": "#FFFFFF"
                 }
                 
-            layers_dict['__parent__'] = layer_attributes_parent
-            layers_dict['length'] = length
-            layers_dict['gc_content'] = gc_content
-            layers_dict['identifier'] = identifier
             layers_dict['percent_identity'] = percent_identity
-
             state_dict['layers'] = layers_dict
 
             # views

--- a/sandbox/anvi-script-filter-hmm-hits-table
+++ b/sandbox/anvi-script-filter-hmm-hits-table
@@ -234,16 +234,18 @@ class FilterHmmHitsTable(object):
 
         # Add meta value to show which HMM_source was filtered
         self.db = db.DB(self.contigs_db_path, anvio.__contigs__version__, new_database=False)
-        sources_that_have_been_filtered = [self.db.get_meta_value('HMM_hits_domain_table_was_filtered', return_none_if_not_in_table=True)]
+        sources_that_have_been_filtered = self.db.get_meta_value('HMM_hits_domain_table_was_filtered', return_none_if_not_in_table=True)
 
         if sources_that_have_been_filtered == None:
-            sources_that_have_been_filtered = [source]
-            self.db.set_meta_value('HMM_hits_domain_table_was_filtered', sources_that_have_been_filtered)
-
-        if source not in sources_that_have_been_filtered:
-            sources_that_have_been_filtered.append(source)
+            self.db.set_meta_value('HMM_hits_domain_table_was_filtered', source)
+        else:
+            sources_that_have_been_filtered_list = sources_that_have_been_filtered.split(",")
+            sources_that_have_been_filtered_set = set(sources_that_have_been_filtered_list)
+            sources_that_have_been_filtered_set.add(source)
+            updated_sources = ",".join(list(sources_that_have_been_filtered_set))
+            self.db.update_meta_value('HMM_hits_domain_table_was_filtered', str(updated_sources))
         
-        self.db.update_meta_value('HMM_hits_domain_table_was_filtered', str(sources_that_have_been_filtered))
+        # self.db.update_meta_value('HMM_hits_domain_table_was_filtered', str(sources_that_have_been_filtered))
         self.db.disconnect()
 
 

--- a/sandbox/anvi-script-filter-hmm-hits-table
+++ b/sandbox/anvi-script-filter-hmm-hits-table
@@ -232,6 +232,20 @@ class FilterHmmHitsTable(object):
 
         hmm_tables.append_to_hmm_hits_table(source, reference, kind_of_search, domain, all_genes_searched_against, search_results_dict)
 
+        # Add meta value to show which HMM_source was filtered
+        self.db = db.DB(self.contigs_db_path, anvio.__contigs__version__, new_database=False)
+        sources_that_have_been_filtered = [self.db.get_meta_value('HMM_hits_domain_table_was_filtered', return_none_if_not_in_table=True)]
+
+        if sources_that_have_been_filtered == None:
+            sources_that_have_been_filtered = [source]
+            self.db.set_meta_value('HMM_hits_domain_table_was_filtered', sources_that_have_been_filtered)
+
+        if source not in sources_that_have_been_filtered:
+            sources_that_have_been_filtered.append(source)
+        
+        self.db.update_meta_value('HMM_hits_domain_table_was_filtered', str(sources_that_have_been_filtered))
+        self.db.disconnect()
+
 
 @terminal.time_program
 def main(args):


### PR DESCRIPTION
Hi Everyone,

I would like to add a new `self` attribute called "HMM_hits_domain_table_was_filtered" to `contigsDBs` after they have been process by `anvi-script-filter-hmm-hits-table `.  I believe this will be important for keeping track of how the `hmm_hits` table was changed. Additionally, it will prevent cases where `anvi-script-filter-hmm-hits-table` is re-run in snakemake workflows.

Will this require a migration script?

Cheers,
Matt