### PR TITLE
DB lock for babies

### DIFF
--- a/bin/anvi-run-hmms
+++ b/bin/anvi-run-hmms
@@ -3,10 +3,12 @@
 
 import os
 import sys
+import time
 
 import anvio
 import anvio.utils as utils
 import anvio.terminal as terminal
+import anvio.filesnpaths as filesnpaths
 
 with terminal.SuppressAllOutput():
     import anvio.data.hmm as hmm_data
@@ -91,14 +93,30 @@ def main(args):
                           "this output in a directory with --hmmer-output-dir. There is no point to requesting this output "
                           "if you are never going to see it, so we figured we'd stop you right there. :)")
 
-    search_tables = TablesForHMMHits(args.contigs_db, num_threads_to_use=args.num_threads, just_do_it=args.just_do_it,
-                                     hmm_program_to_use=args.hmmer_program, hmmer_output_directory=args.hmmer_output_dir,
-                                     get_domain_table_output=args.domain_hits_table, add_to_functions_table=args.add_to_functions_table)
-    search_tables.populate_search_tables(sources)
+    # right before we start, we want to make sure there is no other program actually
+    # running on the same database, and we will not start until it is over:
+    lock = utils.DatabaseLockForBabies(args.contigs_db, 'HMMs')
+    lock.wait()
 
-    if not args.hmm_profile_dir and not args.installed_hmm_profile and args.also_scan_trnas:
-        tables_for_trna_hits = TablesForTransferRNAs(args)
-        tables_for_trna_hits.populate_search_tables(args.contigs_db)
+    # this try/except block is critical, because we don't want to find any lingering
+    # lock files around when a process is dead due to an exception.
+    try:
+        search_tables = TablesForHMMHits(args.contigs_db, num_threads_to_use=args.num_threads, just_do_it=args.just_do_it,
+                                         hmm_program_to_use=args.hmmer_program, hmmer_output_directory=args.hmmer_output_dir,
+                                         get_domain_table_output=args.domain_hits_table, add_to_functions_table=args.add_to_functions_table)
+        search_tables.populate_search_tables(sources)
+
+        if not args.hmm_profile_dir and not args.installed_hmm_profile and args.also_scan_trnas:
+            tables_for_trna_hits = TablesForTransferRNAs(args)
+            tables_for_trna_hits.populate_search_tables(args.contigs_db)
+    except Exception as e:
+        # there was a snafu? get rid of your release first before passing the error to
+        # the user:
+        lock.release()
+        raise ConfigError(e.e)
+
+    # all good
+    lock.release()
 
 
 if __name__ == '__main__':

--- a/bin/anvi-scan-trnas
+++ b/bin/anvi-scan-trnas
@@ -4,6 +4,7 @@
 import sys
 
 import anvio
+import anvio.utils as utils
 import anvio.terminal as terminal
 
 from anvio.tables.trnahits import TablesForTransferRNAs
@@ -28,8 +29,19 @@ progress = terminal.Progress()
 
 @time_program
 def main(args):
-    tables_for_trna_hits = TablesForTransferRNAs(args)
-    tables_for_trna_hits.populate_search_tables(args.contigs_db)
+    # right before we start, we want to make sure there is no other program actually
+    # running on the same database, and we will not start until it is over:
+    lock = utils.DatabaseLockForBabies(args.contigs_db, 'HMMs')
+    lock.wait()
+
+    try:
+        tables_for_trna_hits = TablesForTransferRNAs(args)
+        tables_for_trna_hits.populate_search_tables(args.contigs_db)
+    except Exception as e:
+        lock.release()
+        raise ConfigError(e.e)
+
+    lock.release()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It has been a long time anvi'o suffered from occasional 'sad tables' when a user run programs such as `anvi-run-hmms` on the same database with multiple models in parallel. Or even running different programs targeting the same tables, such as `anvi-run-hmms` and `anvi-scan-trnas` caused occasional race conditions that kind of ruined things.

A solution could have been implementing db lock mechanisms, but in most cases many anvi'o programs can operate on the same anvi'o db without any problem, so blocking write access to anvi'o dbs would have been too much of a bottleneck for performance.

This PR introduces a quick-and-dirty (but effective) solution for this problem, and its application to `anvi-run-hmms` and `anvi-scan-trnas`.

Now if you start `anvi-run-hmms` on a contigs-db, and open a new terminal to start another `anvi-run-hmms` or `anvi-scan-trnas`, the second process will wait until the lock is release by the first one. Here is an example of what the user sees in their terminal in that case:

![image](https://user-images.githubusercontent.com/197307/187032238-77fbe6ec-90d9-4d1a-85b9-1e273b1441ee.png)

Once the first process is done, the user sees that the lock is removed, and the process continues:

![image](https://user-images.githubusercontent.com/197307/187032432-f264e0cf-40b2-4273-8cd5-08f1c181ad6b.png)

_(it is a DB lock for babies because it is not over-engineered, very simple to use, and will solve 99% of our problems. Coding for babies should be a trend against 'everything but the kitchen sink' in programming and here we are leading it by example?)._