### PR TITLE
Pfam accession sanity checks

### DIFF
--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3969,6 +3969,21 @@ def sanity_check_hmm_model(model_path, genes):
                           "Here is a list of missing gene names: %s" % ', '.join(list(genes_in_model.difference(genes))))
 
 
+def sanity_check_pfam_accessions(pfam_accession_ids):
+    """This function sanity checks a list of Pfam accession IDs
+    
+    Parameters
+    ==========
+    pfam_accession_ids: list
+        list of possible Pfam accessions
+    """
+    not_pfam_accession_ids = [pfam_accession_id for pfam_accession_id in pfam_accession_ids if not pfam_accession_id.startswith("PF")]
+
+    if len(not_pfam_accession_ids):
+        raise ConfigError(f"The following accessions do not appear to be from Pfam because they do not "
+                          f"start with \"PF\", please double check the following: {','.join(not_pfam_accession_ids)}")
+
+
 def get_missing_programs_for_hmm_analysis():
     missing_programs = []
     for p in ['prodigal', 'hmmscan']:

--- a/sandbox/anvi-script-pfam-accessions-to-hmms-directory
+++ b/sandbox/anvi-script-pfam-accessions-to-hmms-directory
@@ -58,6 +58,8 @@ def main(args):
     else:
         raise ConfigError("You should provide *some* PFAM accession ids to this program :/")
 
+    utils.sanity_check_pfam_accessions(pfam_accession_ids)
+
     output_directory_path = A('output_directory') or os.path.abspath('./UNKNOWN_HMMS_FROM_PFAM')
 
     pfam_accession_ids = [e.strip() for e in set(pfam_accession_ids)]


### PR DESCRIPTION
Hi everyone! I added the function `sanity_check_pfam_accessions` to `utils.py` to address an aspect of this [thread in discord today](https://discord.com/channels/1002537821212512296/1046482126490583190). I was looking for a definition online for Pfam accessions, but all I know for sure is that they start with "PF". To leave room to expand the sanity check, I threw it in `utils.py`. Let me know what you think!

Here is a quick test:

```bash
anvi-script-pfam-accessions-to-hmms-directory --pfam-accessions-list PF16867 asdf lkj -O asdf
```