### PR TITLE
Metabolic model IDs

### DIFF
--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -95,35 +95,36 @@ class COBRApyJSONStructure:
 
     @staticmethod
     def get_ecoli_objective() -> Dict[str, Any]:
-        """Biomass objective from JSON 'reactions' array in COBRApy example file,
-        'e_coli_core.json'"""
+        """Biomass objective from JSON 'reactions' array in the COBRApy example file,
+        'e_coli_core.json'. BiGG metabolite IDs have been replaced with KBase/ModelSEED compound
+        IDs."""
         return {
             'id': 'BIOMASS_Ecoli_core_w_GAM',
             'name': 'Biomass Objective Function with GAM',
             'metabolites': {
-                '3pg_c': -1.496,
-                'accoa_c': -3.7478,
-                'adp_c': 59.81,
-                'akg_c': 4.1182,
-                'atp_c': -59.81,
-                'coa_c': 3.7478,
-                'e4p_c': -0.361,
-                'f6p_c': -0.0709,
-                'g3p_c': -0.129,
-                'g6p_c': -0.205,
-                'gln__L_c': -0.2557,
-                'glu__L_c': -4.9414,
-                'h2o_c': -59.81,
-                'h_c': 59.81,
-                'nad_c': -3.547,
-                'nadh_c': 3.547,
-                'nadp_c': 13.0279,
-                'nadph_c': -13.0279,
-                'oaa_c': -1.7867,
-                'pep_c': -0.5191,
-                'pi_c': 59.81,
-                'pyr_c': -2.8328,
-                'r5p_c': -0.8977
+                'cpd00169_c': -1.496,
+                'cpd00022_c': -3.7478,
+                'cpd00008_c': 59.81,
+                'cpd00024_c': 4.1182,
+                'cpd00002_c': -59.81,
+                'cpd00010_c': 3.7478,
+                'cpd00236_c': -0.361,
+                'cpd00072_c': -0.0709,
+                'cpd00102_c': -0.129,
+                'cpd00079_c': -0.205,
+                'cpd00053_c': -0.2557,
+                'cpd00023_c': -4.9414,
+                'cpd00001_c': -59.81,
+                'cpd00067_c': 59.81,
+                'cpd00003_c': -3.547,
+                'cpd00004_c': 3.547,
+                'cpd00006_c': 13.0279,
+                'cpd00005_c': -13.0279,
+                'cpd00032_c': -1.7867,
+                'cpd00061_c': -0.5191,
+                'cpd00009_c': 59.81,
+                'cpd00020_c': -2.8328,
+                'cpd00101_c': -0.8977
             },
             'lower_bound': 0.0,
             'upper_bound': 1000.0,
@@ -133,7 +134,32 @@ class COBRApyJSONStructure:
             'notes': {
                 'original_bigg_ids': [
                     'Biomass_Ecoli_core_w_GAM'
-                ]
+                ],
+                'original_metabolite_names': {
+                    '3pg_c': -1.496,
+                    'accoa_c': -3.7478,
+                    'adp_c': 59.81,
+                    'akg_c': 4.1182,
+                    'atp_c': -59.81,
+                    'coa_c': 3.7478,
+                    'e4p_c': -0.361,
+                    'f6p_c': -0.0709,
+                    'g3p_c': -0.129,
+                    'g6p_c': -0.205,
+                    'gln__L_c': -0.2557,
+                    'glu__L_c': -4.9414,
+                    'h2o_c': -59.81,
+                    'h_c': 59.81,
+                    'nad_c': -3.547,
+                    'nadh_c': 3.547,
+                    'nadp_c': 13.0279,
+                    'nadph_c': -13.0279,
+                    'oaa_c': -1.7867,
+                    'pep_c': -0.5191,
+                    'pi_c': 59.81,
+                    'pyr_c': -2.8328,
+                    'r5p_c': -0.8977
+                }
             },
             'annotation': {
                 'bigg.reaction': [

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -634,6 +634,19 @@ class Pangenome(ModelInput):
         elif coefficient > 0:
             cobrapy_metabolite_notes['consuming_genomes'] = []
             cobrapy_metabolite_notes['producing_genomes'] = sorted(genome_ids)
+        cobrapy_metabolite_annotation = cobrapy_metabolite_dict['annotation']
+        for reference, json_key in [
+            ('BiGG', 'bigg.metabolite'),
+            ('KEGG', 'kegg.compound'),
+            ('InChIKey', 'inchi_key'),
+            ('MetaCyc', 'metacyc.compound'),
+            ('ModelSEED_Alternate_Name', 'modelseed-name')
+        ]:
+            try:
+                ids = chemical.reference_ids[reference]
+            except KeyError:
+                continue
+            cobrapy_metabolite_annotation[json_key] = ids
         return cobrapy_metabolite_dict, already_recorded_metabolite
 
 class ExternalGenome(ModelInput):

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -564,6 +564,19 @@ class Pangenome(ModelInput):
             if not already_recorded_metabolite:
                 self.cobrapy_metabolites.append(cobrapy_metabolite_dict)
                 self.recorded_metabolites[metabolite_id] = cobrapy_metabolite_dict
+        cobrapy_reaction_annotation = cobrapy_reaction_dict['annotation']
+        for reference, json_key in [
+            ('BiGG', 'bigg.reaction'),
+            ('EC', 'ec-code'),
+            ('KEGG', 'kegg.reaction'),
+            ('MetaCyc', 'metacyc.reaction'),
+            ('ModelSEED_Alternate_Name', 'modelseed-name')
+        ]:
+            try:
+                ids = reaction.reference_ids[reference]
+            except KeyError:
+                continue
+            cobrapy_reaction_annotation[json_key] = ids
         return cobrapy_reaction_dict, already_recorded_reaction
 
     def _get_cobrapy_metabolite_dict(

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -544,7 +544,11 @@ class Pangenome(ModelInput):
             )
             return cobrapy_reaction_dict, already_recorded_reaction
         cobrapy_reaction_dict['id'] = reaction.id
-        cobrapy_reaction_dict['name'] = reaction.name
+        try:
+            modelseed_name = reaction.reference_ids['ModelSEED_Name'][0]
+        except KeyError:
+            modelseed_name = ''
+        cobrapy_reaction_dict['name'] = modelseed_name
         reversibility = reaction.reversibility
         if not reversibility:
             cobrapy_reaction_dict['lower_bound'] = 0.0

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -587,11 +587,7 @@ class Pangenome(ModelInput):
         reversibility: bool,
         genome_ids: Set[str]
     ) -> Tuple[Dict[str, Any], bool]:
-        if pd.isna(chemical.select_bigg_id):
-            compound_id = chemical.modelseed_compound_id
-        else:
-            compound_id = chemical.select_bigg_id
-        metabolite_id = f'{compound_id}_{compartment}'
+        metabolite_id = f'{chemical.id}_{compartment}'
         try:
             cobrapy_metabolite_dict = self.recorded_metabolites[metabolite_id]
             already_recorded_metabolite = True

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -594,25 +594,25 @@ class Pangenome(ModelInput):
         except KeyError:
             cobrapy_metabolite_dict = COBRApyJSONStructure.get_metabolite_entry()
             already_recorded_metabolite = False
-        cobrapy_metabolite_annotation = cobrapy_metabolite_dict['annotation']
+        cobrapy_metabolite_notes = cobrapy_metabolite_dict['notes']
         if already_recorded_metabolite:
             if reversibility:
-                recorded_consuming_genome_ids: List = cobrapy_metabolite_annotation['consuming_genomes']
-                recorded_producing_genome_ids: List = cobrapy_metabolite_annotation['producing_genomes']
-                cobrapy_metabolite_annotation['consuming_genomes'] = sorted(
+                recorded_consuming_genome_ids: List = cobrapy_metabolite_notes['consuming_genomes']
+                recorded_producing_genome_ids: List = cobrapy_metabolite_notes['producing_genomes']
+                cobrapy_metabolite_notes['consuming_genomes'] = sorted(
                     genome_ids.union(set(recorded_consuming_genome_ids))
                 )
-                cobrapy_metabolite_annotation['producing_genomes'] = sorted(
+                cobrapy_metabolite_notes['producing_genomes'] = sorted(
                     genome_ids.union(set(recorded_producing_genome_ids))
                 )
             elif coefficient < 0:
-                recorded_consuming_genome_ids: List = cobrapy_metabolite_annotation['consuming_genomes']
-                cobrapy_metabolite_annotation['consuming_genomes'] = sorted(
+                recorded_consuming_genome_ids: List = cobrapy_metabolite_notes['consuming_genomes']
+                cobrapy_metabolite_notes['consuming_genomes'] = sorted(
                     genome_ids.union(set(recorded_consuming_genome_ids))
                 )
             elif coefficient > 0:
-                recorded_producing_genome_ids: List = cobrapy_metabolite_annotation['producing_genomes']
-                cobrapy_metabolite_annotation['producing_genomes'] = sorted(
+                recorded_producing_genome_ids: List = cobrapy_metabolite_notes['producing_genomes']
+                cobrapy_metabolite_notes['producing_genomes'] = sorted(
                     genome_ids.union(set(recorded_producing_genome_ids))
                 )
             return cobrapy_metabolite_dict, already_recorded_metabolite
@@ -622,14 +622,14 @@ class Pangenome(ModelInput):
         cobrapy_metabolite_dict['charge'] = chemical.charge if chemical.charge else 0
         cobrapy_metabolite_dict['formula'] = chemical.formula if chemical.formula else ""
         if reversibility:
-            cobrapy_metabolite_annotation['consuming_genomes'] = sorted(genome_ids)
-            cobrapy_metabolite_annotation['producing_genomes'] = sorted(genome_ids)
+            cobrapy_metabolite_notes['consuming_genomes'] = sorted(genome_ids)
+            cobrapy_metabolite_notes['producing_genomes'] = sorted(genome_ids)
         elif coefficient < 0:
-            cobrapy_metabolite_annotation['consuming_genomes'] = sorted(genome_ids)
-            cobrapy_metabolite_annotation['producing_genomes'] = []
+            cobrapy_metabolite_notes['consuming_genomes'] = sorted(genome_ids)
+            cobrapy_metabolite_notes['producing_genomes'] = []
         elif coefficient > 0:
-            cobrapy_metabolite_annotation['consuming_genomes'] = []
-            cobrapy_metabolite_annotation['producing_genomes'] = sorted(genome_ids)
+            cobrapy_metabolite_notes['consuming_genomes'] = []
+            cobrapy_metabolite_notes['producing_genomes'] = sorted(genome_ids)
         return cobrapy_metabolite_dict, already_recorded_metabolite
 
 class ExternalGenome(ModelInput):

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -536,10 +536,10 @@ class Pangenome(ModelInput):
             cobrapy_reaction_dict = COBRApyJSONStructure.get_reaction_entry()
             already_recorded_reaction = False
         # List the genomes encoding the reaction in the JSON reaction object.
-        cobrapy_reaction_annotation = cobrapy_reaction_dict['annotation']
+        cobrapy_reaction_notes = cobrapy_reaction_dict['notes']
         if already_recorded_reaction:
-            recorded_genomes: List = cobrapy_reaction_annotation['genomes']
-            cobrapy_reaction_annotation['genomes'] = sorted(
+            recorded_genomes: List = cobrapy_reaction_notes['genomes']
+            cobrapy_reaction_notes['genomes'] = sorted(
                 genome_ids.union(set(recorded_genomes))
             )
             return cobrapy_reaction_dict, already_recorded_reaction
@@ -548,7 +548,7 @@ class Pangenome(ModelInput):
         reversibility = reaction.reversibility
         if not reversibility:
             cobrapy_reaction_dict['lower_bound'] = 0.0
-        cobrapy_reaction_annotation['genomes'] = sorted(genome_ids)
+        cobrapy_reaction_notes['genomes'] = sorted(genome_ids)
         for chemical, coefficient, compartment in zip(
             reaction.chemicals, reaction.coefficients, reaction.compartments
         ):

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -486,9 +486,7 @@ class Pangenome(ModelInput):
                     f"The protein annotation source, '{self.protein_annotation_source}', is not "
                     "recognized."
                 )
-            reactions = ortholog.get_protein_data(
-                self.source_db, cross_reference_dbs=self.cross_ref_dbs
-            ).reactions
+            reactions = ortholog.get_reactions(self.source_db, cross_reference_dbs=self.cross_ref_dbs)
             if not reactions:
                 # No reference reaction data could be assigned to the ortholog.
                 continue

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -727,9 +727,7 @@ class ExternalGenome(ModelInput):
                     f"The protein annotation source, '{self.protein_annotation_source}', is not "
                     "recognized."
                 )
-            reactions = ortholog.get_protein_data(
-                self.source_db, cross_reference_dbs=self.cross_ref_dbs
-            ).reactions
+            reactions = ortholog.get_reactions(self.source_db, cross_reference_dbs=self.cross_ref_dbs)
             if not reactions:
                 # No reference reaction data could be assigned to the ortholog.
                 continue

--- a/anvio/proteinorthology/metabolicmodel.py
+++ b/anvio/proteinorthology/metabolicmodel.py
@@ -617,7 +617,11 @@ class Pangenome(ModelInput):
                 )
             return cobrapy_metabolite_dict, already_recorded_metabolite
         cobrapy_metabolite_dict['id'] = metabolite_id
-        cobrapy_metabolite_dict['name'] = chemical.name if chemical.name else ""
+        try:
+            modelseed_name = chemical.reference_ids['ModelSEED_Name'][0]
+        except KeyError:
+            modelseed_name = ''
+        cobrapy_metabolite_dict['name'] = modelseed_name
         cobrapy_metabolite_dict['compartment'] = compartment
         cobrapy_metabolite_dict['charge'] = chemical.charge if chemical.charge else 0
         cobrapy_metabolite_dict['formula'] = chemical.formula if chemical.formula else ""

--- a/anvio/proteinorthology/protein.py
+++ b/anvio/proteinorthology/protein.py
@@ -30,11 +30,10 @@ run_quiet = terminal.Run(verbose=False)
 class Chemical:
     """A chemical."""
     def __init__(self) -> None:
-        self.modelseed_compound_id: str = None
-        self.select_bigg_id: str = None
+        # The chemical may have one or more IDs (values) per reference database (key).
+        self.reference_ids: Dict[str, List[str]] = {}
         self.charge: int = None
         self.formula: str = None
-        self.inchi_key: str = None
         self.smiles_string: str = None
 
 class Reaction:

--- a/anvio/proteinorthology/protein.py
+++ b/anvio/proteinorthology/protein.py
@@ -54,10 +54,13 @@ class Reaction:
         self.compartments: List[str] = []
         self.reversibility: bool = None
 
-class ProteinData:
-    """Data regarding a protein."""
-    def __init__(self) -> None:
-        self.reactions: List[Reaction] = [] # catalyzed reactions
+    @property
+    def id(self) -> str:
+        """The first recorded reference database/ID. If none is recorded, return None."""
+        try:
+            return next(iter(self.reference_ids.values()))[0]
+        except StopIteration:
+            return None
 
 class OrthologAnnotation:
     """Data regarding a group of protein functional orthologs."""

--- a/anvio/proteinorthology/protein.py
+++ b/anvio/proteinorthology/protein.py
@@ -47,8 +47,8 @@ class Chemical:
 class Reaction:
     """A chemical reaction."""
     def __init__(self) -> None:
-        self.id: str = None
-        self.name: str = None
+        # The reaction may have one or more IDs (values) per reference database (key).
+        self.reference_ids: Dict[str, List[str]] = {}
         self.chemicals: List[Chemical] = []
         self.coefficients: List[float] = []
         self.compartments: List[str] = []

--- a/anvio/proteinorthology/protein.py
+++ b/anvio/proteinorthology/protein.py
@@ -36,6 +36,14 @@ class Chemical:
         self.formula: str = None
         self.smiles_string: str = None
 
+    @property
+    def id(self) -> str:
+        """The first recorded reference database/ID. If none is recorded, return None."""
+        try:
+            return next(iter(self.reference_ids.values()))[0]
+        except StopIteration:
+            return None
+
 class Reaction:
     """A chemical reaction."""
     def __init__(self) -> None:

--- a/anvio/proteinorthology/protein.py
+++ b/anvio/proteinorthology/protein.py
@@ -27,11 +27,6 @@ __status__ = "Development"
 
 run_quiet = terminal.Run(verbose=False)
 
-class Protein:
-    """A protein."""
-    def __init__(self) -> None:
-        self.ortholog_annotations: List[OrthologAnnotation] = []
-
 class Chemical:
     """A chemical."""
     def __init__(self) -> None:

--- a/anvio/proteinorthology/protein.py
+++ b/anvio/proteinorthology/protein.py
@@ -32,7 +32,7 @@ class Chemical:
     def __init__(self) -> None:
         self.modelseed_compound_id: str = None
         self.select_bigg_id: str = None
-        self.name: str = None
+        self.charge: int = None
         self.formula: str = None
         self.inchi_key: str = None
         self.smiles_string: str = None

--- a/anvio/proteinorthology/refdbs.py
+++ b/anvio/proteinorthology/refdbs.py
@@ -240,12 +240,14 @@ class ModelSEEDDatabase(ProteinReferenceDatabase):
             reaction.compartments.append(self.compartment_ids[int(split_entry[2])])
             chemical = protein.Chemical()
             compound_id = split_entry[1]
-            chemical.modelseed_compound_id = compound_id
             chemical_data = self.compounds_table.loc[compound_id].to_dict()
-            if chemical_data['BiGG']:
-                chemical.select_bigg_id = chemical_data['select_bigg_id']
-            if pd.notna(chemical_data['name']):
-                chemical.name = chemical_data['name']
+            chemical.reference_ids['ModelSEED_ID'] = [compound_id]
+            self._add_ids(chemical, chemical_data, 'name')
+            self._add_ids(chemical, chemical_data, 'inchikey')
+            self._add_ids(chemical, chemical_data, 'BiGG')
+            self._add_ids(chemical, chemical_data, 'KEGG')
+            self._add_ids(chemical, chemical_data, 'MetaCyc')
+            self._add_ids(chemical, chemical_data, 'Name')
             if pd.notna(chemical_data['charge']):
                 chemical.charge = chemical_data['charge']
             if pd.notna(chemical_data['formula']):

--- a/anvio/proteinorthology/refdbs.py
+++ b/anvio/proteinorthology/refdbs.py
@@ -207,14 +207,19 @@ class ModelSEEDDatabase(ProteinReferenceDatabase):
             # Ignore a reaction if it does not have a chemical equation for some reason.
             return None
         reaction = protein.Reaction()
-        # Prefer to ID the reaction by BiGG ID, and if there are multiple BiGG IDs and one
-        # corresponds to the ModelSEED reaction ID, by that BiGG ID.
-        if pd.isna(reaction_data['select_bigg_id']):
-            reaction.id: str = reaction_data['id']
-        else:
-            reaction.id: str = reaction_data['select_bigg_id']
-        reaction.id.replace(' ', '_')
-        reaction.name = '' if pd.isna(reaction_data['name']) else reaction_data['name']
+        modelseed_id = reaction_data['id']
+        if pd.isna(modelseed_id):
+            raise ConfigError(
+                "The row for the reaction in the ModelSEED table does not but should have an ID. "
+                f"Here is the data in the row: '{reaction_data}'"
+            )
+        self._add_ids(reaction, reaction_data, 'id')
+        self._add_ids(reaction, reaction_data, 'name')
+        self._add_ids(reaction, reaction_data, 'ec_numbers')
+        self._add_ids(reaction, reaction_data, 'BiGG')
+        self._add_ids(reaction, reaction_data, 'KEGG')
+        self._add_ids(reaction, reaction_data, 'MetaCyc')
+        self._add_ids(reaction, reaction_data, 'Name')
         reversibility = reaction_data['reversibility']
         if reversibility == '=' or reversibility == '?':
             # Assume that reactions lacking data ('?') are reversible.


### PR DESCRIPTION
This PR updates the anvi'o `proteinorthology` subpackage, which tracks reactions and metabolites associated with proteins and contains the backend of `anvi-get-metabolic-model-file`, which generates a COBRApy JSON file representing the metabolic network of a genome or pangenome. The script currently relies upon KEGG KOfam annotations and the ModelSEED Biochemistry database for reaction information. The PR changes how IDs are assigned to reaction and metabolite objects in the JSON file, with the ID now always being the KBase ID from ModelSEED, and alternate IDs, such as KEGG Reaction and Compound IDs and BiGG IDs cross-referenced in ModelSEED, supplemented as object annotations. Other changes in the PR ensued from this, including the structure of classes in `proteinorthology.protein`, including `Chemical` and `AnvioKOAnnotation`.