### PR TITLE
A new community flag: --force-overwrite

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -27,6 +27,7 @@ QUIET = '--quiet' in sys.argv
 NO_PROGRESS = '--no-progress' in sys.argv
 AS_MARKDOWN = '--as-markdown' in sys.argv
 FIX_SAD_TABLES = '--fix-sad-tables' in sys.argv
+FORCE_OVERWRITE = '--force-overwrite' in sys.argv
 DISPLAY_DB_CALLS = '--display-db-calls' in sys.argv
 FORCE_USE_MY_TREE = '--force-use-my-tree' in sys.argv
 DEBUG_AUTO_FILL_ANVIO_DBS = '--debug-auto-fill-anvio-dbs' in sys.argv

--- a/anvio/argparse.py
+++ b/anvio/argparse.py
@@ -38,9 +38,9 @@ class ArgumentParser(argparse.ArgumentParser):
         self.epilog = epilog or self.get_anvio_epilogue()
 
         self.anvio_allowed_ad_hoc_flags = ['--version', '--debug', '--force', '--fix-sad-tables',
-                                           '--quiet', '--no-progress', '--as-markdown',
-                                           '--display-db-calls', '--force-use-my-tree',
-                                           '--I-know-this-is-not-a-good-idea', '--tmp-dir']
+                                           '--quiet', '--no-progress', '--as-markdown', '--display-db-calls',
+                                           '--force-use-my-tree', '--force-overwrite', '--tmp-dir',
+                                           '--I-know-this-is-not-a-good-idea']
 
 
     def get_anvio_epilogue(self):

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -4740,14 +4740,12 @@ class AA_counts(ContigsSuperclass):
 ####################################################################################################
 
 def is_db_ok_to_create(db_path, db_type):
-    if os.path.exists(db_path):
-        raise ConfigError("Anvi'o will not overwrite an existing %s database. Please choose a different name "
-                           "or remove the existing database ('%s') first." % (db_type, db_path))
-
     if not db_path.lower().endswith('.db'):
         raise ConfigError("Please make sure the file name for your new %s db has a '.db' extension. Anvi'o developers "
                            "apologize for imposing their views on how anvi'o databases should be named, and are "
                            "humbled by your cooperation." % db_type)
+
+    filesnpaths.is_output_file_writable(db_path, ok_if_exists=False)
 
 
 def get_auxiliary_data_path_for_profile_db(profile_db_path):

--- a/anvio/filesnpaths.py
+++ b/anvio/filesnpaths.py
@@ -156,8 +156,18 @@ def is_output_file_writable(file_path, ok_if_exists=True):
     if os.path.exists(file_path) and not os.access(file_path, os.W_OK):
         raise FilesNPathsError(f"You do not have write access to the file at '{file_path}' :/")
     if os.path.exists(file_path) and not ok_if_exists:
-        raise FilesNPathsError(f"The output file '{file_path}' already exists. Generally speaking anvi'o tries to "
-                               f"avoid overwriting stuff.")
+        if anvio.FORCE_OVERWRITE:
+            try:
+                os.remove(file_path)
+            except Exception as e:
+                raise FilesNPathsError(f"As per your instructions, anvi'o was trying to delete the file at '{file_path}', "
+                                       f"yet it failed (typical anvi'o?). Here is the error message from another programmer "
+                                       f"in the matrix: {e}.")
+        else:
+            raise FilesNPathsError(f"The output file '{file_path}' already exists. Generally speaking anvi'o tries to "
+                                   f"avoid overwriting stuff. But you can always use the flag `--force-overwrite` "
+                                   f"to instruct anvi'o to delete the existing file first.")
+
     return True
 
 
@@ -378,8 +388,19 @@ def check_output_directory(output_directory, ok_if_exists=False):
     output_directory = os.path.abspath(output_directory)
 
     if os.path.exists(output_directory) and not ok_if_exists:
-        raise FilesNPathsError(f"The output directory '{output_directory}' already exists (and anvi'o does not like "
-                               f"overwriting stuff (except when it does (typical anvi'o))).")
+        if anvio.FORCE_OVERWRITE:
+            try:
+                shutil.rmtree(output_directory)
+            except Exception as e:
+                raise FilesNPathsError(f"As per your instructions, anvi'o was trying to delete the directory at '{output_directory}', "
+                                       f"yet it failed (typical anvi'o?). Here is the error message from another programmer in "
+                                       f"the matrix: {e}.")
+        else:
+            raise FilesNPathsError(f"The output directory '{output_directory}' already exists (and anvi'o does not like "
+                                   f"overwriting stuff (except when it does (typical anvi'o))). But you can always use "
+                                   f"the flag `--force-overwrite` to assert your dominance. In which case anvi'o would "
+                                   f"first remove the existing output directory (a flag that deserves extreme caution "
+                                   f"for obvious reasons).")
 
     return output_directory
 


### PR DESCRIPTION
This PR introduces a new community flag, `--force-overwrite`, which can be used by any anvi'o program, and would result in the removal of the output files and directories that are not needed.

This was requested by @nick-youngblut in #1921.