### PR TITLE
Use 'rt' mode when reading compressed file

### DIFF
--- a/anvio/fastalib.py
+++ b/anvio/fastalib.py
@@ -95,7 +95,7 @@ class SequenceSource():
         self.unique_next_hash = 0
 
         if self.compressed:
-            self.file_pointer = gzip.open(self.fasta_file_path)
+            self.file_pointer = gzip.open(self.fasta_file_path, mode="rt")
         else:
             self.file_pointer = io.open(self.fasta_file_path, 'rU', newline='')
 


### PR DESCRIPTION
Hi,

This is an attempt at #1920.

In `SequenceSource.__init__`, use `gzip.open(fname, mode='rt')` when reading a compressed file. This prevents errors when looking at the first character of the file (which should be '>'). Both `anvi-gen-contigs-database` and `anvi-script-reformat-fasta` seem to be working with `gz` files now.

An alternative way would be to decode the first character to ensure it's a string, and not a byte, when comparing it to `'>'`.

Please let me know if you'd like me to modify/add anything.

Thanks,
V