### PR TITLE
Function matrix across genomes update

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1138,6 +1138,13 @@ D = {
                      "functions rather than actual functions? We can't. But we have this flag here so you can "
                      "instruct anvi'o to listen to you and not to us."}
                 ),
+    'also-report-accession-numbers': (
+            ['--also-report-accession-numbers'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "When used, this flag will instruct anvi'o to also report the function accession number "
+                     "in a new column, in addition to function name in the output file."}
+                ),
     'aggregate-using-all-hits': (
             ['--aggregate-using-all-hits'],
             {'default': False,

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1138,11 +1138,11 @@ D = {
                      "functions rather than actual functions? We can't. But we have this flag here so you can "
                      "instruct anvi'o to listen to you and not to us."}
                 ),
-    'also-report-accession-numbers': (
-            ['--also-report-accession-numbers'],
+    'also-report-accession-ids': (
+            ['--also-report-accession-ids'],
             {'default': False,
              'action': 'store_true',
-             'help': "When used, this flag will instruct anvi'o to also report the function accession number "
+             'help': "When used, this flag will instruct anvi'o to also report the function accession ids "
                      "in a new column, in addition to function name in the output file."}
                 ),
     'aggregate-using-all-hits': (

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -1364,7 +1364,7 @@ class AggregateFunctions:
                                                                                       progress=self.progress)
 
 
-    def report_functions_across_genomes(self, output_file_prefix, quiet=False, with_function_accession_numbers=False):
+    def report_functions_across_genomes(self, output_file_prefix, quiet=False, with_function_accession_ids=False):
         """Reports text files for functions across genomes data"""
 
         output_file_path_for_frequency_view = f"{os.path.abspath(output_file_prefix)}-FREQUENCY.txt"
@@ -1376,7 +1376,7 @@ class AggregateFunctions:
         with open(output_file_path_for_frequency_view, 'w') as frequency_output, open(output_file_path_for_presence_absence_view, 'w') as presence_absence_output:
             layer_names = sorted(list(self.layer_names_considered))
 
-            if with_function_accession_numbers:
+            if with_function_accession_ids:
                 columns_txt = '\t'.join(['key'] + layer_names + [self.function_annotation_source] + [f"{self.function_annotation_source}_accession"]) + '\n'
             else:
                 columns_txt = '\t'.join(['key'] + layer_names + [self.function_annotation_source]) + '\n'
@@ -1390,7 +1390,7 @@ class AggregateFunctions:
                 frequency_data = [f"{self.functions_across_layers_frequency[key][l] if l in self.functions_across_layers_frequency[key] else 0}" for l in layer_names]
                 presence_absence_data = [f"{self.functions_across_layers_presence_absence[key][l] if l in self.functions_across_layers_presence_absence[key] else 0}" for l in layer_names]
 
-                if with_function_accession_numbers:
+                if with_function_accession_ids:
                     function_accession = ','.join(self.function_to_accession_ids_dict[function][self.function_annotation_source])
                     frequency_output.write('\t'.join([key] + frequency_data + [function, function_accession]) + '\n')
                     presence_absence_output.write('\t'.join([key] + presence_absence_data + [function, function_accession]) + '\n')

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -1364,7 +1364,7 @@ class AggregateFunctions:
                                                                                       progress=self.progress)
 
 
-    def report_functions_across_genomes(self, output_file_prefix, quiet=False):
+    def report_functions_across_genomes(self, output_file_prefix, quiet=False, with_function_accession_numbers=False):
         """Reports text files for functions across genomes data"""
 
         output_file_path_for_frequency_view = f"{os.path.abspath(output_file_prefix)}-FREQUENCY.txt"
@@ -1375,17 +1375,28 @@ class AggregateFunctions:
 
         with open(output_file_path_for_frequency_view, 'w') as frequency_output, open(output_file_path_for_presence_absence_view, 'w') as presence_absence_output:
             layer_names = sorted(list(self.layer_names_considered))
-            frequency_output.write('\t'.join(['key'] + layer_names + [self.function_annotation_source]) + '\n')
-            presence_absence_output.write('\t'.join(['key'] + layer_names + [self.function_annotation_source]) + '\n')
+
+            if with_function_accession_numbers:
+                columns_txt = '\t'.join(['key'] + layer_names + [self.function_annotation_source] + [f"{self.function_annotation_source}_accession"]) + '\n'
+            else:
+                columns_txt = '\t'.join(['key'] + layer_names + [self.function_annotation_source]) + '\n'
+
+            frequency_output.write(columns_txt)
+            presence_absence_output.write(columns_txt)
 
             for key in self.functions_across_layers_frequency:
                 function = self.hash_to_function_dict[key][self.function_annotation_source]
 
                 frequency_data = [f"{self.functions_across_layers_frequency[key][l] if l in self.functions_across_layers_frequency[key] else 0}" for l in layer_names]
-                frequency_output.write('\t'.join([key] + frequency_data + [function]) + '\n')
-
                 presence_absence_data = [f"{self.functions_across_layers_presence_absence[key][l] if l in self.functions_across_layers_presence_absence[key] else 0}" for l in layer_names]
-                presence_absence_output.write('\t'.join([key] + presence_absence_data + [function]) + '\n')
+
+                if with_function_accession_numbers:
+                    function_accession = ','.join(self.function_to_accession_ids_dict[function][self.function_annotation_source])
+                    frequency_output.write('\t'.join([key] + frequency_data + [function, function_accession]) + '\n')
+                    presence_absence_output.write('\t'.join([key] + presence_absence_data + [function, function_accession]) + '\n')
+                else:
+                    frequency_output.write('\t'.join([key] + frequency_data + [function]) + '\n')
+                    presence_absence_output.write('\t'.join([key] + presence_absence_data + [function]) + '\n')
 
         if not quiet:
             self.run.info('Functions across genomes (frequency)', output_file_path_for_frequency_view)

--- a/sandbox/anvi-script-gen-function-matrix-across-genomes
+++ b/sandbox/anvi-script-gen-function-matrix-across-genomes
@@ -39,7 +39,7 @@ def main(args):
         args.output_file = output_file_path_for_functional_enrichment
 
     facc = AggregateFunctions(args, r=run, p=progress)
-    facc.report_functions_across_genomes(args.output_file_prefix, with_function_accession_numbers=args.also_report_accession_numbers)
+    facc.report_functions_across_genomes(args.output_file_prefix, with_function_accession_ids=args.also_report_accession_ids)
 
 
 if __name__ == '__main__':
@@ -66,7 +66,7 @@ if __name__ == '__main__':
     groupC.add_argument(*anvio.A('annotation-source'), **anvio.K('annotation-source', {'required': True}))
     groupC.add_argument(*anvio.A('aggregate-based-on-accession'), **anvio.K('aggregate-based-on-accession'))
     groupC.add_argument(*anvio.A('aggregate-using-all-hits'), **anvio.K('aggregate-using-all-hits'))
-    groupC.add_argument(*anvio.A('also-report-accession-numbers'), **anvio.K('also-report-accession-numbers'))
+    groupC.add_argument(*anvio.A('also-report-accession-ids'), **anvio.K('also-report-accession-ids'))
     groupC.add_argument('--min-occurrence', metavar="NUM GENOMES", default=1, help=("The minimum number of occurrence of any "
                                 "given function accross genomes. If you set a value, those functions that occur in less number "
                                 "of genomes will be excluded."), type=int)

--- a/sandbox/anvi-script-gen-function-matrix-across-genomes
+++ b/sandbox/anvi-script-gen-function-matrix-across-genomes
@@ -39,7 +39,7 @@ def main(args):
         args.output_file = output_file_path_for_functional_enrichment
 
     facc = AggregateFunctions(args, r=run, p=progress)
-    facc.report_functions_across_genomes(args.output_file_prefix)
+    facc.report_functions_across_genomes(args.output_file_prefix, with_function_accession_numbers=args.also_report_accession_numbers)
 
 
 if __name__ == '__main__':
@@ -66,6 +66,7 @@ if __name__ == '__main__':
     groupC.add_argument(*anvio.A('annotation-source'), **anvio.K('annotation-source', {'required': True}))
     groupC.add_argument(*anvio.A('aggregate-based-on-accession'), **anvio.K('aggregate-based-on-accession'))
     groupC.add_argument(*anvio.A('aggregate-using-all-hits'), **anvio.K('aggregate-using-all-hits'))
+    groupC.add_argument(*anvio.A('also-report-accession-numbers'), **anvio.K('also-report-accession-numbers'))
     groupC.add_argument('--min-occurrence', metavar="NUM GENOMES", default=1, help=("The minimum number of occurrence of any "
                                 "given function accross genomes. If you set a value, those functions that occur in less number "
                                 "of genomes will be excluded."), type=int)


### PR DESCRIPTION
This PR responds to a request on anvi'o Discord by Zuhairi, who said "is there a way for me the get accession ID instead of annotation name?" when using the program `anvi-script-gen-function-matrix-across-genomes`.

The PR adds a new flag, `--also-report-accession-ids`, when used, the output file contains an additional column to report accession ids.