### PR TITLE
anvi-script-process-genbank += --include-locus-tags-as-functions

### DIFF
--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -728,7 +728,7 @@ class GenbankToAnvio:
 
         output_fasta = {}
         output_gene_calls = {}
-        output_functions = {}
+        output_functions = []
         num_genbank_records_processed = 0
         num_genes_found = 0
         num_genes_reported = 0
@@ -862,11 +862,12 @@ class GenbankToAnvio:
                 num_genes_reported += 1
 
                 # not writing gene out to functions table if no annotation
-                if "hypothetical protein" not in function:
-                    output_functions[self.gene_callers_id] = {'source': self.source,
-                                                              'accession': accession,
-                                                              'function': function,
-                                                              'e_value': 0}
+                if function:
+                    output_functions.append({'gene_callers_id': self.gene_callers_id,
+                                             'source': self.source,
+                                             'accession': accession,
+                                             'function': function,
+                                             'e_value': 0})
                     num_genes_with_functions += 1
 
                 # increment the gene callers id for the next
@@ -931,9 +932,10 @@ class GenbankToAnvio:
                                                    self.output_gene_calls_path,
                                                    headers=header_for_external_gene_calls)
 
-            utils.store_dict_as_TAB_delimited_file(output_functions,
-                                                   self.output_functions_path,
-                                                   headers=header_for_functions)
+            with open(self.output_functions_path, 'w') as output_functions_file:
+                for entry in output_functions:
+                    functions_text = '\t'.join([f"{entry[k]}" for k in header_for_functions])
+                    output_functions_file.write(f"{functions_text}\n")
 
             self.run.info('External gene calls file', self.output_gene_calls_path)
             self.run.info('TAB-delimited functions', self.output_functions_path)

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -827,15 +827,18 @@ class GenbankToAnvio:
                 # storing gene product annotation if present
                 if "product" in gene.qualifiers:
                     function = gene.qualifiers["product"][0]
-                    # trying to capture all different ways proteins are listed as hypothetical and setting to same thing so can prevent from adding to output functions table below
-                    if function in ["hypothetical", "hypothetical protein", "conserved hypothetical", "conserved hypotheticals", "Conserved hypothetical protein"]:
-                        function = "hypothetical protein"
+                    # trying to capture all different ways proteins are listed as hypothetical and
+                    # setting to same thing so can prevent from adding to output functions table below
+                    if function in ["hypothetical", "hypothetical protein", "conserved hypothetical",
+                                    "conserved hypotheticals", "Conserved hypothetical protein"]:
+                        function = None
                 else:
-                    function = "hypothetical protein"
+                    function = None
 
-                # if present, adding gene name to product annotation (so long as not a hypothetical, sometimes these names are useful, sometimes they are not):
+                # if present, adding gene name to product annotation (so long as not a hypothetical,
+                # sometimes these names are useful, sometimes they are not):
                 if "gene" in gene.qualifiers:
-                    if function not in "hypothetical protein":
+                    if function:
                         gene_name=str(gene.qualifiers["gene"][0])
                         function = function + " (" + gene_name + ")"
 
@@ -866,7 +869,7 @@ class GenbankToAnvio:
                                                               'e_value': 0}
                     num_genes_with_functions += 1
 
-                # increment the gene callers id fo rthe next
+                # increment the gene callers id for the next
                 self.gene_callers_id += 1
 
         if num_genbank_records_processed == 0:

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -664,6 +664,7 @@ class GenbankToAnvio:
         self.source = A('annotation_source') or 'NCBI_PGAP'
         self.version = A('annotation_version') or 'v4.6'
         self.omit_aa_sequences_column = A('omit_aa_sequences_column') or False
+        self.include_locus_tags_as_functions = A('include_locus_tags_as_functions')
 
         # gene callers id start from 0. you can change your instance
         # prior to processing the genbank file to start from another
@@ -870,6 +871,14 @@ class GenbankToAnvio:
                                              'e_value': 0})
                     num_genes_with_functions += 1
 
+                if self.include_locus_tags_as_functions and "locus_tag" in gene.qualifiers:
+                    locus_tag = gene.qualifiers["locus_tag"][0]
+                    output_functions.append({'gene_callers_id': self.gene_callers_id,
+                                             'source': 'GENBANK_LOCUS_TAG',
+                                             'accession': locus_tag,
+                                             'function': locus_tag,
+                                             'e_value': 0})
+
                 # increment the gene callers id for the next
                 self.gene_callers_id += 1
 
@@ -883,6 +892,7 @@ class GenbankToAnvio:
         self.run.info('Num genes reported', num_genes_reported, mc='green')
         self.run.info('Num genes with AA sequences', num_genes_with_AA_sequences, mc='green')
         self.run.info('Num genes with functions', num_genes_with_functions, mc='green')
+        self.run.info('Locus tags included in functions output?', "Yes" if self.include_locus_tags_as_functions else "No", mc='green')
         self.run.info('Num partial genes', num_partial_genes, mc='cyan')
         self.run.info('Num genes excluded', num_genes_excluded, mc='red', nl_after=1)
 

--- a/anvio/docs/programs/anvi-script-process-genbank.md
+++ b/anvio/docs/programs/anvi-script-process-genbank.md
@@ -1,5 +1,7 @@
-This program extracts the data from a %(genbank-file)s and converts it into anvi'o friendly artifacts: namely, a %(contigs-fasta)s, %(external-gene-calls)s and a %(functions-txt)s.
+This program processes a %(genbank-file)s, and converts it into anvi'o friendly artifacts: namely, a %(contigs-fasta)s, %(external-gene-calls)s and a %(functions-txt)s.
 
 The %(contigs-fasta)s and %(external-gene-calls)s can be given to %(anvi-gen-contigs-database)s to create a %(contigs-db)s, and then you can use %(anvi-import-functions)s to bring the function data (in the %(functions-txt)s) into the database. Then you'll have all of the data in your %(genbank-file)s converted into a single %(contigs-db)s, which you can use for a variety of anvi'o analyses.
 
-The parameters of this program entirely deal with the outputs. Besides telling the program where to put them, you can also give the function annotation source (in the %(functions-txt)s) a custom name. 
+The parameters of this program entirely deal with the outputs. Besides telling the program where to put them, you can also give the function annotation source (in the %(functions-txt)s) a custom name.
+
+One important note about this conversion is the following: During the conversion of GenBank entries, anvi'o will assign a new gene call id to each entry, breaking the link between locus tags defined in the GenBank file and the gene entries that will later appear in the anvi'o {% include ARTIFACT name="contigs-db" %}. One way to avoid this is to use the flag `--include-locus-tags-as-functions`, which will instruct anvi'o to add a new 'function' source for each gene in the output file for functional annotations so that the user can trace back a given gene call to the original locus tag.

--- a/sandbox/anvi-script-process-genbank
+++ b/sandbox/anvi-script-process-genbank
@@ -56,6 +56,11 @@ if __name__ == '__main__':
                             "use that information directly, instead of trying to predict the translated sequences itself. "
                             "If you would like this program to not report amino acid sequences even when they present and use "
                             "anvi'o to predict translated sequences later, you can use this flag.")
+    groupC.add_argument("--include-locus-tags-as-functions", default=False, action="store_true", help="When anvi'o processes "
+                            "genes in a GenBank file, it will assign new gene caller ids to each entry. Using this flag will "
+                            "will instruct anvi'o to add a new 'function' source in the annotation of each gene call so the "
+                            "the user can trace back a given gene call to the original locus tag number in the GenBank file.")
+
 
     args = parser.get_args(parser)
 


### PR DESCRIPTION
During the conversion of GenBank entries, anvi'o assigns a new gene call id to each entry, breaking the link between locus tags defined in the GenBank file and the gene entries that will later appear in the anvi'o generated from a GenBank file.

This PR adds a new flag to the program, `--include-locus-tags-as-functions`, which instructs anvi'o to add a new 'function' source for each gene in the output file for functional annotations so that the user can trace back a given gene call to the original locus tag.

We thank Luke McKay for [bringing this up](https://anvio.slack.com/archives/C8SFMGYF3/p1660244245176539) on anvi'o Slack :)