### PR TITLE
Write gzip output when input is also gzipped

### DIFF
--- a/anvio/fastalib.py
+++ b/anvio/fastalib.py
@@ -27,7 +27,7 @@ class FastaOutput:
         self.compressed = True if self.output_file_path.endswith('.gz') else False
 
         if self.compressed:
-            self.output_file_obj = gzip.open(output_file_path, 'w')
+            self.output_file_obj = gzip.open(output_file_path, 'wt')
         else:
             self.output_file_obj = open(output_file_path, 'w')
 

--- a/sandbox/anvi-script-reformat-fasta
+++ b/sandbox/anvi-script-reformat-fasta
@@ -107,8 +107,10 @@ def reformat_FASTA(args):
     total_num_nucleotides_modified = 0
     total_num_contigs_removed = 0
 
-    output = u.FastaOutput(args.output_file)
     fasta = u.SequenceSource(args.contigs_fasta)
+    if (fasta.fasta_file_path.endswith(".gz")) and (not args.output_file.endswith(".gz")):
+        args.output_file += ".gz"
+    output = u.FastaOutput(args.output_file)
 
     while next(fasta):
         l = len(fasta.seq)


### PR DESCRIPTION
Hi, 

this is a follow-up to #1920. When reformatting a gzip FASTA, also write the output as gzip.

**Summary of changes:**
  - Use mode 'wt' when creating 'output_file_obj' in class FastaOutput
  - Append '.gz' to output file if input file name is gzipped

Best,
V