### PR TITLE
anvi-migrate refactor

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2935,25 +2935,25 @@ D = {
              'help': "Provide if working with INSeq/Tn-Seq genomic data. With this, all gene level "
                      "coverage stats will be calculated using INSeq/Tn-Seq statistical methods."}
                 ),
-    'migrate-dbs-safely': (
-            ['--migrate-dbs-safely'],
+    'migrate-safely': (
+            ['--migrate-safely'],
             {'required': False,
              'action': 'store_true',
              'default': False,
-             'help': "If you chose this, anvi'o will first create a copy of your original database. If something "
-                     "goes wrong, it will restore the original. If everything works, it will remove the old copy. "
-                     "IF YOU HAVE DATABASES THAT ARE VERY LARGE OR IF YOU ARE MIGRATING MANY MANY OF THEM THIS "
-                     "OPTION WILL ADD A HUGE I/O BURDEN ON YOUR SYSTEM. But still. Safety is safe."}
+             'help': "If you chose this, anvi'o will first create a copy of your input file, and if something "
+                     "goes wrong, it will restore the original. If everything works fine, it will remove the copy. "
+                     "IF YOU HAVE ANVI'O ARTIFACTS THAT ARE VERY LARGE OR IF YOU ARE MIGRATING MANY MANY OF THEM, "
+                     "THIS OPTION WILL ADD A HUGE I/O BURDEN ON YOUR SYSTEM :/ But still. Safety is safe."}
                 ),
-    'migrate-dbs-quickly': (
-            ['--migrate-dbs-quickly'],
+    'migrate-quickly': (
+            ['--migrate-quickly'],
             {'required': False,
              'action': 'store_true',
              'default': False,
-             'help': "If you chose this, anvi'o will migrate your databases in place. It will be much faster (and arguably "
-                     "more fun) than the safe option, but if something goes wrong, you will lose data. During the first "
-                     "five years of anvi'o development not a single user lost data using our migration scripts as far as "
-                     "we know. But there is always a first, and today might be your lucky day."}
+             'help': "If you chose this, anvi'o will migrate your artifats in place. It will be much faster (and arguably "
+                     "more fun since #YOLO) than the safe option, but if something goes wrong, you will lose data. "
+                     "During the first five years of anvi'o development not, a single user lost data using our migration "
+                     "scripts as far as we know. But there is always a first, and today might be your lucky day."}
                 ),
     'module-completion-threshold': (
             ['--module-completion-threshold'],

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -103,7 +103,7 @@ class DB:
                     progress.reset()
                     raise ConfigError(f"The database at '{self.db_path}' is outdated (this database is v{self.version} and your anvi'o installation "
                                       f"wants to work with v{client_version}). You can migrate your database without losing any data using the "
-                                      f"program `anvi-migrate` with either of the flags `--migrate-dbs-safely` or `--migrate-dbs-quickly`.")
+                                      f"program `anvi-migrate` with either of the flags `--migrate-safely` or `--migrate-quickly`.")
 
             bad_tables = [table_name for table_name in self.table_names_in_db if not tables.is_known_table(table_name)]
             if len(bad_tables):

--- a/anvio/docs/programs/anvi-migrate.md
+++ b/anvio/docs/programs/anvi-migrate.md
@@ -1,26 +1,32 @@
-This is a multi-talented program that seamlessly updates any anvi'o database to the latest version.
+This is a multi-talented program that seamlessly updates any anvi'o artifact (i.e., anvi'o databases or config files) to its latest version.
 
-You can provide one or more anvi'o databases as command line parameters to this program, and it will migrate each one. However, you must choose whether to migrate the databases safely, or quickly.
+You can provide one or more files and the program will migrate all. However, you must choose whether to migrate the databases safely, or quickly.
 
-If you choose to migrate safely, anvi'o will first make a copy of each database and save it as a backup. In case something goes wrong during the migration, it let you know what happened and will restore your original database from the copy it made. Then you can go on your merry way. (The copy is deleted after the migration script is finished running.)
+If you choose to migrate safely, anvi'o will first make a copy of each file and save it as a backup. In case something goes wrong during the migration, it let you know what happened and will restore your original file from its copy. In the case of a successful migration, the old copy will go away gracefully (and quietly).
 
 This is how you migrate safely:
+
 ```
-anvi-migrate --migrate-dbs-safely *.db
+anvi-migrate --migrate-safely *.db
 ```
 
 Of course, we will always suggest that migrating safely is better, because fewer people get angry at us when we do that. In practice though, making those backup copies takes up extra time and it is unlikely that the migration will fail anyway, so if you have a lot of databases to migrate and are okay with a bit of risk, you have the option to migrate quickly instead. In this case, anvi'o will _not_ copy your databases before starting the migration.
+
 ```
-anvi-migrate --migrate-dbs-quickly *.db
+anvi-migrate --migrate-quickly *.db
 ```
-Please remember that by living life in the fast lane, you forego your safety net. On the rare occasion that the migration does fail, this program will let you know what happened, leave you with a database that has a `.broken` file extension, and sassily remind you that this all could have been avoided if you chose the other option. In this unlikely event, you can always reach out to us. We will probably be sassy to you, too, but we will still see if we can help you unbreak things. :)
+Please remember that by living life in the fast lane, you forego your safety net. On the rare occasion that the migration does fail, this program will let you know what happened, leave you with a database that has a `.broken` file extension. In this unlikely event, you can always reach out to us.
 
 ### Migrating to a specific version
+
 If your database is a few versions behind the highest available version but for whatever reason you don't want to migrate it all the way, you can specify which version to update your database to. Just use the `-t` flag (note: migrating with this parameter only works on ONE database at a time):
+
 ```
-anvi-migrate --migrate-dbs-safely -t 15 CONTIGS.db
+anvi-migrate --migrate-safely -t 15 CONTIGS.db
 ```
+
 Then anvi'o will update your database until it is whatever version you specified and stop. Of course, you cannot provide a version number that is higher than the highest available version. Nor can you provide a number that is lower than your database's current version (ie, backwards migration is not possible).
 
 Not sure what your database's current version is? Try %(anvi-db-info)s.
-Not sure what the highest available version is? Run any anvi'o command with the `-v` option to see the version information for all database types (we recommend `anvi-interactive -v` for no particular reason).
+
+You can always run `anvi-migrate -v` to learn about the versions of artifact types _your_ anvi'o installation can work with.

--- a/anvio/migrations/config/v1_to_v2.py
+++ b/anvio/migrations/config/v1_to_v2.py
@@ -21,6 +21,7 @@ def migrate(config_path):
     if config_path is None:
         raise ConfigError("No config path is given.")
 
+    anvio.QUIET = True
     workflow_name, version = w.get_workflow_name_and_version_from_config(config_path, dont_raise=True)
 
     if not workflow_name:
@@ -50,6 +51,9 @@ def migrate(config_path):
     open(config_path, 'w').write(json.dumps(config, indent=4))
 
     progress.end()
+
+    anvio.QUIET = False
+
     run.info_single("The config file version is now %s. This upgrade removed --external-gene-calls from "
                     "the rule anvi_gen_contigs_database, if it existed at all. This was a redundant parameter, "
                     "since external gene calls are supplied to anvi-run-workflow as an external_gene_calls "

--- a/anvio/tests/run_component_tests_for_gene_level_stats.sh
+++ b/anvio/tests/run_component_tests_for_gene_level_stats.sh
@@ -13,7 +13,7 @@ cp $inseq_files/PROFILE.db $output_dir/PROFILE.db
 cp $inseq_files/AUXILIARY-DATA.db $output_dir/AUXILIARY-DATA.db
 
 INFO "Migrate all dbs"
-anvi-migrate $output_dir/*db --migrate-dbs-quickly
+anvi-migrate $output_dir/*db --migrate-quickly
 
 # Generate gene-level-stats database
 INFO "Computing gene level stats database"

--- a/anvio/tests/run_component_tests_for_inversions.sh
+++ b/anvio/tests/run_component_tests_for_inversions.sh
@@ -12,7 +12,7 @@ cd $output_dir/
 
 INFO "Migrating the contigs database (quetly)"
 anvi-migrate 02_CONTIGS/CONTIGS.db \
-             --migrate-dbs-quickly \
+             --migrate-quickly \
              --quiet
 
 INFO "Generating single profile databases with '--fetch-filter inversions' (quietly)"

--- a/anvio/tests/run_component_tests_for_metabolism.sh
+++ b/anvio/tests/run_component_tests_for_metabolism.sh
@@ -14,7 +14,7 @@ cp $files/data/input_files/*.txt                        $output_dir/metabolism_t
 cd $output_dir/metabolism_test
 
 INFO "Migrating all databases"
-anvi-migrate *db --migrate-dbs-quickly
+anvi-migrate *db --migrate-quickly
 
 # generate a temporary directory to store anvi-setup-kegg-kofams output,
 # and remove it immediately to make sure it doesn't exist:

--- a/anvio/tests/run_migration_tests_for_ancient_anvio_databases.sh
+++ b/anvio/tests/run_migration_tests_for_ancient_anvio_databases.sh
@@ -21,7 +21,7 @@ cd $output_dir
 #INFO "[$TEST] Unpacking"
 #tar -zxvf P214-MERGED.tar.gz && cd P214-MERGED/
 #INFO "[$TEST] Migrating databases"
-#anvi-migrate *db --migrate-dbs-safely
+#anvi-migrate *db --migrate-safely
 #INFO "[$TEST] Downloading state"
 #curl -L http://merenlab.org/files/P-214-state.json -o P-214-state.json
 #INFO "[$TEST] Importing state"
@@ -47,7 +47,7 @@ INFO "[$TEST] Unpacking"
 tar -zxvf TARA_ANW_MAG_00006.tar.gz && cd TARA_ANW_MAG_00006
 gzip -d AUXILIARY-DATA.h5.gz
 INFO "[$TEST] Migrating databases"
-anvi-migrate PROFILE.db CONTIGS.db --migrate-dbs-safely
+anvi-migrate PROFILE.db CONTIGS.db --migrate-quickly
 INFO "[$TEST] Running the interactive interface (--dry)"
 anvi-interactive -p PROFILE.db -c CONTIGS.db --dry
 INFO "[$TEST] Setting up SCG taxonomy databases"

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -87,7 +87,7 @@ class WorkflowSuperClass:
                 raise ConfigError(f"Anvi'o couldn't get things moving because the version of your config file is out "
                                   f"of date (your version: {self.config['config_version']}; up-to-date version: "
                                   f"{workflow_config_version}). Not a problem though, simply run `anvi-migrate {self.config_file} "
-                                  f"--migrate-dbs-safely` and it will be updated. Then re-run the command producing "
+                                  f"--migrate-safely` and it will be updated. Then re-run the command producing "
                                   f"this error message.")
 
         self.rules = []

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -31,13 +31,11 @@ class Migrater(object):
     def __init__(self, args):
         self.args = args
         self.db_path = args.db_path
-        self.db_type = None
+        self.db_type = 'Unknown'
         self.db_version = None
         self.target_version = None
 
         filesnpaths.is_file_exists(self.db_path)
-        self.get_db_meta()
-        self.get_target_version()
 
         if not args.migrate_dbs_safely and not args.migrate_dbs_quickly:
             raise ConfigError("You must choose either `--migrate-dbs-safely` or `--migrate-dbs-quickly`. Anvi'o would "
@@ -53,18 +51,6 @@ class Migrater(object):
             self.sqlite_version = utils.get_command_output_from_shell("sqlite3 --version")[0].decode("utf-8").split(' ')[0].split('.')
         except:
             self.sqlite_version = None
-
-        run.info('Database Path', self.db_path)
-        run.info('Detected Type', self.db_type)
-        run.info('Current Version', self.db_version)
-        run.info('Target Version', self.target_version)
-
-        if args.migrate_dbs_safely:
-           run.info('Migration mode', "Safe", mc="green")
-        else:
-           run.info('Migration mode', "Adventurous", mc="red")
-
-        run.info('SQLite Version', '.'.join(self.sqlite_version) if self.sqlite_version else 'Unknown :/', nl_after=1, nl_before=1)
 
         if not (int(self.sqlite_version[0]) >= 3 and int(self.sqlite_version[1]) >= 30):
             if not args.just_do_it:
@@ -139,6 +125,9 @@ class Migrater(object):
 
 
     def get_db_meta(self):
+        if not self.is_good_to_go():
+            return
+
         if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5', 'json']:
             raise ConfigError("This program only works with files that end with `.db` or `.json` extensions. "
                               "But if you sure that, this is in fact an anvi'o database or config file "
@@ -154,12 +143,9 @@ class Migrater(object):
                 pass
 
 
-        if self.db_path.endswith('GENOMES.h5'):
-            utils.check_h5py_module()
-            import h5py
-
         try:
             if self.db_path.endswith('GENOMES.h5'):
+                import h5py
                 fp = h5py.File(self.db_path, 'r')
 
                 self.db_type = 'genomestorage'
@@ -167,6 +153,8 @@ class Migrater(object):
 
                 fp.close()
             elif self.db_path.endswith('json') or file_is_config:
+                # the file is a json file, but is it a config file for an anvi'o workflow?
+                # here we will test it by looking for `workflow_name` in the JSON data.
                 import anvio.workflows as w
                 self.db_type = 'config'
                 workflow_name, config_version = w.get_workflow_name_and_version_from_config(self.db_path, dont_raise=True)
@@ -178,9 +166,11 @@ class Migrater(object):
                 self.db_version = int(db_conn.get_meta_value('version'))
 
                 db_conn.disconnect()
-        except:
-            raise ConfigError('Are you sure "%s" is a database or config file? Because, you know, probably '
-                               'it is not at all.' % self.db_path)
+        except Exception as e:
+            raise ConfigError(f"Anvi'o had a problem with `{self.db_path}` :( Here is the error: '{e}'")
+
+        # now we know about the target anvi'o artifact, we can fill in the version.
+        self.get_target_version()
 
 
     def get_target_version(self):
@@ -224,8 +214,18 @@ class Migrater(object):
 
 
     def process(self):
-        tasks = []
+        run.warning(None, header="NEW MIGRATION TASK", lc='cyan')
+        if not self.is_good_to_go():
+            return
 
+        self.get_db_meta()
+
+        if not self.is_something_to_migrate():
+            return
+
+        self.print_info()
+
+        tasks = []
 
         # if we are in safe mode, we will first copy the db
         if self.safe_mode:

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -17,7 +17,8 @@ import anvio.filesnpaths as filesnpaths
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.migrations import migration_scripts
 
-__description__ = "Migrate an anvi'o database or config file to a newer version"
+
+__description__ = "Migrates any anvi'o artifact, whether it is a database or a config file, to a newer version. Pure magic."
 __authors__ = ['meren', 'ozcan', 'ekiefl', 'ivagljiva', 'semiller10']
 __requires__ = ["contigs-db", "profile-db", "pan-db", "genes-db", "genomes-storage-db", "structure-db", "modules-db", "workflow-config"]
 __provides__ = []
@@ -30,22 +31,22 @@ progress = terminal.Progress()
 class Migrater(object):
     def __init__(self, args):
         self.args = args
-        self.db_path = args.db_path
-        self.db_type = 'Unknown'
-        self.db_version = None
+        self.artifact_path = args.artifact_path
+        self.artifact_type = 'Unknown'
+        self.artifact_version = None
         self.target_version = None
 
-        filesnpaths.is_file_exists(self.db_path)
+        filesnpaths.is_file_exists(self.artifact_path)
 
-        if not args.migrate_dbs_safely and not args.migrate_dbs_quickly:
-            raise ConfigError("You must choose either `--migrate-dbs-safely` or `--migrate-dbs-quickly`. Anvi'o would "
+        if not args.migrate_safely and not args.migrate_quickly:
+            raise ConfigError("You must choose either `--migrate-safely` or `--migrate-quickly`. Anvi'o would "
                               "have chosen one for you, but our lawyers suggested that it may put our life savings in "
                               "jeopardy.")
 
-        if args.migrate_dbs_safely and args.migrate_dbs_quickly:
+        if args.migrate_safely and args.migrate_quickly:
             raise ConfigError("Please don't ask anvi'o to migrate your databases both safely and quickly :/")
 
-        self.safe_mode = args.migrate_dbs_safely
+        self.safe_mode = args.migrate_safely
 
         try:
             self.sqlite_version = utils.get_command_output_from_shell("sqlite3 --version")[0].decode("utf-8").split(' ')[0].split('.')
@@ -58,7 +59,7 @@ class Migrater(object):
                                   "v3.30.0. Yours seem to be %s (if this doesn't make any sense, you can take "
                                   "a look at the output of the command 'sqlite3 --version' on your terminal). "
                                   "You can skip this check if you use the argument `--just-do-it` with your "
-                                  "command. In which case we strongly recommend you to use `--migrate-dbs-safely` "
+                                  "command. In which case we strongly recommend you to use `--migrate-safely` "
                                   "flag since it will be likely for you to lose your database if something goes "
                                   "wrong downstream." % '.'.join(self.sqlite_version) if self.sqlite_version else 'Unknown :/')
             else:
@@ -66,12 +67,12 @@ class Migrater(object):
 
 
     def print_info(self):
-        run.info('Input file path', self.db_path)
-        run.info('Input file type', self.db_type)
-        run.info('Current Version', self.db_version)
+        run.info('Input file path', self.artifact_path)
+        run.info('Input file type', self.artifact_type)
+        run.info('Current Version', self.artifact_version)
         run.info('Target Version', self.target_version)
 
-        if args.migrate_dbs_safely:
+        if args.migrate_safely:
            run.info('Migration mode', "Safe", mc="green")
         else:
            run.info('Migration mode', "Adventurous", mc="red")
@@ -82,38 +83,38 @@ class Migrater(object):
     def is_good_to_go(self):
         """Basic checks to make sure file types and so on looks correct"""
         # let's start with very basics
-        if os.path.isdir(self.db_path):
-            run.info('Input file path', self.db_path, mc='red')
+        if os.path.isdir(self.artifact_path):
+            run.info('Input file path', self.artifact_path, mc='red')
             run.warning("This is a directory, and yet the training of the members of the migration headquarters "
                         "of anvi'o only covers files. MOVING ON.", header='NOPE: LA DIRECTORY', lc='yellow')
 
         # check file extensions to make sure we're clear with this.
-        if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5', 'json']:
-            run.info('Input file path', self.db_path)
-            run.info('Input file type', self.db_type)
+        if not args.just_do_it and self.artifact_path.split('.')[-1] not in ['db', 'h5', 'json']:
+            run.info('Input file path', self.artifact_path)
+            run.info('Input file type', self.artifact_type)
             run.warning(f"This program only works with files that end with `.db` or `.json` extensions. "
-                        f"But if you are sure that your input file at `{self.db_path}` is indeed an anvi'o "
+                        f"But if you are sure that your input file at `{self.artifact_path}` is indeed an anvi'o "
                         f"database or config file you can use the flag `--just-do-it` at your own risk.",
                         header="NOPE: LA FILE EXTENSION", lc='yellow')
 
             return False
 
         # make sure we have the Python module for HDF is present if we have an .h5 file
-        if self.db_path.endswith('GENOMES.h5'):
+        if self.artifact_path.endswith('GENOMES.h5'):
             utils.check_h5py_module()
 
         # if we have a JSON file, we have to make sure a few things to say we're good to go
-        if self.db_path.endswith('json') or self.db_path.endswith('JSON'):
+        if self.artifact_path.endswith('json') or self.artifact_path.endswith('JSON'):
             # does it look like a JSON file?
-            filesnpaths.is_file_json_formatted(self.db_path)
+            filesnpaths.is_file_json_formatted(self.artifact_path)
 
             # does it look like an anvi'o config file?
             import json
-            with open(self.db_path) as json_file:
+            with open(self.artifact_path) as json_file:
                 json_content = json.load(json_file)
                 if 'workflow_name' not in json_content:
-                    run.info('Input file path', self.db_path)
-                    run.info('Input file type', self.db_type, mc='red')
+                    run.info('Input file path', self.artifact_path)
+                    run.info('Input file type', self.artifact_type, mc='red')
 
                     run.info_single("Your input file is a proper JSON file, but it doesn't look like an anvi'o workflow "
                                     "since nowhere in it there is a variable called `workflow_name`. So, there is nothing "
@@ -124,11 +125,11 @@ class Migrater(object):
         return True
 
 
-    def get_db_meta(self):
+    def get_artifact_meta(self):
         if not self.is_good_to_go():
             return
 
-        if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5', 'json']:
+        if not args.just_do_it and self.artifact_path.split('.')[-1] not in ['db', 'h5', 'json']:
             raise ConfigError("This program only works with files that end with `.db` or `.json` extensions. "
                               "But if you sure that, this is in fact an anvi'o database or config file "
                               "you can use --just-do-it flag at your own risk.")
@@ -137,53 +138,55 @@ class Migrater(object):
         if args.just_do_it:
             # check if this a config file by checking if it is a JSON formatted file
             try:
-                filesnpaths.is_file_json_formatted(self.db_path)
+                filesnpaths.is_file_json_formatted(self.artifact_path)
                 file_is_config = True
             except:
                 pass
 
 
         try:
-            if self.db_path.endswith('GENOMES.h5'):
+            if self.artifact_path.endswith('GENOMES.h5'):
                 import h5py
-                fp = h5py.File(self.db_path, 'r')
+                fp = h5py.File(self.artifact_path, 'r')
 
-                self.db_type = 'genomestorage'
-                self.db_version = int(fp.attrs['version'])
+                self.artifact_type = 'genomestorage'
+                self.artifact_version = int(fp.attrs['version'])
 
                 fp.close()
-            elif self.db_path.endswith('json') or file_is_config:
+            elif self.artifact_path.endswith('json') or file_is_config:
                 # the file is a json file, but is it a config file for an anvi'o workflow?
                 # here we will test it by looking for `workflow_name` in the JSON data.
                 import anvio.workflows as w
-                self.db_type = 'config'
-                workflow_name, config_version = w.get_workflow_name_and_version_from_config(self.db_path, dont_raise=True)
-                self.db_version = int(config_version)
+                self.artifact_type = 'config'
+                anvio.QUIET = True
+                workflow_name, config_version = w.get_workflow_name_and_version_from_config(self.artifact_path, dont_raise=True)
+                self.artifact_version = int(config_version)
+                anvio.QUIET = False
             else:
-                db_conn = db.DB(self.db_path, None, ignore_version=True)
+                db_conn = db.DB(self.artifact_path, None, ignore_version=True)
 
-                self.db_type = db_conn.get_meta_value('db_type')
-                self.db_version = int(db_conn.get_meta_value('version'))
+                self.artifact_type = db_conn.get_meta_value('db_type')
+                self.artifact_version = int(db_conn.get_meta_value('version'))
 
                 db_conn.disconnect()
         except Exception as e:
-            raise ConfigError(f"Anvi'o had a problem with `{self.db_path}` :( Here is the error: '{e}'")
+            raise ConfigError(f"Anvi'o had a problem with `{self.artifact_path}` :( Here is the error: '{e}'")
 
         # now we know about the target anvi'o artifact, we can fill in the version.
         self.get_target_version()
 
 
     def get_target_version(self):
-        if self.db_type in t.versions_for_db_types:
-            version = int(t.versions_for_db_types[self.db_type])
+        if self.artifact_type in t.versions_for_db_types:
+            version = int(t.versions_for_db_types[self.artifact_type])
         else:
-            raise ConfigError("Anvi'o does not have any version information about this ('%s') database type" % self.db_type)
+            raise ConfigError("Anvi'o does not have any version information about this ('%s') database type" % self.artifact_type)
 
         if args.target_version:
             target = int(args.target_version)
 
-            if target <= self.db_version:
-                raise ConfigError("Target version ('%s') can not be lower than db version ('%s')." % (target, self.db_version))
+            if target <= self.artifact_version:
+                raise ConfigError("Target version ('%s') can not be lower than the artifact version ('%s')." % (target, self.artifact_version))
             elif target > version:
                 raise ConfigError("Target version ('%s') can not be higher than highest available version ('%s') for this type." % (target, version))
 
@@ -195,18 +198,18 @@ class Migrater(object):
     def is_something_to_migrate(self):
         """Test if there is anything worth migrating."""
 
-        if not self.db_version:
-            self.get_db_meta()
+        if not self.artifact_version:
+            self.get_artifact_meta()
 
-            if not self.db_version():
+            if not self.artifact_version():
                 raise ConfigError("Anvi'o needs an adult :( PS: if you are the programmer, you are the adult, and your code "
                                   "should have never made it here.")
 
-        if self.target_version == self.db_version:
-            run.info('Input file path', self.db_path)
-            run.info('Input file type', self.db_type)
+        if self.target_version == self.artifact_version:
+            run.info('Input file path', self.artifact_path)
+            run.info('Input file type', self.artifact_type)
 
-            run.info_single(f"Your {self.db_type} looks good and needs no updatin' ☘️", nl_before=1, mc="green")
+            run.info_single(f"Your {self.artifact_type} looks good and needs no updatin' ☘️", nl_before=1, mc="green")
 
             return False
 
@@ -218,7 +221,7 @@ class Migrater(object):
         if not self.is_good_to_go():
             return
 
-        self.get_db_meta()
+        self.get_artifact_meta()
 
         if not self.is_something_to_migrate():
             return
@@ -227,32 +230,33 @@ class Migrater(object):
 
         tasks = []
 
-        # if we are in safe mode, we will first copy the db
+        # if we are in safe mode, we will first copy the artifact file
         if self.safe_mode:
             progress.new("Migration preparation")
             progress.update("Copying the original db for safety ...")
-            temp_file_path = filesnpaths.get_temp_file_path() + '.db'
-            shutil.copy(self.db_path, temp_file_path)
+            artifact_file_name = os.path.basename(self.artifact_path)
+            temp_file_path = filesnpaths.get_temp_file_path() + artifact_file_name
+            shutil.copy(self.artifact_path, temp_file_path)
             progress.end()
         else:
             temp_file_path = None
 
-        for i in range(self.db_version, self.target_version):
+        for i in range(self.artifact_version, self.target_version):
             script_name = "v%s_to_v%s" % (i, i + 1)
 
-            if not self.db_type in migration_scripts or not script_name in migration_scripts[self.db_type]:
+            if not self.artifact_type in migration_scripts or not script_name in migration_scripts[self.artifact_type]:
                 raise ConfigError("Anvi'o can not find a migrate script required "
-                   "for this operation. (DB Type: %s, Script name: %s) " % (self.db_type, script_name))
+                   "for this operation. (DB Type: %s, Script name: %s) " % (self.artifact_type, script_name))
 
             tasks.append(script_name)
 
         for script_name in tasks:
             try:
-                migration_scripts[self.db_type][script_name].migrate(self.db_path)
+                migration_scripts[self.artifact_type][script_name].migrate(self.artifact_path)
             except Exception as e:
                 if temp_file_path:
-                    shutil.move(self.db_path, self.db_path + '.broken')
-                    shutil.copy(temp_file_path, self.db_path)
+                    shutil.move(self.artifact_path, self.artifact_path + '.broken')
+                    shutil.copy(temp_file_path, self.artifact_path)
                     os.remove(temp_file_path)
 
                     progress.reset()
@@ -264,25 +268,25 @@ class Migrater(object):
                 else:
                     progress.reset()
 
-                    shutil.move(self.db_path, self.db_path + '.broken')
+                    shutil.move(self.artifact_path, self.artifact_path + '.broken')
 
                     raise ConfigError("Anvi'o has very bad news for you :( Your migration failed, and anvi'o has no backups to restore your "
                                       "original database. The current database is likely in a broken state, and you will unlkely going to be "
                                       "able to use it. So anvi'o renamed it by adding a prefix '.broken' to its file name. We are very sorry "
                                       "for this error (and anvi'o will certainly not put salt on the wound by reminding you that you could "
-                                      "have avoided it by using the `--migrate-dbs-safely` flag): \"%s\"." % e)
+                                      "have avoided it by using the `--migrate-safely` flag): \"%s\"." % e)
 
                     print(e)
                     sys.exit(-1)
 
             # special cases #
             # after this script is done, genome storage changes extension from .h5 to .db
-            if self.db_type == 'genomestorage' and script_name == 'v4_to_v5':
-                self.db_path = self.db_path[:-3] + '.db'
+            if self.artifact_type == 'genomestorage' and script_name == 'v4_to_v5':
+                self.artifact_path = self.artifact_path[:-3] + '.db'
 
         if self.safe_mode:
             progress.new("Post migration")
-            progress.update("Removing the backup db ...")
+            progress.update("Removing the backup file ...")
             os.remove(temp_file_path)
             progress.end()
         else:
@@ -293,15 +297,15 @@ if __name__ == '__main__':
     parser = ArgumentParser(description=__description__)
 
     groupA = parser.add_argument_group('INPUTS', "You will literally give us any anvi'o database.")
-    groupA.add_argument('input', metavar = 'DATABASE(S)', nargs='+', help = "Anvi'o database or config file for migration. You "
-                                                        "can give many of them all at once. Running `anvi-migrate *.db` "
-                                                        "in a directory will migrate all databases in that directory.")
+    groupA.add_argument('input', metavar = 'DATABASE(S)', nargs='+', help = "Anvi'o database or config file(s) for migration. If "
+                        "you proved many of them by running something like `anvi-migrate *.db *.json`, anvi'o will try to migrate "
+                        "all of the files that match to your filters.")
 
     groupB = parser.add_argument_group('SAFETY', "It is up to you. Safe things take much longer and boring. Unsafe things "
                                                  "are fast, fun, and .. well, don't come to use if your computer loses power "
                                                  "or somiething.")
-    groupB.add_argument(*anvio.A('migrate-dbs-safely'), **anvio.K('migrate-dbs-safely'))
-    groupB.add_argument(*anvio.A('migrate-dbs-quickly'), **anvio.K('migrate-dbs-quickly'))
+    groupB.add_argument(*anvio.A('migrate-safely'), **anvio.K('migrate-safely'))
+    groupB.add_argument(*anvio.A('migrate-quickly'), **anvio.K('migrate-quickly'))
 
     groupC = parser.add_argument_group('PARAMETERS OF CONVENIENCE', "This is how anvi'o spoils you.")
     groupC.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
@@ -312,13 +316,12 @@ if __name__ == '__main__':
         if len(args.input) > 1 and args.target_version:
             raise ConfigError("You have to provide single database to use --target-version parameter. You have provided %d databases." % len(args.input))
 
-        for db_path in args.input:
-            args_for_single_db = copy.deepcopy(args)
-            args_for_single_db.db_path = db_path
+        for artifact_path in args.input:
+            args_for_single_artifact = copy.deepcopy(args)
+            args_for_single_artifact.artifact_path = artifact_path
 
-            Migrater(args_for_single_db).process()
+            Migrater(args_for_single_artifact).process()
 
-            print("") # put little gap
     except ConfigError as e:
         print(e)
         sys.exit(-1)

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -44,7 +44,7 @@ class Migrater(object):
                               "jeopardy.")
 
         if args.migrate_safely and args.migrate_quickly:
-            raise ConfigError("Please don't ask anvi'o to migrate your databases both safely and quickly :/")
+            raise ConfigError("Please don't ask anvi'o to migrate your files both safely and quickly :/")
 
         self.safe_mode = args.migrate_safely
 
@@ -60,7 +60,7 @@ class Migrater(object):
                                   "a look at the output of the command 'sqlite3 --version' on your terminal). "
                                   "You can skip this check if you use the argument `--just-do-it` with your "
                                   "command. In which case we strongly recommend you to use `--migrate-safely` "
-                                  "flag since it will be likely for you to lose your database if something goes "
+                                  "flag since it will be likely for you to lose your file if something goes "
                                   "wrong downstream." % '.'.join(self.sqlite_version) if self.sqlite_version else 'Unknown :/')
             else:
                 run.warning("Anvi'o is skipping the version number check for SQLite. Brace yourself for impact?")
@@ -180,7 +180,7 @@ class Migrater(object):
         if self.artifact_type in t.versions_for_db_types:
             version = int(t.versions_for_db_types[self.artifact_type])
         else:
-            raise ConfigError("Anvi'o does not have any version information about this ('%s') database type" % self.artifact_type)
+            raise ConfigError(f"Anvi'o does not have any version information about the type '{self.artifact_type}'.")
 
         if args.target_version:
             target = int(args.target_version)
@@ -233,7 +233,7 @@ class Migrater(object):
         # if we are in safe mode, we will first copy the artifact file
         if self.safe_mode:
             progress.new("Migration preparation")
-            progress.update("Copying the original db for safety ...")
+            progress.update("Copying the original file for safety ...")
             artifact_file_name = os.path.basename(self.artifact_path)
             temp_file_path = filesnpaths.get_temp_file_path() + artifact_file_name
             shutil.copy(self.artifact_path, temp_file_path)
@@ -245,8 +245,7 @@ class Migrater(object):
             script_name = "v%s_to_v%s" % (i, i + 1)
 
             if not self.artifact_type in migration_scripts or not script_name in migration_scripts[self.artifact_type]:
-                raise ConfigError("Anvi'o can not find a migrate script required "
-                   "for this operation. (DB Type: %s, Script name: %s) " % (self.artifact_type, script_name))
+                raise ConfigError("Anvi'o can not find a migrate script required for this operation. (Artifact Type: %s, Script name: %s) " % (self.artifact_type, script_name))
 
             tasks.append(script_name)
 
@@ -260,10 +259,10 @@ class Migrater(object):
                     os.remove(temp_file_path)
 
                     progress.reset()
-                    raise ConfigError("Something went wrong during the migration of your database :( But anvi'o was able to restore your "
-                                      "original database, and stored the unfinished upgrade in the same directory with the '.broken' "
+                    raise ConfigError("Something went wrong during the migration of your file :( But anvi'o was able to restore your "
+                                      "original artifact, and stored the unfinished upgrade in the same directory with the '.broken' "
                                       "in case you may need it for debugging purposes. Please feel free to get in touch with the "
-                                      "developers, who may ask you to make available the original database to reproduce the problem. This "
+                                      "developers, who may ask you to make available the original file to reproduce the problem. This "
                                       "was the original error message that caused this: '%s'." % e)
                 else:
                     progress.reset()
@@ -271,7 +270,7 @@ class Migrater(object):
                     shutil.move(self.artifact_path, self.artifact_path + '.broken')
 
                     raise ConfigError("Anvi'o has very bad news for you :( Your migration failed, and anvi'o has no backups to restore your "
-                                      "original database. The current database is likely in a broken state, and you will unlkely going to be "
+                                      "original file. The current artifact is likely in a broken state, and you will unlkely going to be "
                                       "able to use it. So anvi'o renamed it by adding a prefix '.broken' to its file name. We are very sorry "
                                       "for this error (and anvi'o will certainly not put salt on the wound by reminding you that you could "
                                       "have avoided it by using the `--migrate-safely` flag): \"%s\"." % e)
@@ -296,9 +295,9 @@ class Migrater(object):
 if __name__ == '__main__':
     parser = ArgumentParser(description=__description__)
 
-    groupA = parser.add_argument_group('INPUTS', "You will literally give us any anvi'o database.")
-    groupA.add_argument('input', metavar = 'DATABASE(S)', nargs='+', help = "Anvi'o database or config file(s) for migration. If "
-                        "you proved many of them by running something like `anvi-migrate *.db *.json`, anvi'o will try to migrate "
+    groupA = parser.add_argument_group('INPUTS', "You will literally give us anything.")
+    groupA.add_argument('input', metavar = 'FILE(S)', nargs='+', help = "One or more files to migrate. If you unleash the program on "
+                        "many files by running something like `anvi-migrate *.db *.json`, anvi'o will try to migrate "
                         "all of the files that match to your filters.")
 
     groupB = parser.add_argument_group('SAFETY', "It is up to you. Safe things take much longer and boring. Unsafe things "
@@ -314,7 +313,8 @@ if __name__ == '__main__':
 
     try:
         if len(args.input) > 1 and args.target_version:
-            raise ConfigError("You have to provide single database to use --target-version parameter. You have provided %d databases." % len(args.input))
+            raise ConfigError(f"You have to provide a single file to use with the `--target-version` parameter. "
+                              f"You have provided {len(args.input)} :/")
 
         for artifact_path in args.input:
             args_for_single_artifact = copy.deepcopy(args)

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -202,6 +202,27 @@ class Migrater(object):
         self.target_version = int(version)
 
 
+    def is_something_to_migrate(self):
+        """Test if there is anything worth migrating."""
+
+        if not self.db_version:
+            self.get_db_meta()
+
+            if not self.db_version():
+                raise ConfigError("Anvi'o needs an adult :( PS: if you are the programmer, you are the adult, and your code "
+                                  "should have never made it here.")
+
+        if self.target_version == self.db_version:
+            run.info('Input file path', self.db_path)
+            run.info('Input file type', self.db_type)
+
+            run.info_single(f"Your {self.db_type} looks good and needs no updatin' ☘️", nl_before=1, mc="green")
+
+            return False
+
+        return True
+
+
     def process(self):
         tasks = []
 

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -79,6 +79,65 @@ class Migrater(object):
                 run.warning("Anvi'o is skipping the version number check for SQLite. Brace yourself for impact?")
 
 
+    def print_info(self):
+        run.info('Input file path', self.db_path)
+        run.info('Input file type', self.db_type)
+        run.info('Current Version', self.db_version)
+        run.info('Target Version', self.target_version)
+
+        if args.migrate_dbs_safely:
+           run.info('Migration mode', "Safe", mc="green")
+        else:
+           run.info('Migration mode', "Adventurous", mc="red")
+
+        run.info('SQLite Version', '.'.join(self.sqlite_version) if self.sqlite_version else 'Unknown :/', nl_after=1, nl_before=1)
+
+
+    def is_good_to_go(self):
+        """Basic checks to make sure file types and so on looks correct"""
+        # let's start with very basics
+        if os.path.isdir(self.db_path):
+            run.info('Input file path', self.db_path, mc='red')
+            run.warning("This is a directory, and yet the training of the members of the migration headquarters "
+                        "of anvi'o only covers files. MOVING ON.", header='NOPE: LA DIRECTORY', lc='yellow')
+
+        # check file extensions to make sure we're clear with this.
+        if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5', 'json']:
+            run.info('Input file path', self.db_path)
+            run.info('Input file type', self.db_type)
+            run.warning(f"This program only works with files that end with `.db` or `.json` extensions. "
+                        f"But if you are sure that your input file at `{self.db_path}` is indeed an anvi'o "
+                        f"database or config file you can use the flag `--just-do-it` at your own risk.",
+                        header="NOPE: LA FILE EXTENSION", lc='yellow')
+
+            return False
+
+        # make sure we have the Python module for HDF is present if we have an .h5 file
+        if self.db_path.endswith('GENOMES.h5'):
+            utils.check_h5py_module()
+
+        # if we have a JSON file, we have to make sure a few things to say we're good to go
+        if self.db_path.endswith('json') or self.db_path.endswith('JSON'):
+            # does it look like a JSON file?
+            filesnpaths.is_file_json_formatted(self.db_path)
+
+            # does it look like an anvi'o config file?
+            import json
+            with open(self.db_path) as json_file:
+                json_content = json.load(json_file)
+                if 'workflow_name' not in json_content:
+                    run.info('Input file path', self.db_path)
+                    run.info('Input file type', self.db_type, mc='red')
+
+                    run.info_single("Your input file is a proper JSON file, but it doesn't look like an anvi'o workflow "
+                                    "since nowhere in it there is a variable called `workflow_name`. So, there is nothing "
+                                    "anvi'o can do with this.", nl_before=1)
+
+                    return False
+
+        return True
+
+
     def get_db_meta(self):
         if not args.just_do_it and self.db_path.split('.')[-1] not in ['db', 'h5', 'json']:
             raise ConfigError("This program only works with files that end with `.db` or `.json` extensions. "


### PR DESCRIPTION
This PR introduces some major changes to `anvi-migrate`, although, most of them are under the hood and will not influence user experience.

* The flow has changed, so if the user runs anvi-migrate * in a large directory, it will still work nicely without creating a lot of `.broken` files for things that are obviously not meant to be migrated.

* Flags and code changed (i.e., user flags `--migrate-dbs-safely` and `--migrate-dbs-quickly` are now `--migrate-safely` and `--migrate-quickly`. This program was written only from the perspective of anvi'o dbs. but it also migrates JSON files, and perhaps ohters in the future. The issue was most obvious with the command line flags, `--migrate-dbs-safely` and `--migrate-dbs-quickly`, which were making things awkward when the user had to pass them to the program while migrating JSON files. "They are not DBs, Bob. They are JSON files FFS". Bob now knows better.

I did every test imaginable, and things seem to be working on my end.