### PR TITLE
Ecophylo skip sanity check

### DIFF
--- a/anvio/docs/workflows/ecophylo.md
+++ b/anvio/docs/workflows/ecophylo.md
@@ -60,7 +60,7 @@ To initialize [AA-mode](#aa-mode), go to the rule `cluster_X_percent_sim_mmseqs`
     "hmm_list": "hmm_list.txt",
     "samples_txt": ""
     "cluster_X_percent_sim_mmseqs": {
-        "AA_mode": True,
+        "AA_mode": true,
     }
 }
 ```
@@ -88,7 +88,7 @@ To initialize [profile-mode](#profile-mode-insights-into-the-ecological-and-evol
 
 ## Config file options
 
-Ecophylo will sanity check all input files that contain %(contigs-db)ss before the workflow starts. This can take a while especially if you are working with 1000's of genomes. If you want to skip sanity checks for contigsDBs in your external-genomes and/or %(metagenomes)s then adjust your config to the following:
+Ecophylo will sanity check all input files that contain %(contigs-db)ss before the workflow starts. This can take a while especially if you are working with 1000's of genomes. If you want to skip sanity checks for %(contigs-db)ss in your %(external-genomes)s and/or %(metagenomes)s then adjust your config to the following:
 
 ```bash
 {

--- a/anvio/docs/workflows/ecophylo.md
+++ b/anvio/docs/workflows/ecophylo.md
@@ -17,6 +17,7 @@ anvi-run-workflow -w ecophylo \
                   --get-default-config config.json
 {{ codestop }}
 
+
 {:.notice}
 Here is a tutorial walking through more details regarding the ecophylo %(workflow-config)s file: coming soon!
 
@@ -82,5 +83,15 @@ To initialize [profile-mode](#profile-mode-insights-into-the-ecological-and-evol
     "external_genomes": "external-genomes.txt",
     "hmm_list": "hmm_list.txt",
     "samples_txt": "samples.txt"
+}
+```
+
+## Config file options
+
+Ecophylo will sanity check all input files that contain %(contigs-db)ss before the workflow starts. This can take a while especially if you are working with 1000's of genomes. If you want to skip sanity checks for contigsDBs in your external-genomes and/or %(metagenomes)s then adjust your config to the following:
+
+```bash
+{
+    "run_genomes_sanity_check": false
 }
 ```

--- a/anvio/tests/run_workflow_tests_for_ecophylo.sh
+++ b/anvio/tests/run_workflow_tests_for_ecophylo.sh
@@ -24,6 +24,7 @@ sed 's|samples\.txt||' default-config.json > no-samples-txt-config.json
 sed 's|\"AA_mode\"\: false|\"AA_mode\"\: true|' no-samples-txt-config.json > AA-mode-config.json
 sed 's|external-genomes.txt||' default-config.json | sed 's|samples\.txt||' > no-samples-only-metagenomes-txt-config.json
 sed 's|metagenomes.txt||' default-config.json | sed 's|samples\.txt||' > no-samples-only-external-genomes-txt-config.json
+sed 's|"run_genomes_sanity_check": true|"run_genomes_sanity_check": false|' default-config.json > no-genomes-sanity-check-config.json
 
 
 INFO "Generating r1 and r2 short reads for samples"
@@ -54,8 +55,11 @@ anvi-run-workflow -w ecophylo -c default-config.json -A --dry-run
 INFO "Running ecophylo workflow with ecophylo dry-run: only metagenomes.txt (profile-mode)"
 anvi-run-workflow -w ecophylo -c only-metagenomes-txt-config.json -A --dry-run
 
-INFO "Running ecophylo workflow with ecophylo dry-run: only external-genomes.txtn(profile-mode)"
+INFO "Running ecophylo workflow with ecophylo dry-run: only external-genomes.txt (profile-mode)"
 anvi-run-workflow -w ecophylo -c only-external-genomes-txt-config.json -A --dry-run
+
+INFO "Running ecophylo workflow with ecophylo dry-run: no GenomeDescriptions and MetagenomeDescriptions"
+anvi-run-workflow -w ecophylo -c no-genomes-sanity-check-config.json -A --dry-run
 
 INFO "Running ecophylo workflow (profile-mode)"
 anvi-run-workflow -w ecophylo -c default-config.json

--- a/anvio/workflows/ecophylo/Snakefile
+++ b/anvio/workflows/ecophylo/Snakefile
@@ -1040,9 +1040,9 @@ rule anvi_scg_taxonomy:
         # Concatenate metagenomes.txt and external-genomes.txt
         contigs_db_name_path_list = list(M.contigs_db_name_path_dict.items())
         contigs_db_name_path_df = pd.DataFrame(contigs_db_name_path_list, columns=['name', 'contigs_db_path'])
-        combined_genomes_df_path = os.path.join(dirs_dict['HOME'], "combined_genomes.txt") 
+        combined_genomes_df_path = "combined_genomes.txt"
         contigs_db_name_path_df.to_csv(combined_genomes_df_path, sep="\t", index=False, header=True)
-        
+
         if hmm_source in M.internal_hmm_sources:
             shell("anvi-estimate-scg-taxonomy -M {combined_genomes_df_path} \
                                               --metagenome-mode \
@@ -1050,6 +1050,7 @@ rule anvi_scg_taxonomy:
                                               -T {threads} \
                                               --raw-output \
                                               -O {params.taxonomy} &> {log}")
+            
             # Import data
             #------------
             scg_taxonomy = pd.read_csv(params.taxonomy_long, \

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -177,17 +177,23 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
         if not gene_caller_to_use:
             gene_caller_to_use = constants.default_gene_caller
 
+        sanity_checked_metagenomes_file = os.path.join(self.dirs_dict['HOME'], "sanity_checked_metagenomes.txt")
+        sanity_checked_genomes_file = os.path.join(self.dirs_dict['HOME'], "sanity_checked_genomes.txt")
+
         if self.metagenomes:
             filesnpaths.is_file_exists(self.metagenomes)
             self.metagenomes_df = pd.read_csv(self.metagenomes, sep='\t', index_col=False)
 
-            if self.run_genomes_sanity_check:
+            if not os.path.exists(sanity_checked_metagenomes_file):
                 args = argparse.Namespace(metagenomes=self.get_param_value_from_config(['metagenomes']), gene_caller = gene_caller_to_use)
                 g = MetagenomeDescriptions(args)
                 g.load_metagenome_descriptions(init=False)
                 self.metagenomes_dict = g.metagenomes_dict
                 self.metagenomes_name_list = list(self.metagenomes_dict.keys())
                 self.metagenomes_path_list = [value['contigs_db_path'] for key,value in self.metagenomes_dict.items()]
+
+                with open(sanity_checked_metagenomes_file, 'w') as fp:
+                    pass
             else:
                 self.metagenomes_name_list = self.metagenomes_df.name.to_list()
                 self.metagenomes_path_list = self.metagenomes_df.contigs_db_path.to_list()
@@ -207,7 +213,7 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
             filesnpaths.is_file_exists(self.external_genomes)
             self.external_genomes_df = pd.read_csv(self.external_genomes, sep='\t', index_col=False)
             
-            if self.run_genomes_sanity_check:
+            if not os.path.exists(sanity_checked_genomes_file):
                 # FIXME: metagenomes.txt or external-genomes.txt with multiple gene-callers will break
                 # here. Users should only have one type of gene-caller e.g. "NCBI_PGAP".
 
@@ -217,6 +223,9 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                 self.external_genomes_dict = genome_descriptions.external_genomes_dict
                 self.external_genomes_names_list = list(self.external_genomes_dict.keys())
                 self.external_genomes_path_list = [value['contigs_db_path'] for key,value in self.external_genomes_dict.items()]
+
+                with open(sanity_checked_genomes_file, 'w') as fp:
+                    pass
             else:
                 self.external_genomes_names_list = self.external_genomes_df.name.to_list()
                 self.external_genomes_path_list = self.external_genomes_df.contigs_db_path.to_list()

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -184,16 +184,22 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
             filesnpaths.is_file_exists(self.metagenomes)
             self.metagenomes_df = pd.read_csv(self.metagenomes, sep='\t', index_col=False)
 
-            if not os.path.exists(sanity_checked_metagenomes_file):
-                args = argparse.Namespace(metagenomes=self.get_param_value_from_config(['metagenomes']), gene_caller = gene_caller_to_use)
-                g = MetagenomeDescriptions(args)
-                g.load_metagenome_descriptions(init=False)
-                self.metagenomes_dict = g.metagenomes_dict
-                self.metagenomes_name_list = list(self.metagenomes_dict.keys())
-                self.metagenomes_path_list = [value['contigs_db_path'] for key,value in self.metagenomes_dict.items()]
+            if self.run_genomes_sanity_check:
+                if not os.path.exists(sanity_checked_metagenomes_file):
+                    args = argparse.Namespace(metagenomes=self.get_param_value_from_config(['metagenomes']), gene_caller = gene_caller_to_use)
+                    g = MetagenomeDescriptions(args)
+                    g.load_metagenome_descriptions(init=False)
+                    self.metagenomes_dict = g.metagenomes_dict
+                    self.metagenomes_name_list = list(self.metagenomes_dict.keys())
+                    self.metagenomes_path_list = [value['contigs_db_path'] for key,value in self.metagenomes_dict.items()]
 
-                with open(sanity_checked_metagenomes_file, 'w') as fp:
-                    pass
+                    with open(sanity_checked_metagenomes_file, 'w') as fp:
+                        pass
+                else:
+                    self.run.warning(f"You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
+                                        f"for any genomes or metagenomes that cause issues downstream in ecophylo.")
+                    self.metagenomes_name_list = self.metagenomes_df.name.to_list()
+                    self.metagenomes_path_list = self.metagenomes_df.contigs_db_path.to_list()
             else:
                 self.metagenomes_name_list = self.metagenomes_df.name.to_list()
                 self.metagenomes_path_list = self.metagenomes_df.contigs_db_path.to_list()
@@ -213,19 +219,23 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
             filesnpaths.is_file_exists(self.external_genomes)
             self.external_genomes_df = pd.read_csv(self.external_genomes, sep='\t', index_col=False)
             
-            if not os.path.exists(sanity_checked_genomes_file):
-                # FIXME: metagenomes.txt or external-genomes.txt with multiple gene-callers will break
-                # here. Users should only have one type of gene-caller e.g. "NCBI_PGAP".
+            if self.run_genomes_sanity_check:
+                if not os.path.exists(sanity_checked_genomes_file):
+                    # FIXME: metagenomes.txt or external-genomes.txt with multiple gene-callers will break
+                    # here. Users should only have one type of gene-caller e.g. "NCBI_PGAP".
 
-                args = argparse.Namespace(external_genomes=self.external_genomes, gene_caller = gene_caller_to_use)
-                genome_descriptions = GenomeDescriptions(args)
-                genome_descriptions.load_genomes_descriptions(init=False)
-                self.external_genomes_dict = genome_descriptions.external_genomes_dict
-                self.external_genomes_names_list = list(self.external_genomes_dict.keys())
-                self.external_genomes_path_list = [value['contigs_db_path'] for key,value in self.external_genomes_dict.items()]
+                    args = argparse.Namespace(external_genomes=self.external_genomes, gene_caller = gene_caller_to_use)
+                    genome_descriptions = GenomeDescriptions(args)
+                    genome_descriptions.load_genomes_descriptions(init=False)
+                    self.external_genomes_dict = genome_descriptions.external_genomes_dict
+                    self.external_genomes_names_list = list(self.external_genomes_dict.keys())
+                    self.external_genomes_path_list = [value['contigs_db_path'] for key,value in self.external_genomes_dict.items()]
 
-                with open(sanity_checked_genomes_file, 'w') as fp:
-                    pass
+                    with open(sanity_checked_genomes_file, 'w') as fp:
+                        pass
+                else:
+                    self.external_genomes_names_list = self.external_genomes_df.name.to_list()
+                    self.external_genomes_path_list = self.external_genomes_df.contigs_db_path.to_list()
             else:
                 self.external_genomes_names_list = self.external_genomes_df.name.to_list()
                 self.external_genomes_path_list = self.external_genomes_df.contigs_db_path.to_list()


### PR DESCRIPTION
This PR is to address #1993

By default the ecophylo workflow will now only sanity check `external-genomes` and `metagenomes` one time. Additionally, the user can now by pass the one time check by switching the `run_genomes_sanity_check` to `false`