### PR TITLE
Issue 1945

### DIFF
--- a/anvio/docs/programs/anvi-rename-bins.md
+++ b/anvio/docs/programs/anvi-rename-bins.md
@@ -2,7 +2,7 @@ This program **creates a new %(collection)s from the %(bin)ss in another collect
 
 ### Renaming all bins in a collection
 
-Let's say you have a %(collection)s called `MY_COLLECTION`, which has four bins that are named poorly (which can happen due to decisions made by automatic binning tools, or after a few steps of manual refinement): `Bin_1_2_1`, `Bin_2`, `Bin_3_1_1`, and `Bin_4`. In an instance like this, running the program %(anvi-rename-bins)s the following way will standardize these bin names with a prefix specific to your project: 
+Let's say you have a %(collection)s called `MY_COLLECTION`, which has four bins that are named poorly (which can happen due to decisions made by automatic binning tools, or after a few steps of manual refinement): `Bin_1_2_1`, `Bin_2`, `Bin_3_1_1`, and `Bin_4`. In an instance like this, running the program %(anvi-rename-bins)s the following way will standardize these bin names with a prefix specific to your project:
 
 {{ codestart }}
 anvi-rename-bins -c %(contigs-db)s \
@@ -36,7 +36,7 @@ Now, the %(collection)s `SURFACE_OCEAN_MAGS` will include  `SURFACE_OCEAN_MAG_00
 
 In addition to minimum completion estimate, you can also adjust the maximum redundancy value, minimum size to call MAGs. Please see the help menu for all parameters and their descriptions. 
 
-### Exclude bins that are not MAGs 
+### Exclude bins that are not MAGs
 
 When you use the flag `--call-MAGs`, anvi'o identifies those bins that could be considered 'MAGs' based on your specific criteria. But regardles of whether an original bin remains a bin, or tagged as a MAG, everything in your original collection will end up in your new collection. The flag `--exclude-bins` enable you to filter out those that end up not being tagged as MAGs:
 
@@ -55,3 +55,17 @@ anvi-rename-bins -c %(contigs-db)s \
 With the addition of the flag `--exclude-bins` to the same command, the %(collection)s `SURFACE_OCEAN_MAGS` will no longer include %(bin)ss `SURFACE_OCEAN_Bin_00003` and `SURFACE_OCEAN_Bin_00004`.
 
 See also the program %(anvi-delete-collection)s.
+
+### The report file
+
+Following is an example reporting output file anvi'o will generate at the file path declared with the parameter `--report-file`:
+
+|**old_bin_name**|**new_bin_name**|**SCG_domain**|**completion**|**redundancy**|**size_in_Mbp**|
+|:--|:--|:--|:--|:--|:--|
+|Bin_2|p800_MAG_00001|eukarya|61.45|7.23|26.924911|
+|Bin_1|p800_MAG_00002|bacteria|98.59|8.45|1.612349|
+|Bin_3|p800_Bin_00003|blank|0.00|0.00|0.103694|
+|Bin_5|p800_Bin_00004|blank|0.00|0.00|0.128382|
+|Bin_4|p800_Bin_00005|bacteria|1.41|0.00|0.378418|
+
+The column `SCG_domain` will explain which collection of single-copy core genes were used to generate these completion/redundancy estimates. The absence of any domain prediction for any given bin will be marked with the keyrowd `blank`.

--- a/bin/anvi-rename-bins
+++ b/bin/anvi-rename-bins
@@ -175,15 +175,15 @@ def main(args):
         if call_MAGs:
             if p_redundancy < max_redundancy_for_MAG:
                 if p_completion >= min_completion_for_MAG:
-                    MAGs_sorted_by_completion.append((bin_name, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'MAG'),)
+                    MAGs_sorted_by_completion.append((bin_name, domain, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'MAG'),)
                 elif size_for_MAG and size_in_Mbp >= size_for_MAG:
-                    MAGs_sorted_by_completion.append((bin_name, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'MAG'),)
+                    MAGs_sorted_by_completion.append((bin_name, domain, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'MAG'),)
                 else:
-                    bins_sorted_by_completion.append((bin_name, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'Bin'),)
+                    bins_sorted_by_completion.append((bin_name, domain, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'Bin'),)
             else:
-                bins_sorted_by_completion.append((bin_name, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'Bin'),)
+                bins_sorted_by_completion.append((bin_name, domain, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'Bin'),)
         else:
-            bins_sorted_by_completion.append((bin_name, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'Bin'),)
+            bins_sorted_by_completion.append((bin_name, domain, substantive_completion, p_completion, p_redundancy, size_in_Mbp, 'Bin'),)
 
     MAGs_sorted_by_completion.sort(key=operator.itemgetter(1), reverse=True)
     bins_sorted_by_completion.sort(key=operator.itemgetter(1), reverse=True)
@@ -195,22 +195,22 @@ def main(args):
 
     counter = 0
     report = open(report_file_path, 'w')
-    report.write('old_bin_name\tnew_bin_name\tcompletion\tredundancy\tsize_in_Mbp\n')
+    report.write('old_bin_name\tnew_bin_name\tSCG_domain\tcompletion\tredundancy\tsize_in_Mbp\n')
 
     if exclude_bins:
         list_of_bins_in_the_workings = MAGs_sorted_by_completion
     else:
         list_of_bins_in_the_workings = MAGs_sorted_by_completion + bins_sorted_by_completion
 
-    for bin_name, substantive_completion, completion, redundancy, size_in_Mbp, bin_type in list_of_bins_in_the_workings:
+    for bin_name, domain, substantive_completion, completion, redundancy, size_in_Mbp, bin_type in list_of_bins_in_the_workings:
         counter += 1
-        new_bin_name = '%s_%s_%05d' % (prefix, bin_type, counter)
+        new_bin_name = f"{prefix}_{bin_type}_{counter:05}"
         new_collection_dict[new_bin_name] = copy.deepcopy(collection_dict[bin_name])
 
         if bin_name in bins_info_dict:
             new_bins_info_dict[new_bin_name] = copy.deepcopy(bins_info_dict[bin_name])
 
-        report.write('%s\t%s\t%.2f\t%.2f\t%.2f\n' % (bin_name, new_bin_name, completion, redundancy, size_in_Mbp))
+        report.write(f"{bin_name}\t{new_bin_name}\t{domain}\t{completion:.2f}\t{redundancy:.2f}\t{size_in_Mbp}\n")
 
     report.close()
 

--- a/bin/anvi-rename-bins
+++ b/bin/anvi-rename-bins
@@ -152,14 +152,22 @@ def main(args):
         progress.update('%d in %d' % (counter, total_num_bins))
         p_completion, p_redundancy, domain, domain_probabilities, info_text, d = completeness.get_info_for_splits(set(collection_dict[bin_name]))
 
-        l = []
-        for domain in d:
-            for scg_collection_name in d[domain]:
-                l.append((d[domain][scg_collection_name]['percent_completion'], domain, scg_collection_name),)
-        _, domain, scg_collection_name = sorted(l, reverse=True)[0]
+        if domain == 'blank':
+            # if the domain is 'blank', it most likely means that our random forest classifier
+            # was not certain about the domain because the genome bin wish highly incomplete
+            # for a reliable prediction. in that case we will use the most reasonable C/R
+            # estimate based on the highest C and set the domain to that for reporting.
+            l = []
+            for domain in d:
+                for scg_collection_name in d[domain]:
+                    l.append((d[domain][scg_collection_name]['percent_completion'], domain, scg_collection_name),)
+            _, domain, scg_collection_name = sorted(l, reverse=True)[0]
 
-        p_completion = d[domain][scg_collection_name]['percent_completion']
-        p_redundancy = d[domain][scg_collection_name]['percent_redundancy']
+            if d[domain][scg_collection_name]['percent_completion'] > 0.0:
+                p_completion = d[domain][scg_collection_name]['percent_completion']
+                p_redundancy = d[domain][scg_collection_name]['percent_redundancy']
+            else:
+                domain = 'blank'
 
         size_in_Mbp = sum([contigs_db.splits_basic_info[split_name]['length'] for split_name in set(collection_dict[bin_name])]) / 1000000.0
         substantive_completion = p_completion - p_redundancy


### PR DESCRIPTION
PR that addresses the discrepancy in reporting file generated by `anvi-rename-bins` regarding the C/R estimates of individual bins reported in #1945. It was due to a bug in the code that give priority to highest C estimate rather than model suggested domain.