### PR TITLE
genomeview-backend/metadata notes, saving to state, querying separately

### DIFF
--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -814,10 +814,12 @@ GenomeDrawer.prototype.queryFunctions = async function () {
     alert('please provide values for function category and/or query')
     return
   }
-  if (category == 'metadata'){
-    drawer.queryMetadata(query)
-    return
+  if (category.split(' ')[0] == 'metadata'){
+    type = category.split(' ')[1]
+    drawer.queryMetadata(query, type)
+    return;
   }
+
   this.settings['genomeData']['genomes'].map(genome => {
     for (const [key, value] of Object.entries(genome[1]['genes']['functions'])) {
       if (value[category]?.[0].toLowerCase().includes(query)) {
@@ -913,12 +915,12 @@ GenomeDrawer.prototype.queryFunctions = async function () {
   this.glowGenes(glowPayload, true)
 }
 
-GenomeDrawer.prototype.queryMetadata = async function(metadataLabel){
+GenomeDrawer.prototype.queryMetadata = async function(metadataLabel, type){
   $('#query-results-table').empty()
   let glowPayload = Array()
   let foundInGenomes = Object()
   let matches = settings['display']['metadata'].filter( m => m.label.toLowerCase().includes(metadataLabel.toLowerCase()))
-                                               .filter( m => m.type == 'tag')
+                                               .filter( m => m.type == type )
   matches.map(metadata => {
     glowPayload.push({
       geneID: metadata.gene,

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -618,6 +618,13 @@ function showDeepDiveToolTip(event){
   }).keyup(function() {
       $(this).colpickSetColor(this.value);
   });
+
+  $('#deepdive-modal-body').unbind('hidden.bs.modal');
+  $('#deepdive-modal-body').on('hidden.bs.modal', function () {
+    let note = $('#metadata-gene-note').val()
+    if(!note || note.trim().length == 0) return;
+    addMetadataNote(event.target.genomeID, event.target.geneID, note);
+  });
 }
 
 function showToolTip(event){

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -395,22 +395,25 @@ function showDeepDiveToolTip(event){
   let totalMetadataString = String()
   let totalAnnotationsString = String()
   let metadataLabel = String()
+  let geneNote = String()
   let queryBtn = `<button type='button' class='btn btn-default btn-sm metadata-query'>Query sequence for matches</button>`
-  let removeBtn = `<button type='button' class='btn btn-default btn-sm metadata-remove'>Remove metadata item</button>`
+  let removeBtn = `<button type='button' class='btn btn-default btn-sm metadata-remove'>Remove metadata tag</button>`
 
   let includeMetadataHeader = false;
   if(settings['display']?.['metadata']){
-    let geneMetadata = settings['display']['metadata'].filter(metadata => metadata.genome == event.target.genomeID && metadata.gene == event.target.geneID )
-    if(geneMetadata.length > 0) includeMetadataHeader = true;
+    let geneMetadata = settings['display']['metadata'].filter(metadata => metadata.genome == event.target.genomeID && metadata.gene == event.target.geneID)
+    let geneTags = geneMetadata.filter(metadata => metadata.type === 'tag')
+    geneNote = geneMetadata.filter(metadata => metadata.type === 'note')[0]
+    if(geneTags.length > 0) includeMetadataHeader = true;
     
     const createMetadataContent = () => {
-      geneMetadata.map(metadata => {
+      geneTags.map(metadata => {
         metadataLabel = metadata.label
 
         totalMetadataString += `
         <tr>
         <td class='metadata'>${metadata.label}</td>
-        <td>${metadata.type == 'tag'? queryBtn : 'n/a'}</td>
+        <td>${queryBtn}</td>
         <td>${removeBtn}</td>
         </tr>
         `
@@ -486,8 +489,8 @@ function showDeepDiveToolTip(event){
       <input    id='metadata-gene-label' type='text' placeholder='Metadata tag'>
       <button   id='metadata-gene-label-add' type='button' class="btn btn-default btn-sm">Add tag</button>
       <br>
-      <textarea id='metadata-gene-description' placeholder='Metadata description'></textarea>
-      <button   id='metadata-gene-description-add' type='button' class="btn btn-default btn-sm">Add description</button>
+      <textarea id='metadata-gene-note' rows='15' cols='100' placeholder='Metadata Note'></textarea>
+      <button   id='metadata-gene-note-save' type='button' class="btn btn-default btn-sm">Save Note</button>
       <br>
       <table class="table table-striped" id="metadata-deepdive-table">
         <thead id="metadata-deepdive-header"></thead>
@@ -514,6 +517,9 @@ function showDeepDiveToolTip(event){
     $('#annotations-deepdive-header').empty()
   }
 
+  if(geneNote){
+    $('#metadata-gene-note').val(geneNote.label)
+  }
   if(includeMetadataHeader) $('#metadata-deepdive-header').append('<th>metadata</th><th>action</th><th>remove</th>')
 
   $('.metadata-query').on('click', function(){
@@ -577,6 +583,9 @@ function showDeepDiveToolTip(event){
     if(tagAdded && geneMetadata.length == 0) {
       $('#metadata-deepdive-header').append('<th>Tag</th><th>Query</th><th>Remove</th>')
     }
+  })
+  $('#metadata-gene-note-save').on('click', function(){
+    addMetadataNote(event.target.genomeID, event.target.geneID, $('#metadata-gene-note').val());
   })
   $('#picker_tooltip').colpick({
     layout: 'hex',
@@ -885,6 +894,21 @@ function showTabularModal(){
   });
 }
 
+function addMetadataNote(genomeID, geneID, payload) {
+  if(payload.trim().length === 0) return false; 
+
+  let noteObj = {
+    label   : payload,
+    genome  : genomeID,
+    gene    : geneID, 
+    type    : 'note'
+  }
+
+  if(!settings['display']['metadata']) settings['display']['metadata'] = []
+  settings['display']['metadata'].push(noteObj)
+  toastr.success('Saved metadata note')
+}
+
 function addMetadataTag(genomeID, geneID, label) {
   if(label.trim().length == 0) return false;
   let geneTags = settings['display']['metadata'].filter(metadata => metadata.genome == genomeID && metadata.gene == geneID && metadata.type == 'tag')
@@ -894,7 +918,7 @@ function addMetadataTag(genomeID, geneID, label) {
   }
   
   let queryBtn = `<button type='button' class='btn btn-default btn-sm metadata-query'>Query sequence for matches</button>`
-  let removeBtn = `<button type='button' class='btn btn-default btn-sm metadata-remove'>Remove metadata item</button>`
+  let removeBtn = `<button type='button' class='btn btn-default btn-sm metadata-remove'>Remove metadata tag</button>`
 
   let metadataObj = {
     label  : label,
@@ -1594,7 +1618,8 @@ function buildGeneLabelsSelect(){
   })
   // while we're here, we add 'metadata' to the function_search_category dropdown select
   // TODO refactor naming convention to sequence_search_category, bc we're not just querying functions!
-  $('#function_search_category').append(new Option('metadata', 'metadata'))
+  $('#function_search_category').append(new Option('metadata tag', 'metadata tag'))
+  $('#function_search_category').append(new Option('metadata note', 'metadata note'))
 }
 
 function setGeneVisibilityRange(targetGene, targetGenome){

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -897,15 +897,20 @@ function showTabularModal(){
 function addMetadataNote(genomeID, geneID, payload) {
   if(payload.trim().length === 0) return false; 
 
-  let noteObj = {
-    label   : payload,
-    genome  : genomeID,
-    gene    : geneID, 
-    type    : 'note'
-  }
-
   if(!settings['display']['metadata']) settings['display']['metadata'] = []
-  settings['display']['metadata'].push(noteObj)
+
+  let currentNoteIdx = settings['display']['metadata'].findIndex(metadata => metadata.genome == genomeID && metadata.gene == geneID && metadata.type == 'note');
+  if(currentNoteIdx == -1) {
+    let noteObj = {
+      label   : payload,
+      genome  : genomeID,
+      gene    : geneID, 
+      type    : 'note'
+    }
+    settings['display']['metadata'].push(noteObj)
+  } else {
+    settings['display']['metadata'][currentNoteIdx].label = payload
+  }
   toastr.success('Saved metadata note')
 }
 


### PR DESCRIPTION
this PR adds metadata Note creation/persistence/query-ability functionality to genome-view

From a gene's deepdive modal, a user can add add text to a textarea input box
- they can click 'save note' to persist the note to state --> a toastr message should confirm
- they can close the modal, navigate elsewhere, return to the gene's deepdive modal, and expect to see their note populated
- they can query all metadata via discrete `tags` and `notes` dropdown selects

![metadate notes](https://user-images.githubusercontent.com/62408216/235560777-c9c8ec05-f104-4fcb-9288-ae6417711b52.gif)
