### PR TITLE
signalp6 parser

### DIFF
--- a/anvio/parsers/__init__.py
+++ b/anvio/parsers/__init__.py
@@ -14,6 +14,7 @@ from anvio.parsers.hmmer import HMMERTableOutput, HMMERStandardOutput
 from anvio.parsers.concoct import CONCOCT
 from anvio.parsers.interproscan import InterProScan
 from anvio.parsers.agnostos import AGNOSTOS
+from anvio.parsers.signalp6 import signalp6
 
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
@@ -28,7 +29,7 @@ __email__ = "a.murat.eren@gmail.com"
 parser_modules = {}
 parser_modules['taxonomy_genes']  = {"default_matrix": DefaultMatrix, "centrifuge": Centrifuge, 'kaiju': Kaiju}
 parser_modules['taxonomy_layers'] = {"krakenuniq": KrakenUniq}
-parser_modules['functions']       = {"interproscan": InterProScan, "AGNOSTOS": AGNOSTOS}
+parser_modules['functions']       = {"interproscan": InterProScan, "AGNOSTOS": AGNOSTOS, "signalp6": signalp6}
 parser_modules['search']          = {"hmmer_table_output": HMMERTableOutput, "hmmer_std_output": HMMERStandardOutput}
 parser_modules['collections']     = {"concoct": CONCOCT}
 

--- a/anvio/parsers/signalp6.py
+++ b/anvio/parsers/signalp6.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import os
+import sys
+import csv
+import pandas as pd
+
+import anvio
+import anvio.terminal as terminal
+import anvio.constants as constants
+import anvio.filesnpaths as filesnpaths
+
+from anvio.errors import ConfigError
+from anvio.parsers.base import Parser
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__credits__ = []
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "Matthew S. Schechter"
+__email__ = "mschechter@uchicago.edu"
+
+
+class signalp6(Parser):
+    def __init__(self, input_file_paths, run=terminal.Run(), progress=terminal.Progress()):
+        self.run = run
+        self.progress = progress
+        self.just_do_it = False
+
+        input_file_path = self.fix_input_file(input_file_paths[0])
+
+        files_expected = {'signalp6_output': input_file_path}
+
+        files_structure = {'signalp6_output':
+                                {'col_names': ['gene_callers_id', 'Prediction', 'OTHER', 'SP(Sec/SPI)', 'LIPO(Sec/SPII)', 'TAT(Tat/SPI)', 'TATLIPO(Sec/SPII)', 'PILIN(Sec/SPIII)', 'CS Position'],
+                                 'col_mapping': [int, str, float, float, float, float, float, float, str],
+                                 'indexing_field': -1,
+                                 'separator': '\t'},
+                            }
+
+        self.progress.new('Initializing the parser')
+        self.progress.update('...')
+        Parser.__init__(self, 'signalp6', [input_file_path], files_expected, files_structure)
+        self.progress.end()
+
+        # This is where I would write specific sanity checks for signalp6
+
+
+    def fix_input_file(self, input_file_path):
+        """Select columns for anvio and remove duplicate rows"""
+        self.progress.new('Making signalp6 output anvio friendly')
+        self.progress.update('...')
+
+        temp_file_path = filesnpaths.get_temp_file_path()
+
+        file = open(input_file_path, "r")
+        tsv_file = csv.reader(file, delimiter="\t")
+
+        lists_from_csv = []
+        for row in tsv_file:
+            lists_from_csv.append(row)
+
+        # Remove first line
+        del lists_from_csv[0]
+
+        # Get column names
+        col_names = lists_from_csv[0]
+        col_names[0] = col_names[0][2:]
+
+        # create df
+        df = pd.DataFrame(lists_from_csv[1:], columns = col_names)
+        df = df.rename(columns={'ID': 'gene_callers_id'})
+        df = df.drop_duplicates(subset=["gene_callers_id"])
+
+        # remove "Other" annotations which means no signal peptide  
+        df = df[df['Prediction'] != "OTHER"]
+
+        df.to_csv(temp_file_path, sep = '\t', index = False, na_rep = 'NA')
+
+        self.progress.end()
+
+        return temp_file_path
+
+
+    def get_dict(self):
+        """Convert angostos output into functions dict"""
+        d = self.dicts['signalp6_output']
+
+        # Parse signalp6 output to make functions_dict
+        df = pd.DataFrame.from_dict(d, orient='index')
+        df['source'] = "signalp6"
+        df['e_value'] = 0
+        df['accession'] = df['Prediction']
+        df['function'] = df['Prediction']
+        df = df.drop_duplicates(subset=['gene_callers_id', 'source', 'accession', 'function'])
+        d = df.to_dict(orient='index')
+
+        return d


### PR DESCRIPTION
Hi anvi'o team!

I would like to add a new parser for `anvi-import-function` to include [signalp6](https://github.com/fteufel/signalp-6.0) annotations to gene calls. I believe it will be impactful for the userbase to learn which proteins in their contigs-dbs have the potential to be secreted. 

Here's an example of signalp6 with the Infant Gut Dataset:

If just want to run the parser, paste this output into the file `prediction_results.txt`  and that will work with the example below
```bash
$ cat prediction_results.txt
# SignalP-6.0	Organism: Other	Timestamp: 20220210111111
# ID	Prediction	OTHER	SP(Sec/SPI)	LIPO(Sec/SPII)	TAT(Tat/SPI)	TATLIPO(Sec/SPII)	PILIN(Sec/SPIII)	CS Position
52	LIPO	0.000000	0.000000	1.000050	0.000000	0.000000	0.000000	CS pos: 23-24. Pr: 0.9947
57	SP	0.000394	0.998806	0.000252	0.000182	0.000179	0.000159	CS pos: 32-33. Pr: 0.9711
58	LIPO	0.000000	0.000000	1.000062	0.000000	0.000000	0.000000	CS pos: 22-23. Pr: 0.9938
66	SP	0.001318	0.511084	0.486915	0.000299	0.000197	0.000167	CS pos: 32-33. Pr: 0.4850
80	SP	0.000331	0.998925	0.000253	0.000165	0.000164	0.000147	CS pos: 32-33. Pr: 0.9691
84	SP	0.000336	0.998851	0.000203	0.000207	0.000197	0.000182	CS pos: 24-25. Pr: 0.9744
86	LIPO	0.000000	0.000000	1.000077	0.000000	0.000000	0.000000	CS pos: 21-22. Pr: 0.9955
122	LIPO	0.000000	0.000000	1.000044	0.000000	0.000000	0.000000	CS pos: 22-23. Pr: 0.9970
123	LIPO	0.000000	0.000000	1.000072	0.000000	0.000000	0.000000	CS pos: 22-23. Pr: 0.9957
```

Quick note about the signalp6 output:
- Not including the model probability for the signal peptide annotation type
- filtering out annotations the are "OTHER" (no signal peptide annotations)


Here's is the parser in action:
```bash
# get sequences from IGD genome
anvi-get-sequences-for-gene-calls -c additional-files/pangenomics/external-genomes/Enterococcus_faecalis_6563.db  --get-aa-sequences -o Enterococcus_faecalis_6563.fa

# Subset for a faster prediction
head -n 3001 Enterococcus_faecalis_6563.fa > Enterococcus_faecalis_6563_small.fa

# run signalp6
signalp6 --fastafile Enterococcus_faecalis_6563_small.fa --organism other --output_dir signal_peps --format txt --mode fast

# import signalp6 predictions into anvio
anvi-import-functions -c additional-files/pangenomics/external-genomes/Enterococcus_faecalis_6563.db -p signalp6 -i signal_peps/prediction_results.txt
```

Thanks!