### PR TITLE
Updating docs for KEGG snapshot version errors (v8)

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2825,14 +2825,13 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
                 kegg_modules_db.disconnect()
 
                 if contigs_db_mod_hash != mod_db_hash:
-                    raise ConfigError("The contigs DB that you are working with has been annotated with a different version of the MODULES.db than you are working with now. "
-                                      "Perhaps you updated your KEGG setup after running `anvi-run-kegg-kofams` on this contigs DB? Or maybe you have multiple KEGG data "
-                                      "directories set up on your computer, and the one you are using now is different from the one that you used for `anvi-run-kegg-kofams`? "
-                                      "Well. The solution to the first problem is to re-run `anvi-run-kegg-kofams` on the contigs DB (%s) using the updated MODULES.db "
-                                      "(located in the KEGG data directory %s). The solution to the second problem is to specify the appropriate KEGG data directory using "
-                                      "the --kegg-data-dir flag. If neither of those things make this work, then you should contact the developers to see if they can help you "
-                                      "figure this out. For those who need this information, the Modules DB used to annotate this contigs database previously had the "
-                                      "following hash: %s. And the hash of the current Modules DB is: %s" % (self.contigs_db_path, self.kegg_data_dir, contigs_db_mod_hash, mod_db_hash))
+                    raise ConfigError(f"The contigs DB that you are working with has been annotated with a different version of the MODULES.db "
+                                      f"than you are working with now. Basically, this means that the annotations are not compatible with the "
+                                      f"metabolism data to be used for estimation. There are several ways this can happen. Please visit the "
+                                      f"following URL to get help for your particular situation (copy and paste the full URL into your browser): "
+                                      f"https://anvio.org/help/main/programs/anvi-estimate-metabolism/#help-im-getting-version-errors . "
+                                      f"For those who need this information, the Modules DB used to annotate this contigs database has the "
+                                      f"following hash: {contigs_db_mod_hash}. And the hash of the current Modules DB is: {mod_db_hash}")
         else: # USER data only
             annotation_source_set = set([])
             self.kegg_modules_db_path = None # we nullify this just in case


### PR DESCRIPTION
In this PR I've edited the help page for clarity on fixing KEGG snapshot version errors. I also fixed the error message itself to point to that help page.

I had intended to also create a new snapshot of the KEGG database (ie, to be the new default snapshot for anvi'o v8). However, after downloading the latest data from KEGG, I realized that the hash of the resulting database was exactly the same as the snapshot I made 3 months ago. Which means nothing has updated on KEGG's side, so we can keep everything the same :) 

(the current default snapshot for v8 is `v2023-01-10` and it has the hash `d20a0dcd2128`)