### PR TITLE
anvi-run-cazymes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ anvio/data/misc/Pfam/
 anvio/data/misc/PDB.db
 anvio/data/misc/Interacdome/
 anvio/data/misc/MODELLER/db/
+anvio/data/misc/CAZyme/
 anvio/data/interactive/lib/ngl/
 smtp_config.ini
 .snakemake

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -100,7 +100,7 @@ class CAZymeSetup(object):
 
     def is_database_exists(self):
         """Determine if CAZyme database has already been downloaded"""
-        if os.path.exists(os.path.join(self.cazyme_data_dir, f"dbCAN-HMMdb-{self.page_index}.txt")):
+        if os.path.exists(os.path.join(self.cazyme_data_dir, f"CAZyme_HMMs.txt")):
             raise ConfigError(f"It seems you already have CAZyme database installed in {self.cazyme_data_dir}, please use --reset flag if you want to re-download it.")
 
     def download(self, hmmpress_files=True):

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -152,6 +152,7 @@ class CAZyme(object):
         self.num_threads = A('num_threads', null)
         self.hmm_program = A('hmmer_program', null) or 'hmmsearch'
         self.noise_cutoff_terms = A('noise_cutoff_terms', null)
+        self.cazyme_data_dir = args.cazyme_data_dir
 
         # load_catalog will populate this
         self.function_catalog = {}
@@ -159,7 +160,8 @@ class CAZyme(object):
         filesnpaths.is_program_exists(self.hmm_program)
         utils.is_contigs_db(self.contigs_db_path)
 
-        self.cazyme_data_dir = os.path.join(os.path.dirname(anvio.__file__), 'data/misc/CAZyme')
+        if not self.cazyme_data_dir:
+            self.cazyme_data_dir = os.path.join(os.path.dirname(anvio.__file__), 'data/misc/CAZyme')
 
         self.is_database_exists()
 

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -126,6 +126,21 @@ class CAZymeSetup(object):
             os.remove(log_file_path)
 
 class CAZyme(object):
+    """Search CAZyme database over contigs-db
+
+    Parameters
+    ==========
+    args : argparse.Namespace
+        See `bin/anvi-run-cazymes` for available arguments
+        - noise_cutoff_terms : str, optional
+            Filtering option for HMM search
+        - hmm_program : str, optional
+            hmmsearch (default) or hmmscan
+    run : terminal.Run, optional
+        An object for printing messages to the console.
+    progress : terminal.Progress, optional
+        An object for printing progress bars to the console.
+    """
     def __init__(self, args, run=run, progress=progress):
 
         self.run = run
@@ -149,11 +164,11 @@ class CAZyme(object):
         self.is_database_exists()
 
     def is_database_exists(self):
-        """Checks if database files exist and decompresses them if compressed"""
-
+        """Checks if decompressed database files exist"""
 
         if not glob.glob(os.path.join(self.cazyme_data_dir, "dbCAN-HMMdb-*.txt")):
-            raise ConfigError(f"It seems you do not have the CAZyme database installed in {self.cazyme_data_dir}, please run 'anvi-setup-cazymes' download it.")
+            raise ConfigError(f"It seems you do not have the CAZyme database installed in {self.cazyme_data_dir}, "
+                              f"please run 'anvi-setup-cazymes' download it.")
 
         # Glob and find what files we have then check if we have them all
         downloaded_files = glob.glob(os.path.join(self.cazyme_data_dir, '*'))
@@ -164,10 +179,13 @@ class CAZyme(object):
 
         if hmmpress_file_extensions.sort() != extant_extensions.sort():
             raise ConfigError("Anvi'o detected that the CAZyme database was not properly compressed with hmmpress. "
-                                "Please 'anvi-setup-cazymes --reset'")
+                              "Please 'anvi-setup-cazymes --reset'")
 
     def process(self):
-        # hmm_file = glob.glob(os.path.join(self.cazyme_data_dir, "dbCAN-HMMdb-*.txt"))
+        """Search CAZyme HMMs over contigs-db, parse, and filter results"""
+
+        #FIXME: need a smarter way to find the CAZyme HMM file for when users 
+        # want a specific version. This will break if it's not V11
         hmm_file = os.path.join(self.cazyme_data_dir, "dbCAN-HMMdb-V11.txt")
 
         # initialize contigs database

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -157,6 +157,10 @@ class CAZyme(object):
         # load_catalog will populate this
         self.function_catalog = {}
 
+        # default noise_cutoff_terms
+        if not self.noise_cutoff_terms:
+            self.noise_cutoff_terms = "-E 1e-12"
+
         filesnpaths.is_program_exists(self.hmm_program)
         utils.is_contigs_db(self.contigs_db_path)
 

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -165,6 +165,11 @@ class CAZyme(object):
 
         self.is_database_exists()
 
+        # reminder to be a good citizen (Good idea Iva!)
+        self.run.warning("Anvi'o will annotate your contigs-db genes with the dbCAN CAZyme database. "
+                         "Please do not forget to cite this database when you publish your science :) "
+                         "(http://www.cazy.org/Citing-CAZy).", lc='green', header="CITATION")
+
     def is_database_exists(self):
         """Checks if decompressed database files exist"""
 

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -92,7 +92,7 @@ class CAZymeSetup(object):
             self.run.info('Attempting to use version', self.args.cazyme_version)
         else:
             self.page_index = 'V11'
-            self.run.info_single('No CAZyme version specified. Using current release.')
+            self.run.info_single(f"No CAZyme version specified. Using {self.page_index}.")
 
         self.database_url = os.path.join("https://bcb.unl.edu/dbCAN2/download/Databases", f"{self.page_index}", f"dbCAN-HMMdb-{self.page_index}.txt") 
 

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -119,7 +119,7 @@ class CAZymeSetup(object):
         ret_val = utils.run_command(cmd_line, log_file_path)
 
         if ret_val:
-            raise ConfigError("Hmm. There was an error while running `hmmpress` on the Pfam HMM profiles. "
+            raise ConfigError("Hmm. There was an error while running `hmmpress` on the CAZyme HMM profiles. "
                                 "Check out the log file ('%s') to see what went wrong." % (log_file_path))
         else:
             # getting rid of the log file because hmmpress was successful
@@ -214,7 +214,7 @@ class CAZyme(object):
                             "and gracefully quit.", nl_before=1, nl_after=1)
             shutil.rmtree(tmp_directory_path)
             hmmer.clean_tmp_dirs()
-            gene_function_calls_table.add_empty_sources_to_functional_sources({'Pfam'})
+            gene_function_calls_table.add_empty_sources_to_functional_sources({'CAZyme'})
             return
 
         # parse hmmer output

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+"""This file contains CAZyme related classes."""
+
+import os
+
+import anvio
+import anvio.utils as utils
+import anvio.terminal as terminal
+import anvio.filesnpaths as filesnpaths
+
+from anvio.errors import ConfigError
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2020, the Meren Lab (http://merenlab.org/)"
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__maintainer__ = "Matthew Schechter"
+__email__ = "mschechter@uchicago.edu"
+
+run = terminal.Run()
+progress = terminal.Progress()
+pp = terminal.pretty_print
+
+class CAZymeSetup(object):
+    def __init__(self, args, run=run, progress=progress):
+        """Setup a CAZyme database for anvi'o
+
+        http://www.cazy.org/
+
+        Parameters
+        ==========
+        args : argparse.Namespace
+            See `bin/anvi-setup-cazymes` for available arguments
+            - cazyme_data_dir : str, optional
+                The directory where the CAZyme data should be stored. If not provided, the data will be stored in the anvi'o data directory.
+            - reset : bool, optional
+                If True, the data directory will be deleted and recreated. Defaults to False.
+        run : terminal.Run, optional
+            An object for printing messages to the console.
+        progress : terminal.Progress, optional
+            An object for printing progress bars to the console.
+        """
+
+        self.args = args
+        self.run = run
+        self.progress = progress
+        self.cazyme_data_dir = args.cazyme_data_dir
+
+        filesnpaths.is_program_exists('hmmpress')
+        
+        if self.cazyme_data_dir and args.reset:
+            raise ConfigError("You are attempting to run CAZyme setup on a non-default data directory (%s) using the --reset flag. "
+                              "To avoid automatically deleting a directory that may be important to you, anvi'o refuses to reset "
+                              "directories that have been specified with --cazyme-data-dir. If you really want to get rid of this "
+                              "directory and regenerate it with CAZyme data inside, then please remove the directory yourself using "
+                              "a command like `rm -r %s`. We are sorry to make you go through this extra trouble, but it really is "
+                              "the safest way to handle things." % (self.cazyme_data_dir, self.cazyme_data_dir))
+
+        if not self.cazyme_data_dir:
+            self.cazyme_data_dir = os.path.join(os.path.dirname(anvio.__file__), 'data/misc/CAZyme')
+
+        filesnpaths.is_output_dir_writable(os.path.dirname(os.path.abspath(self.cazyme_data_dir)))
+
+        self.resolve_database_url()
+
+        if not args.reset and not anvio.DEBUG:
+            self.is_database_exists()
+
+        if args.reset:
+            filesnpaths.gen_output_directory(self.cazyme_data_dir, delete_if_exists=True, dont_warn=True)
+        else:
+            filesnpaths.gen_output_directory(self.cazyme_data_dir)
+
+    def resolve_database_url(self):
+        """Create path to CAZyme ftp
+
+        Added self values
+        ================= 
+        - self.page_index : string
+            version of CAZyme database
+
+        """
+        if self.args.cazyme_version:
+            self.page_index = self.args.cazyme_version 
+            self.run.info('Attempting to use version', self.args.cazyme_version)
+        else:
+            self.page_index = 'V11'
+            self.run.info_single('No CAZyme version specified. Using current release.')
+
+        self.database_url = os.path.join("https://bcb.unl.edu/dbCAN2/download/Databases", f"{self.page_index}", f"dbCAN-HMMdb-{self.page_index}.txt") 
+
+    def is_database_exists(self):
+        """Determine if CAZyme database has already been downloaded"""
+        if os.path.exists(os.path.join(self.cazyme_data_dir, f"dbCAN-HMMdb-{self.page_index}.txt")):
+            raise ConfigError(f"It seems you already have CAZyme database installed in {self.cazyme_data_dir}, please use --reset flag if you want to re-download it.")
+
+    def download(self, hmmpress_files=True):
+        """Download CAZyme database and compress with hmmpress"""
+        self.run.info("Database URL", self.database_url)
+
+        utils.download_file(self.database_url, os.path.join(self.cazyme_data_dir, os.path.basename(self.database_url)) , progress=self.progress, run=self.run)
+
+        if hmmpress_files:
+            self.hmmpress_files()
+
+    def hmmpress_files(self):
+        """Runs hmmpress on CAZyme HMM profiles."""
+
+        file_path = os.path.join(self.cazyme_data_dir, os.path.basename(self.database_url))
+        cmd_line = ['hmmpress', file_path]
+        log_file_path = os.path.join(self.cazyme_data_dir, '00_hmmpress_log.txt')
+        ret_val = utils.run_command(cmd_line, log_file_path)
+
+        if ret_val:
+            raise ConfigError("Hmm. There was an error while running `hmmpress` on the Pfam HMM profiles. "
+                                "Check out the log file ('%s') to see what went wrong." % (log_file_path))
+        else:
+            # getting rid of the log file because hmmpress was successful
+            os.remove(log_file_path)

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -42,6 +42,8 @@ class CAZymeSetup(object):
                 The directory where the CAZyme data should be stored. If not provided, the data will be stored in the anvi'o data directory.
             - reset : bool, optional
                 If True, the data directory will be deleted and recreated. Defaults to False.
+            - cazyme_version : str, optional
+                Version of CAZyme database that will be installed
         run : terminal.Run, optional
             An object for printing messages to the console.
         progress : terminal.Progress, optional
@@ -136,10 +138,16 @@ class CAZyme(object):
     ==========
     args : argparse.Namespace
         See `bin/anvi-run-cazymes` for available arguments
+        - contigs_db_path : str
+            Path to contigs-db
+        - num_threads : str
+            Number of threads to run hmmsearch or hmmscan
         - noise_cutoff_terms : str, optional
             Filtering option for HMM search
         - hmm_program : str, optional
             hmmsearch (default) or hmmscan
+        - cazyme_data_dir : str, optional
+            path to downloaded copy of CAZyme data, default downloaded in anvio
     run : terminal.Run, optional
         An object for printing messages to the console.
     progress : terminal.Progress, optional

--- a/anvio/docs/__init__.py
+++ b/anvio/docs/__init__.py
@@ -383,6 +383,12 @@ ANVIO_ARTIFACTS ={
         "provided_by_anvio": True,
         "provided_by_user": False
     },
+    "cazyme-data": {
+        "name": "CAZymes HMM DATA",
+        "type": "DATA",
+        "provided_by_anvio": True,
+        "provided_by_user": False
+    },
     "misc-data-items-txt": {
         "name": "ITEMS DATA",
         "type": "TXT",

--- a/anvio/docs/artifacts/anvi-setup-cazymes.md
+++ b/anvio/docs/artifacts/anvi-setup-cazymes.md
@@ -5,7 +5,7 @@ This program **downloads and organizes a local copy of the dbCAN [CAZyme HMMs da
 anvi-setup-cazymes 
 {{ codestop }}
 
-By default, this data is stored at `anvio/data/misc/CAZyme/`. To set up this data in a non-default location, run 
+By default, this data is stored at `anvio/data/misc/CAZyme/`. To set up this data in a non-default location, run the code code below. This is a good way to download multiple versions of the CAZyme database.
 {{ codestart }}
 anvi-setup-cazymes --cazyme-data-dir path/to/location
 {{ codestop }}

--- a/anvio/docs/artifacts/anvi-setup-cazymes.md
+++ b/anvio/docs/artifacts/anvi-setup-cazymes.md
@@ -1,0 +1,17 @@
+This program **downloads and organizes a local copy of the dbCAN [CAZyme HMMs database](https://bcb.unl.edu/dbCAN2/download/Databases/) for function annotation.** This program generates a %(cazymes-data)s artifact, which is required to run the program %(anvi-run-cazymes)s. 
+
+### Set up CAZyme data
+{{ codestart }}
+anvi-setup-cazymes 
+{{ codestop }}
+
+By default, this data is stored at `anvio/data/misc/CAZyme/`. To set up this data in a non-default location, run 
+{{ codestart }}
+anvi-setup-cazymes --cazyme-data-dir path/to/location
+{{ codestop }}
+
+If you already have a %(cazyme-data)s artifact and are trying to re-download this data, run 
+
+{{ codestart }}
+anvi-setup-cazymes --reset
+{{ codestop }}

--- a/anvio/docs/artifacts/cazyme-data.md
+++ b/anvio/docs/artifacts/cazyme-data.md
@@ -1,0 +1,3 @@
+This basically stores **a local copy of the data from the dbCAN [CAZyme HMMs](https://bcb.unl.edu/dbCAN2/download/Databases/) for functional annotation.** 
+
+It is required to run %(anvi-run-cazymes)s and is set up on your computer by the program %(anvi-setup-cazymes)s. 

--- a/anvio/docs/programs/anvi-run-cazymes.md
+++ b/anvio/docs/programs/anvi-run-cazymes.md
@@ -1,0 +1,34 @@
+This program **annotates genes in your %(contigs-db)s with functions using dbCAN [CAZyme HMMs](https://bcb.unl.edu/dbCAN2/download/Databases/)** 
+
+Before you run this program, you'll have to set up the CAZyme database on your computer with the program %(anvi-setup-cazymes)s.  
+
+The CAZyme database is based on protein sequences, so anvi'o will convert your genetic information into protein sequences and then use HMMs to compare them to the database. 
+
+{:.notice}
+Unsure what an HMM is? Check out [our vocab page](http://merenlab.org/vocabulary/#hmm)
+
+To run, you'll need to provide a %(contigs-db)s. If you stored the %(cazyme-data)s that you got from running %(anvi-setup-cazymes)s in a custom location, you'll need to provide that path as well. The output is a %(functions)s artifact. 
+
+Here is a default run: 
+
+{{ codestart }}
+anvi-run-cazymes -c %(contigs-db)s \
+            --pfam-data-dir %(cazyme-data)s 
+{{ codestop }}
+
+By default, this uses `hmmsearch` to run HMMs. You can choose to use `hmmscan` instead by running
+
+{{ codestart }}
+anvi-run-cazymes -c %(contigs-db)s \
+            --pfam-data-dir %(cazyme-data)s \
+            --noise-cutoff-terms "-E 1" \
+            --hmmer-program hmmscan
+{{ codestop }}
+
+Use the parameter `--noise-cutoff-terms` to filter out hits e.g. `--noise-cutoff-terms "-E 1"`. If you want to explore filtering options, check out the help menu of the underlying hmm program you are using e.g. `hmmsearch -h`
+
+{{ codestart }}
+anvi-run-cazymes -c %(contigs-db)s \
+            --pfam-data-dir %(cazyme-data)s \
+            --noise-cutoff-terms "-E 1"
+{{ codestop }}

--- a/anvio/docs/programs/anvi-run-cazymes.md
+++ b/anvio/docs/programs/anvi-run-cazymes.md
@@ -13,14 +13,14 @@ Here is a default run:
 
 {{ codestart }}
 anvi-run-cazymes -c %(contigs-db)s \
-            --pfam-data-dir %(cazyme-data)s 
+            --cazyme-data-dir %(cazyme-data)s 
 {{ codestop }}
 
 By default, this uses `hmmsearch` to run HMMs. You can choose to use `hmmscan` instead by running
 
 {{ codestart }}
 anvi-run-cazymes -c %(contigs-db)s \
-            --pfam-data-dir %(cazyme-data)s \
+            --cazyme-data-dir %(cazyme-data)s \
             --noise-cutoff-terms "-E 1" \
             --hmmer-program hmmscan
 {{ codestop }}
@@ -29,6 +29,6 @@ Use the parameter `--noise-cutoff-terms` to filter out hits e.g. `--noise-cutoff
 
 {{ codestart }}
 anvi-run-cazymes -c %(contigs-db)s \
-            --pfam-data-dir %(cazyme-data)s \
+            --cazyme-data-dir %(cazyme-data)s \
             --noise-cutoff-terms "-E 1"
 {{ codestop }}

--- a/anvio/tests/run_component_tests_for_cazymes.sh
+++ b/anvio/tests/run_component_tests_for_cazymes.sh
@@ -18,4 +18,4 @@ INFO "Running anvi-run-cazymes"
 anvi-run-cazymes -c B_thetaiotamicron_VPI-5482.db
 
 INFO "Running anvi-run-cazymes with --noise-cutoff-terms"
-anvi-run-cazymes -c B_thetaiotamicron_VPI-5482.db --noise-cutoff-terms "-E 1"
+anvi-run-cazymes -c B_thetaiotamicron_VPI-5482.db --noise-cutoff-terms "-E 1e-12"

--- a/anvio/tests/run_component_tests_for_cazymes.sh
+++ b/anvio/tests/run_component_tests_for_cazymes.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source 00.sh
+
+# Setup #############################
+SETUP_WITH_OUTPUT_DIR $1 $2
+#####################################
+
+INFO "Setting up the anvi-export-locus test directory"
+mkdir $output_dir/cazyme_test
+cp $files/data/genomes/bacteria/*.db $output_dir/cazyme_test
+
+cd $output_dir/cazyme_test
+
+INFO "Running anvi-run-cazymes help menu"
+anvi-run-cazymes -h
+
+INFO "Running anvi-run-cazymes"
+anvi-run-cazymes -c B_thetaiotamicron_VPI-5482.db
+
+INFO "Running anvi-run-cazymes with --noise-cutoff-terms"
+anvi-run-cazymes -c B_thetaiotamicron_VPI-5482.db --noise-cutoff-terms "-E 1"

--- a/bin/anvi-run-cazymes
+++ b/bin/anvi-run-cazymes
@@ -10,12 +10,11 @@ from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
-__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__copyright__ = "Copyleft 2015-2020, the Meren Lab (http://merenlab.org/)"
 __license__ = "GPL 3.0"
 __version__ = anvio.__version__
 __authors__ = ['mschecht']
-__requires__ = ['contigs-db']
-#FIXME: add cazyme data artifact
+__requires__ = ['contigs-db', 'cazyme-data']
 __provides__ = ['functions']
 __description__ = "Run dbCAN CAZymes on contigs-db"
 

--- a/bin/anvi-run-cazymes
+++ b/bin/anvi-run-cazymes
@@ -33,6 +33,8 @@ if __name__ == '__main__':
     parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
     parser.add_argument('--noise-cutoff-terms', default=None, help="Choose a threshold for the CAZyme HMMs e.g. --noise-cutoff-terms \"-E 1\". \
                         If you are not sure what to pick run `hmmsearch -h` or `hmmscan -h` and check out your options.")
+    parser.add_argument('--cazyme-data-dir', default=None, type=str, help="The directory path for your downloaded CAZyme database. Anvi'o will try to use the default path \
+                        if you do not specify anything.")
     parser.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
     parser.add_argument(*anvio.A('hmmer-program'), **anvio.K('hmmer-program'))
 

--- a/bin/anvi-run-cazymes
+++ b/bin/anvi-run-cazymes
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+
+import anvio
+import anvio.cazymes as cazymes
+
+from anvio.errors import ConfigError, FilesNPathsError
+from anvio.terminal import time_program
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__authors__ = ['mschecht']
+__requires__ = ['contigs-db']
+#FIXME: add cazyme data artifact
+__provides__ = ['functions']
+__description__ = "Run dbCAN CAZymes on contigs-db"
+
+
+@time_program
+def main(args):
+    p = cazymes.CAZyme(args)
+    p.process()
+
+
+if __name__ == '__main__':
+    from anvio.argparse import ArgumentParser
+
+    parser = ArgumentParser(description=__description__)
+
+    parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+    parser.add_argument('--noise-cutoff-terms', default=None, help="Choose a threshold for the CAZyme HMMs e.g. --noise-cutoff-terms \"-E 1\". \
+                        If you are not sure what to pick run `hmmsearch -h` or `hmmscan -h` and check out your options.")
+    parser.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
+    parser.add_argument(*anvio.A('hmmer-program'), **anvio.K('hmmer-program'))
+
+    args = parser.get_args(parser)
+
+    try:
+        main(args)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)
+    except FilesNPathsError as e:
+        print(e)
+        sys.exit(-1)

--- a/bin/anvi-run-cazymes
+++ b/bin/anvi-run-cazymes
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     parser = ArgumentParser(description=__description__)
 
     parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
-    parser.add_argument('--noise-cutoff-terms', default=None, help="Choose a threshold for the CAZyme HMMs e.g. --noise-cutoff-terms \"-E 1\". \
+    parser.add_argument('--noise-cutoff-terms', default=None, help="Choose a threshold for the CAZyme HMMs (default --noise-cutoff-terms \"-E 1e-12\". \
                         If you are not sure what to pick run `hmmsearch -h` or `hmmscan -h` and check out your options.")
     parser.add_argument('--cazyme-data-dir', default=None, type=str, help="The directory path for your downloaded CAZyme database. Anvi'o will try to use the default path \
                         if you do not specify anything.")

--- a/bin/anvi-self-test
+++ b/bin/anvi-self-test
@@ -40,6 +40,7 @@ tests = {'mini'                  : ['run_component_tests_for_minimal_metagenomic
          'workflow-phylogenomics': ['run_workflow_tests_for_phylogenomics.sh'],
          'database-migrations'   : ['run_migration_tests_for_ancient_anvio_databases.sh'],
          'workflow-sra-download' : ['run_workflow_tests_for_sra_download.sh'],
+         'run-cazymes'           : ['run_component_tests_for_cazymes.sh'],
          }
 
 run = terminal.Run()

--- a/bin/anvi-setup-cazymes
+++ b/bin/anvi-setup-cazymes
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+
+import anvio
+import anvio.cazymes as cazymes
+
+from anvio.errors import ConfigError, FilesNPathsError
+
+
+__author__ = "Developers of anvi'o (see AUTHORS.txt)"
+__copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
+__license__ = "GPL 3.0"
+__version__ = anvio.__version__
+__authors__ = ['mschecht']
+__provides__ = ['pfams-data']
+__description__ = "Download and setup Pfam data from the EBI"
+
+
+if __name__ == '__main__':
+    from anvio.argparse import ArgumentParser
+
+    parser = ArgumentParser(description=__description__)
+    parser.add_argument('--cazyme-data-dir', default=None, type=str, help="The directory for CAZyme data to be stored. If you leave it\
+                        as is without specifying anything, the default destination for the data directory will be used to set things\
+                        up. The advantage of it is that everyone will be using a single data directory, but then you may need\
+                        superuser privileges to do it. Using this parameter you can choose the location of the data directory somewhere\
+                        you like. However, when it is time to run CAZyme, you will need to remember that path and provide it to the program.")
+    parser.add_argument('--reset', default=False, action="store_true", help="This program by default attempts to use previously\
+                        downloaded files in your Pfam data directory if there are any. If something is wrong for some reason you\
+                        can use this to tell anvi'o to remove everything, and start over.")
+    parser.add_argument('--cazyme-version', default=None, help="By default, the most current version available (V11) will be downloaded.\
+                        If you have specific tastes for a different version, you can provide it here. For example, `V10`. Here are\
+                        all possible versions: https://bcb.unl.edu/dbCAN2/download/Databases/")
+
+    args = parser.get_args(parser)
+
+    try:
+        setup = cazymes.CAZymeSetup(args)
+        setup.download()
+
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)
+    except FilesNPathsError as e:
+        print(e)
+        sys.exit(-1)

--- a/bin/anvi-setup-cazymes
+++ b/bin/anvi-setup-cazymes
@@ -14,7 +14,7 @@ __copyright__ = "Copyleft 2015-2018, the Meren Lab (http://merenlab.org/)"
 __license__ = "GPL 3.0"
 __version__ = anvio.__version__
 __authors__ = ['mschecht']
-__provides__ = ['pfams-data']
+__provides__ = ['cazyme-data']
 __description__ = "Download and setup Pfam data from the EBI"
 
 


### PR DESCRIPTION
Hi everyone! I implemented two programs, `anvi-setup-cazymes` and `anvi-run-cazymes`, to annotate genes in contig-dbs with [dbCAN CAZymes](https://bcb.unl.edu/dbCAN2/download/Databases/). Unfortunately, CAZyme HMMs don't have `--cut-ga` values so the user will need to input an `e-value` to filter the hits via `anvi-run-cazymes --noise-cutoff-terms`.

```bash
anvi-self-test --suite run-cazymes
```

Thanks for taking a look!