### PR TITLE
Python upgrade trnaseq patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ anvio/data/misc/SCG_TAXONOMY/GTDB/SCG_SEARCH_DATABASES/*.dmnd
 anvio/tests/sandbox/update-contigs-and-bams-for-mini-test/output
 anvio/tests/sandbox/test_visualize_split_coverages/TEST_OUTDIR
 anvio/data/misc/KEGG/
+anvio/data/misc/TRNA_TAXONOMY/

--- a/anvio/tests/run_component_tests_for_trnaseq.sh
+++ b/anvio/tests/run_component_tests_for_trnaseq.sh
@@ -46,3 +46,5 @@ INFO "Firing up the interactive interface with the \"combined\" profile database
 anvi-interactive -p ${output_dir}/CONVERTED/COMBINED_COVERAGE/PROFILE.db \
                  -c ${output_dir}/CONVERTED/CONTIGS.db \
                  ${dry_run_controller}
+
+rm blast-log.txt

--- a/anvio/trnaseq.py
+++ b/anvio/trnaseq.py
@@ -6651,26 +6651,26 @@ class DatabaseMerger(object):
             for seed in self.seeds:
                 split_name = seed.name + '_split_00001'
                 for sample_id in self.trnaseq_db_sample_ids:
-                    auxiliary_db.append(split_name, sample_id, seed.sample_spec_covs_dict[sample_id].tolist())
+                    auxiliary_db.append(split_name, sample_id, seed.sample_spec_covs_dict[sample_id])
         elif db_cov_type == 'nonspecific':
             auxiliary_db = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.nonspec_auxiliary_db_path, self.contigs_db_hash, db_variant='trnaseq', create_new=True)
             for seed in self.seeds:
                 split_name = seed.name + '_split_00001'
                 for sample_id in self.trnaseq_db_sample_ids:
-                    auxiliary_db.append(split_name, sample_id, seed.sample_nonspec_covs_dict[sample_id].tolist())
+                    auxiliary_db.append(split_name, sample_id, seed.sample_nonspec_covs_dict[sample_id])
         elif db_cov_type == 'combined':
             auxiliary_db = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.combined_auxiliary_db_path, self.contigs_db_hash, db_variant='trnaseq', create_new=True)
             for seed in self.seeds:
                 split_name = seed.name + '_split_00001'
                 for sample_id in self.trnaseq_db_sample_ids:
-                    auxiliary_db.append(split_name, sample_id + '_specific', seed.sample_spec_covs_dict[sample_id].tolist())
-                    auxiliary_db.append(split_name, sample_id + '_nonspecific', seed.sample_nonspec_covs_dict[sample_id].tolist())
+                    auxiliary_db.append(split_name, sample_id + '_specific', seed.sample_spec_covs_dict[sample_id])
+                    auxiliary_db.append(split_name, sample_id + '_nonspecific', seed.sample_nonspec_covs_dict[sample_id])
         elif db_cov_type == 'summed':
             auxiliary_db = auxiliarydataops.AuxiliaryDataForSplitCoverages(self.summed_auxiliary_db_path, self.contigs_db_hash, db_variant='trnaseq', create_new=True)
             for seed in self.seeds:
                 split_name = seed.name + '_split_00001'
                 for sample_id in self.trnaseq_db_sample_ids:
-                    auxiliary_db.append(split_name, sample_id, (seed.sample_spec_covs_dict[sample_id] + seed.sample_nonspec_covs_dict[sample_id]).tolist())
+                    auxiliary_db.append(split_name, sample_id, (seed.sample_spec_covs_dict[sample_id] + seed.sample_nonspec_covs_dict[sample_id]))
         else:
             raise ConfigError(f"The type of profile database provided, {db_cov_type}, "
                               "is not among those that are recognized: 'specific', 'nonspecific', 'combined', and 'summed'.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numba
 paste
 pyani
 psutil
-pandas
+pandas>=1.2.1
 snakemake
 multiprocess
 plotext


### PR DESCRIPTION
This PR patches bugs that arose in testing the tRNA-seq workflow with python `3.7`, upgraded from `3.6`.

Following anvi'o installation instructions, the default version of `pandas` installed without version specification was `0.25.1`. I changed `requirements.txt` to use `pandas>=1.2.1` in order to fix an error involving DataFrame creation. See:
https://stackoverflow.com/questions/65998646/pandas-error-for-creating-an-emptydataframe

The answer to the stack overflow question indicates that the error is due to incompatibility between versions of pandas and numpy. The default version of numpy being installed is `1.21.5`: it is possible the error can also be fixed by downgrading numpy to `1.19.5` if pandas cannot be upgraded for other reasons.