### PR TITLE
anvi'o mode 'display functions' fixy

### DIFF
--- a/anvio/data/mini-states/display-functions.json
+++ b/anvio/data/mini-states/display-functions.json
@@ -2,7 +2,7 @@
     "version": "3",
     "tree-type": "circlephylogram",
     "order-by": ">> associated_groups",
-    "current-view": "presence_absence_view",
+    "current-view": "functions_presence_absence_view",
     "samples-order": "FREQUENCY_VIEW",
     "angle-min": "0",
     "angle-max": "180",
@@ -44,7 +44,7 @@
         }
     },
     "views": {
-        "presence_absence_view": {
+        "functions_presence_absence_view": {
             "unadjusted_p_value": {
                 "normalization": "none",
                 "min": {
@@ -68,7 +68,7 @@
                 }
             }
         },
-        "frequency_view": {
+        "functions_frequency_view": {
             "unadjusted_p_value": {
                 "normalization": "none",
                 "min": {

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -866,7 +866,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.run.info('Only the best hits are considered', "False" if facc.aggregate_using_all_hits else "True", nl_after=1)
 
         # now we will work on views and clustering our data to get newick trees.
-        self.p_meta['default_view'] = 'presence_absence_view'
+        self.p_meta['default_view'] = 'functions_presence_absence_view'
         self.default_view = self.p_meta['default_view']
 
         # our 'samples' in this context are individual genomes we are about to display
@@ -874,10 +874,10 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         self.p_meta['sample_id'] = f"{facc.function_annotation_source} DISPLAY"
 
         # setup the views dict
-        self.views = {'frequency_view'       : {'header': list(facc.layer_names_considered),
-                                                'dict': facc.functions_across_layers_frequency},
-                      'presence_absence_view': {'header': list(facc.layer_names_considered),
-                                                'dict': facc.functions_across_layers_presence_absence}}
+        self.views = {'functions_frequency_view'       : {'header': sorted(list(facc.layer_names_considered)),
+                                                          'dict': facc.functions_across_layers_frequency},
+                      'functions_presence_absence_view': {'header': sorted(list(facc.layer_names_considered)),
+                                                          'dict': facc.functions_across_layers_presence_absence}}
 
         # create a new, empty profile database for manual operations
         if not os.path.exists(self.profile_db_path):
@@ -906,7 +906,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
             # then add the items order to the database
             dbops.add_items_order_to_db(self.profile_db_path, item_order_name, items_order, order_data_type_newick=True,
-                                        distance=self.distance, linkage=self.linkage, make_default=True if view == 'presence_absence_view' else False,
+                                        distance=self.distance, linkage=self.linkage, make_default=True if view == 'functions_presence_absence_view' else False,
                                         check_names_consistency=False)
 
             # if there are more than one genome in the analysis (which should almost always be the case),

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1765,7 +1765,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                     json_entry.extend([self.splits_basic_info[split_name][header] for header in basic_info_headers])
 
                 # (3) adding essential data for the view
-                json_entry.extend([view_dict[split_name][header] for header in view_headers])
+                json_entry.extend([view_dict[split_name][header] if header in view_dict[split_name] else 0 for header in view_headers])
 
                 # (4) adding additional layers
                 if self.items_additional_data_keys:

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -665,10 +665,10 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
             for view in views_table:
                 table_name = views_table[view]['target_table']
 
-                data = profile_db.db.get_table_as_dict(table_name)
+                data, header = profile_db.db.get_view_data(table_name)
 
                 self.views[view] = {'table_name': table_name,
-                                    'header': profile_db.db.get_table_structure(table_name)[1:],
+                                    'header': header,
                                     'dict': data}
 
             self.p_meta['default_view'] = sorted(list(self.views.keys()), reverse=True)[0]

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -900,7 +900,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         for view in self.views:
             # first, generate an items order for a given view:
             items_order = clustering.get_newick_tree_data_for_dict(self.views[view]['dict'], zero_fill_missing=True, distance=self.distance, linkage=self.linkage)
-            item_order_name = f"{view[:-5]}"
+            item_order_name = f"{view[10:-5]}"
             self.p_meta['available_item_orders'].append(item_order_name)
             self.p_meta['item_orders'][item_order_name] = {'type': 'newick', 'data': copy.deepcopy(items_order)}
 

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -367,8 +367,10 @@ table_requires_unique_entry_id = {'self': False,
                                   'mean_coverage_Q1Q3_contigs': False,
                                   'portion_covered_contigs': False,
                                   'portion_covered_splits': False,
-                                  'frequency_view': False,
-                                  'presence_absence_view': False,
+                                  'frequency_view': False,           #
+                                  'presence_absence_view': False,    # These two tables are for pangeomes
+                                  'functions_frequency_view': True,        #
+                                  'functions_presence_absence_view': True, # And these two are for anvi-display-functions stuff
                                   'atomic_data_splits': False,
                                   'atomic_data_contigs': False,
                                   'max_normalized_ratio_contigs': False,


### PR DESCRIPTION
Clearly we (as in, an unnamed anvi'o developer (as in me)) BROKE `anvi-interactive PROFILE.db --manual` mechanism to produce beautiful views for profile-db files that contain actual view data (such as those that are generated by the program `anvi-display-functions`) when we changed the way we store view data in and retrieve view data from profile databases.

This PR addresses that issue, and only took a life time to find out how to fix multiple layers of nightmares. For details, see commit messages, and then clean your eyes with this:

![image](https://user-images.githubusercontent.com/197307/194319796-ccc5df58-b691-4bd5-8dcc-0450b7c7e993.png)
