### PR TITLE
Add lambda parameter for q-value estimation in enrichment script

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -626,6 +626,14 @@ D = {
                      "A file name must be provided. To learn more about how the functional occurrence is computed, please "
                      "refer to the tutorial."}
                 ),
+    'qlambda': (
+            ['--qlambda'],
+            {'default': None,
+             'metavar': 'NUM',
+             'type': float,
+             'help': "If you want to set the maximum lambda value for q-value estimation, provide a fraction between "
+                     "0.05 and 1."}
+                ),
     'table': (
             ['--table'],
             {'metavar': 'TABLE_NAME',

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -922,6 +922,7 @@ class AggregateFunctions:
         self.print_genome_names_and_quit = A('print_genome_names_and_quit') or False
         self.functional_occurrence_table_output_path = A('functional_occurrence_table_output')
         self.functional_enrichment_output_path = A('output_file')
+        self.qlambda = A('qlambda')
 
         # -----8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<-----8<-----
         # these are some primary data structures this class reports
@@ -1357,6 +1358,7 @@ class AggregateFunctions:
         # run the enrichment analysis
         self.functional_enrichment_stats_dict = utils.run_functional_enrichment_stats(functional_occurrence_stats_input_file_path=self.functional_occurrence_table_output_path,
                                                                                       enrichment_output_file_path=self.functional_enrichment_output_path,
+                                                                                      qlambda=self.qlambda,
                                                                                       run=self.run,
                                                                                       progress=self.progress)
 

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -1178,7 +1178,8 @@ def apply_and_concat(df, fields, func, column_names, func_args=tuple([])):
     return pd.concat((df, df2), axis=1, sort=True)
 
 
-def run_functional_enrichment_stats(functional_occurrence_stats_input_file_path, enrichment_output_file_path=None, run=run, progress=progress):
+def run_functional_enrichment_stats(functional_occurrence_stats_input_file_path, enrichment_output_file_path=None,
+                                    qlambda=None, run=run, progress=progress):
     """This function runs the enrichment analysis implemented by Amy Willis.
 
     Since the enrichment analysis is an R script, we interface with that program by
@@ -1193,6 +1194,8 @@ def run_functional_enrichment_stats(functional_occurrence_stats_input_file_path,
         script.
     enrichment_output_file_path, str file path
         An optional output file path for the enrichment analysis.
+    qlambda : float
+        An optional fraction that sets the maximum lambda for q-value
 
     Returns
     =======
@@ -1224,14 +1227,19 @@ def run_functional_enrichment_stats(functional_occurrence_stats_input_file_path,
     run.warning(None, header="AMY's ENRICHMENT ANALYSIS 🚀", lc="green")
     run.info("Functional occurrence stats input file path: ", functional_occurrence_stats_input_file_path)
     run.info("Functional enrichment output file path: ", enrichment_output_file_path)
+    if anvio.DEBUG:
+        run.info("User set max lambda for q-values: ", qlambda)
     run.info("Temporary log file (use `--debug` to keep): ", log_file_path, nl_after=2)
 
     # run enrichment script
     progress.new('Functional enrichment analysis')
     progress.update("Running Amy's enrichment")
-    run_command(['anvi-script-enrichment-stats',
+    enrichment_command = ['anvi-script-enrichment-stats',
                  '--input', f'{functional_occurrence_stats_input_file_path}',
-                 '--output', f'{enrichment_output_file_path}'], log_file_path)
+                 '--output', f'{enrichment_output_file_path}']
+    if qlambda:
+        enrichment_command += ['--qlambda', f'{qlambda}']
+    run_command(enrichment_command, log_file_path)
     progress.end()
 
     if not filesnpaths.is_file_exists(enrichment_output_file_path, dont_raise=True):

--- a/bin/anvi-compute-functional-enrichment-across-genomes
+++ b/bin/anvi-compute-functional-enrichment-across-genomes
@@ -70,6 +70,7 @@ if __name__ == '__main__':
     groupD.add_argument(*anvio.A('functional-occurrence-table-output'), **anvio.K('functional-occurrence-table-output'))
 
     groupE = parser.add_argument_group('OPTIONAL THINGIES', "If you want it, here it is, come and get it.")
+    groupE.add_argument(*anvio.A('qlambda'), **anvio.K('qlambda'))
     groupE.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     args = parser.get_args(parser)

--- a/sandbox/anvi-script-enrichment-stats
+++ b/sandbox/anvi-script-enrichment-stats
@@ -209,7 +209,12 @@ pvalues_df <- df_unique %>%
 
 # find the maximum lambda for qvalue
 # reasons for this change documented at https://github.com/merenlab/anvio/issues/1383
-max_lambda <- min(0.95, max(pvalues_df$unadjusted_p_value, na.rm=T))
+if (length(opts$qlambda) > 0) {
+    max_lambda = opts$qlambda
+    sprintf("Using user-defined max lambda value of %s for q-value estimation", opts$qlambda)
+} else {
+    max_lambda <- min(0.95, max(pvalues_df$unadjusted_p_value, na.rm=T))
+}
 if (max_lambda < 0.05) {
     stop(sprintf("Unfortunately, the maximum lambda for q-value estimation is < 0.05. This \
          value is coming from the p-values in the enrichment test, so something in \

--- a/sandbox/anvi-script-enrichment-stats
+++ b/sandbox/anvi-script-enrichment-stats
@@ -99,7 +99,9 @@ option_list <- list(
   make_option(c("--output"),
               help = "Output file name"),
   make_option(c("--input"),
-              help = "Input file name")
+              help = "Input file name"),
+  make_option(c("--qlambda"),
+              help = "Optional parameter. The maximum lambda for q-value estimation.")
 )
 parser <- OptionParser(option_list = option_list,
                        description = "Hypothesis testing for 'enrichment' claims. Fits a GLM and computes the Rao Test statistic as an enrichment score.")

--- a/sandbox/anvi-script-enrichment-stats
+++ b/sandbox/anvi-script-enrichment-stats
@@ -210,6 +210,15 @@ pvalues_df <- df_unique %>%
 # find the maximum lambda for qvalue
 # reasons for this change documented at https://github.com/merenlab/anvio/issues/1383
 max_lambda <- min(0.95, max(pvalues_df$unadjusted_p_value, na.rm=T))
+if (max_lambda < 0.05) {
+    stop(sprintf("Unfortunately, the maximum lambda for q-value estimation is < 0.05. This \
+         value is coming from the p-values in the enrichment test, so something in \
+         your data is making those p-values low. This sometimes happens when you \
+         have a very short input file (your input file has %s rows). Regardless, \
+         a possible solution is for you to pick your own max lambda that is >= 0.05, \
+         and provide it to the program calling this script by using the \
+         --qlambda parameter.", nrow(df_in)))
+}
 lambdas <- seq(0.05, max_lambda, 0.05)
 
 # obtain an estimate of the proportion of features that are truly null


### PR DESCRIPTION
This PR addresses an issue discovered [here](https://github.com/merenlab/anvio/issues/1383#issuecomment-1169142656), whereby very small p-values would lead to an ugly `seq` bug like this:
```
Error in seq.default(0.05, max_lambda, 0.05) :
  wrong sign in 'by' argument
```
(which can happen because the input file is too short, due to the fact that we remove all core functions/annotations when we generate the input file).

There are two new aspects of the code as of these changes:
1. When the `max_lambda` is too small, we stop the script and print a nicer error for the user:
```
Error: Unfortunately, the maximum lambda for q-value estimation is < 0.05. This
         value is coming from the p-values in the enrichment test, so something in
         your data is making those p-values low. This sometimes happens when you
         have a very short input file (your input file has 4 rows). Regardless,
         a possible solution is for you to pick your own max lambda that is >= 0.05,
         and provide it to the program calling this script by using the
         --qlambda parameter.
```
2. The enrichment script now accepts a `--qlambda` parameter allowing the user to set `max_lambda` themselves. This optional parameter has been added to the program `anvi-compute-functional-enrichment-across-genomes`.

On my test data (Enterococcus genomes from the Infant Gut Tutorial, using the annotation source `COG20_PATHWAY` which only has 3 annotations differentially present across the genomes), using the `--qlambda` parameter allows the script to proceed through the q-value estimation, but it still ends in this later error:
```
Error: Doh! We still can't estimate the proportion of features that are truly null. It's Amy's fault, so please let her know ASAP so she can fix it!
```
Which I suspect is happening because the input file is just too darn small. So even the addition of this parameter doesn't really fix this issue. But at least now users have a bit more control.

@adw96, could you please take a look at these changes and let me know what you think? If you like them, I'll update the documentation and merge the code :)
