### PR TITLE
Genome View: user-defined annotations

### DIFF
--- a/anvio/data/interactive/genomeview.html
+++ b/anvio/data/interactive/genomeview.html
@@ -128,8 +128,12 @@
               </div>
               <div id="tabular-modal-sequence-checkboxes"></div>
               <div>
-                <input type='text' placeholder='metadata tag' id='metadata-tag-multiselect' />
+                <input type='text' placeholder='Metadata tag' id='metadata-tag-multiselect' />
                 <button class="btn btn-default" onclick="gatherTabularModalSelectedItems('metadata')">Add metadata tag to selected</button>
+              </div>
+              <div>
+                <input type='text' placeholder='User-defined annotation' id='metadata-annotation-multiselect' />
+                <button class="btn btn-default" onclick="gatherTabularModalSelectedItems('annotation')">Add user-defined annotation to selected</button>
               </div>
               <div>
                 <div id="multiselect-picker-tabular-modal" class="colorpicker" color="#808080"

--- a/anvio/data/interactive/genomeview.html
+++ b/anvio/data/interactive/genomeview.html
@@ -505,6 +505,7 @@
             <button onclick='drawer.queryFunctions()'>Let's Go!</button>
             <button onclick='drawer.removeAllGeneGlows()'>Clear All Gene Glows</button>
             <button onclick='drawer.showAllTags()'>Show All Metadata Tags</button>
+            <button onclick='drawer.showAllUserDefined()'>Show All User-Defined Annotations</button>
             <button onclick='$("#query-results-head, #query-results-table").empty()'>Clear Results</button>
           </td>
           <br>

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -828,6 +828,10 @@ GenomeDrawer.prototype.queryFunctions = async function () {
     drawer.queryMetadata(query, type)
     return;
   }
+  if(category == 'User-defined') {
+    drawer.queryUserDefined(query);
+    return;
+  }
 
   this.settings['genomeData']['genomes'].map(genome => {
     for (const [key, value] of Object.entries(genome[1]['genes']['functions'])) {
@@ -981,6 +985,17 @@ GenomeDrawer.prototype.queryMetadata = async function(metadataLabel, type){
   }
   await zoomOutAndWait('partial', lowestStart, highestEnd, 350)
   this.glowGenes(glowPayload, true)
+}
+
+GenomeDrawer.prototype.queryUserDefined = async function (query) {
+  if(!settings['display']['metadata'] || settings['display']['metadata'].filter(m => m.type == 'annotation').length == 0) {
+    alert(`No hits were found matching ${query} in user-defined annotations`)
+    return
+  }
+
+  let distinctQueryMatches = Object()
+  let glowPayload = Array()
+  let foundInGenomes = Object()
 }
 
 GenomeDrawer.prototype.showAllTags = function(){

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -828,10 +828,6 @@ GenomeDrawer.prototype.queryFunctions = async function () {
     drawer.queryMetadata(query, type)
     return;
   }
-  if(category == 'User-defined') {
-    drawer.queryUserDefined(query);
-    return;
-  }
 
   this.settings['genomeData']['genomes'].map(genome => {
     for (const [key, value] of Object.entries(genome[1]['genes']['functions'])) {
@@ -941,13 +937,21 @@ GenomeDrawer.prototype.queryMetadata = async function(metadataLabel, type){
   `);
 
   if(!settings['display']['metadata']) {
-    alert(`No hits were found matching ${metadataLabel} in metadata`)
+    alert(`No hits were found matching ${metadataLabel} in ${type == 'annotation' ? 'user-defined annotations' : 'metadata'}`)
     return
   }
   let glowPayload = Array()
   let foundInGenomes = Object()
-  let matches = settings['display']['metadata'].filter( m => m.label.toLowerCase().includes(metadataLabel.toLowerCase()))
-                                               .filter( m => m.type == type )
+  let typeMatches = settings['display']['metadata'].filter(m => m.type == type);
+  let matches;
+  if(type == 'annotation') {
+    matches = typeMatches.filter(m => m.accession.toLowerCase().includes(metadataLabel.toLowerCase()))
+    if(matches.length == 0) {
+      matches = typeMatches.filter(m => m.annotation.toLowerCase().includes(metadataLabel.toLowerCase()))
+    }
+  } else {
+    matches = typeMatches.filter(m => m.label.toLowerCase().includes(metadataLabel.toLowerCase()))
+  }
   matches.map(metadata => {
     glowPayload.push({
       geneID: metadata.gene,
@@ -958,7 +962,7 @@ GenomeDrawer.prototype.queryMetadata = async function(metadataLabel, type){
     }
   })
   if (glowPayload.length < 1) {
-    alert(`No hits were found matching ${metadataLabel} in metadata`)
+    alert(`No hits were found matching ${metadataLabel} in ${type == 'annotation' ? 'user-defined annotations' : 'metadata'}`)
     return
   }
   let lowestStart, highestEnd = null
@@ -985,17 +989,6 @@ GenomeDrawer.prototype.queryMetadata = async function(metadataLabel, type){
   }
   await zoomOutAndWait('partial', lowestStart, highestEnd, 350)
   this.glowGenes(glowPayload, true)
-}
-
-GenomeDrawer.prototype.queryUserDefined = async function (query) {
-  if(!settings['display']['metadata'] || settings['display']['metadata'].filter(m => m.type == 'annotation').length == 0) {
-    alert(`No hits were found matching ${query} in user-defined annotations`)
-    return
-  }
-
-  let distinctQueryMatches = Object()
-  let glowPayload = Array()
-  let foundInGenomes = Object()
 }
 
 GenomeDrawer.prototype.showAllTags = function(){

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -1029,6 +1029,47 @@ GenomeDrawer.prototype.showAllTags = function(){
   });
 }
 
+GenomeDrawer.prototype.showAllUserDefined = function(){
+  if(!settings['display']['metadata'] || settings['display']['metadata'].filter(metadata => metadata.type == 'annotation').length == 0) {
+    alert('No user-defined annotations currently exist');
+    return;
+  }
+
+  $('#query-results-table').empty();
+  $('#query-results-head').empty().append(`
+    <tr>
+      <th>Gene ID</th>
+      <th>Genome</th>
+      <th>Start</th>
+      <th>Stop</th>
+      <th>Go To</th>
+      <th>Remove</th>
+    </tr>
+  `);
+
+  settings['display']['metadata'].filter(metadata => metadata.type == 'annotation').forEach(annotation => {
+    let genome = this.settings['genomeData']['genomes'].filter(genome => genome[0] == annotation.genome)
+    let start = genome[0][1]['genes']['gene_calls'][annotation.gene]['start']
+    let end = genome[0][1]['genes']['gene_calls'][annotation.gene]['stop']
+
+    $('#query-results-table').append(`
+      <tr>
+        <td>${annotation.gene}</td>
+        <td>${annotation.genome}</td>
+        <td>${start}</td>
+        <td>${end}</td>
+        <td><button onclick="goToGene('${annotation.genome}',${annotation.gene},${start},${end})">Go To</button</td>
+        <td><button onclick="$(this).closest('tr').remove(); removeAnnotation('${annotation.genome}',${annotation.gene})">Remove Tag</button</td>
+      </tr>
+    `)
+  });
+
+  removeAnnotation = (genomeID, geneID) => {
+    let index = settings['display']['metadata'].findIndex(m => m.gene == geneID && m.genome == genomeID && m.type == 'annotation');
+    settings['display']['metadata'].splice(index, 1);
+  }
+}
+
 GenomeDrawer.prototype.setInitialZoom = function(){
     let start = 0
     let stop = globalGenomeMax > 35000 ? 35000 : globalGenomeMax

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -1027,6 +1027,14 @@ GenomeDrawer.prototype.showAllTags = function(){
       </tr>
     `)
   });
+
+  removeTagFromQueryTable = (genomeID, geneID, label) => {
+    let index = settings['display']['metadata'].findIndex(m => m.label == label && m.gene == geneID && m.genome == genomeID && m.type == 'tag');
+    settings['display']['metadata'].splice(index, 1);
+    if($('#query-results-table').children().length == 0) {
+      $('#query-results-head').empty();
+    }
+  }
 }
 
 GenomeDrawer.prototype.showAllUserDefined = function(){

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -783,9 +783,16 @@ GenomeDrawer.prototype.setGenomeLabelSize = function (newSize) {
 }
 
 GenomeDrawer.prototype.redrawSingleGenome = function (genomeID) {
+  if(!$('#' + genomeID + '-show').is(':checked')) return;
+
   canvas.getObjects().filter(o => o.groupID == genomeID).forEach(obj => canvas.remove(obj));
   let idx = this.settings['genomeData']['genomes'].findIndex(obj => obj[0] == genomeID);
-  this.addLayers(idx);
+  let orderIndex = idx;
+  for(genome of this.settings['genomeData']['genomes']) {
+    if(genome[0] == genomeID) break;
+    if(!$('#' + genome[0] + '-show').is(':checked')) orderIndex--;
+  }
+  this.addLayers(idx, orderIndex);
   checkGeneLabels();
 }
 

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -219,10 +219,9 @@ GenomeDrawer.prototype.addGenome = function (orderIndex, layerHeight, layerPos, 
 
       if (source == 'default') {
         return `${geneID}`
-      }
-      if (source == 'user') {
-        if (this.settings['display']?.hasOwnProperty('gene-labels')) {
-          return this.settings['display']['gene-labels'][genomeID][geneID]
+      } else if (source == 'user') {
+        if (this.settings['display']?.['metadata']?.filter(m => m.genome == genomeID && m.gene == geneID && m.type == 'annotation')?.length > 0) {
+          return this.settings['display']['metadata'].filter(m => m.genome == genomeID && m.gene == geneID && m.type == 'annotation')[0].annotation;
         } else {
           return ''
         }

--- a/anvio/data/interactive/js/genomeview/drawer.js
+++ b/anvio/data/interactive/js/genomeview/drawer.js
@@ -1081,6 +1081,7 @@ GenomeDrawer.prototype.showAllUserDefined = function(){
   removeAnnotation = (genomeID, geneID) => {
     let index = settings['display']['metadata'].findIndex(m => m.gene == geneID && m.genome == genomeID && m.type == 'annotation');
     settings['display']['metadata'].splice(index, 1);
+    if($('#gene_label_source').val() == 'user') this.redrawSingleGenome(genomeID);
   }
 }
 

--- a/anvio/data/interactive/js/genomeview/main.js
+++ b/anvio/data/interactive/js/genomeview/main.js
@@ -422,6 +422,12 @@ function processState(stateName, stateData) {
     settings['display']['xDisps'] = stateData['display']['xDisps']
   }
 
+  if(stateData?.['display']?.['accessionNum']) {
+    settings['display']['accessionNum'] = stateData['display']['accessionNum'];
+  } else {
+    settings['display']['accessionNum'] = 0;
+  }
+
   if(settings?.['display']?.['show-genomes']) {
     settings['display']['show-genomes'] = stateData['display']['show-genomes']
   } else {

--- a/anvio/data/interactive/js/genomeview/main.js
+++ b/anvio/data/interactive/js/genomeview/main.js
@@ -578,6 +578,9 @@ function loadAll(loadType) {
     buildGeneLabelsSelect()
   }
 
+  $('#query-results-table').empty();
+  $('#query-results-head').empty();
+
   $('#gene_label_color').css('background-color', settings['display']['colors']['gene-label']);
   $('#gene_label_color').attr('color', settings['display']['colors']['gene-label']);
 

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -430,16 +430,16 @@ function showDeepDiveToolTip(event){
       </tr>
       `
     })
-    let annotations = settings['display']['metadata'].filter(m => m.genome == genomeID && m.gene == geneID && m.type == 'annotation');
-    if(annotations.length > 0) {
-      totalAnnotationsString += `
-      <tr id="user-defined-annotation-row">
-      <td>User_Defined</td>
-      <td>${annotations[0].accession}</td>
-      <td>${annotations[0].annotation}</td>
-      </tr>
-      `
-    }
+  }
+  let annotations = settings['display']['metadata'].filter(m => m.genome == genomeID && m.gene == geneID && m.type == 'annotation');
+  if(annotations.length > 0) {
+    totalAnnotationsString += `
+    <tr id="user-defined-annotation-row">
+    <td>User_Defined</td>
+    <td>${annotations[0].accession}</td>
+    <td>${annotations[0].annotation}</td>
+    </tr>
+    `
   }
 
   $('#deepdive-modal-body').modal('show')
@@ -499,28 +499,31 @@ function showDeepDiveToolTip(event){
       <button   id='metadata-gene-note-save' type='button' class="btn btn-default btn-sm">Save Note</button>
       <br>
       <table class="table table-striped" id="metadata-deepdive-table">
-        <thead id="metadata-deepdive-header">${includeMetadataHeader ? '<th>Tag</th><th>Query</th><th>Remove</th>' : ''}</thead>
+        <thead id="metadata-deepdive-header">${includeMetadataHeader ? '<tr><th>Tag</th><th>Query</th><th>Remove</th></tr>' : ''}</thead>
         <tbody id="metadata-body">
          ${totalMetadataString}
         </tbody>
       </table>
   </div>
 
-  ${event.target.functions ?
-    `<h2>Annotations</h2>
-    <input id="annotation-deepdive-input" type="text" placeholder="User-defined annotation" size='50'>
-    <button id='annotation-add' type='button' class="btn btn-default btn-sm">Add custom annotation</button>
-    <button id='annotation-remove' type='button' class="btn btn-default btn-sm">Remove custom annotation</button>
-    <table class="table table-striped">
-      <thead id="annotations-deepdive-header">
-        <th>Source</th>
-        <th>Accession</th>
-        <th>Annotation</th> 
-      </thead>
-      <tbody id="annotations-deepdive-body">
-        ${totalAnnotationsString}
-      </tbody>
-    </table>` : ''}
+  <h2>Annotations</h2>
+  <input id="annotation-deepdive-input" type="text" placeholder="User-defined annotation" size='50'>
+  <button id='annotation-add' type='button' class="btn btn-default btn-sm">Add custom annotation</button>
+  <button id='annotation-remove' type='button' class="btn btn-default btn-sm">Remove custom annotation</button>
+  <table class="table table-striped">
+    <thead id="annotations-deepdive-header">
+      ${totalAnnotationsString.length == 0 ? '' : `
+        <tr>
+          <th>Source</th>
+          <th>Accession</th>
+          <th>Annotation</th> 
+        </tr>
+      `}
+    </thead>
+    <tbody id="annotations-deepdive-body">
+      ${totalAnnotationsString}
+    </tbody>
+  </table>
   `)
 
   if(geneNote){
@@ -605,7 +608,7 @@ function showDeepDiveToolTip(event){
     let accession = 'UD_' + "0".repeat(5-settings['display']['accessionNum'].toString().length) + settings['display']['accessionNum'];
 
     if(!event.target.functions && settings['display']['metadata'].filter(metadata => metadata.genome == genomeID && metadata.gene == geneID && metadata.type == 'annotation').length == 0) {
-      $('#annotations-deepdive-header').append('<th>Tag</th><th>Query</th><th>Remove</th>')
+      $('#annotations-deepdive-header').append('<tr><th>Source</th><th>Accession</th><th>Annotation</th></tr>')
     }
     $('#annotations-deepdive-body').append(`
       <tr id='user-defined-annotation-row'>

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -1662,8 +1662,9 @@ function buildGeneLabelsSelect(){
     // we can also build the dropdown UI element for source-selection in functional querying
     $("#function_search_category").append(new Option(source, source))
   })
-  // while we're here, we add 'metadata' to the function_search_category dropdown select
+  // while we're here, we add 'user-defined annotations' 'metadata' to the function_search_category dropdown select
   // TODO refactor naming convention to sequence_search_category, bc we're not just querying functions!
+  $('#function_search_category').append(new Option('User-defined', 'User-defined'))
   $('#function_search_category').append(new Option('metadata tag', 'metadata tag'))
   $('#function_search_category').append(new Option('metadata note', 'metadata note'))
 }

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -1033,6 +1033,29 @@ function addMetadataTag(genomeID, geneID, label) {
   return true;
 }
 
+function addAnnotation(genomeID, geneID, label){
+  // called from the viewport menu
+
+  if(label.trim().length == 0) return false;
+  let annotation = settings['display']['metadata'] ? settings['display']['metadata'].filter(m => m.genome == genomeID && m.gene == geneID && m.type == 'annotation') : []
+  if(annotation.length > 0) {
+    toastr.warning(`'Cannot add more than one user-defined annotation to gene ${geneID} of ${genomeID}'`);
+    return false;
+  }
+
+  if(!settings['display']['metadata']) settings['display']['metadata'] = []
+  settings['display']['metadata'].push({
+    genome : genomeID,
+    gene   : geneID,
+    accession : 'UD_' + "0".repeat(5-settings['display']['accessionNum'].toString().length) + settings['display']['accessionNum'],
+    annotation : label,
+    type   : 'annotation'
+  })
+  settings['display']['accessionNum']++;
+
+  return true;
+}
+
 function gatherTabularModalSelectedItems(action){
   let targetedGenes = []
   let curr_genome = $('.active')[1].id;
@@ -1073,6 +1096,14 @@ function gatherTabularModalSelectedItems(action){
         addMetadataTag(gene['genomeID'], gene['geneID'], label);
       });
       $('#metadata-tag-multiselect').val('');
+      break;
+    case 'annotation':
+      let annotation = $('#metadata-annotation-multiselect').val();
+      if(annotation.trim().length == 0) return;
+      targetedGenes.forEach(gene => {
+        addAnnotation(gene['genomeID'], gene['geneID'], annotation);
+      });
+      $('#metadata-annotation-multiselect').val('');
       break;
     default:
       break;

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -636,6 +636,8 @@ function showDeepDiveToolTip(event){
     let index = settings['display']['metadata'].findIndex(m => m.gene == geneID && m.genome == genomeID && m.type == 'annotation');
     if(index == -1) return;
     settings['display']['metadata'].splice(index, 1);
+
+    if($('#annotations-deepdive-body').children().length == 0) $('#annotations-deepdive-header').empty();
   });
   $('#picker_tooltip').colpick({
     layout: 'hex',

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -430,6 +430,16 @@ function showDeepDiveToolTip(event){
       </tr>
       `
     })
+    let annotations = settings['display']['metadata'].filter(m => m.genome == genomeID && m.gene == geneID && m.type == 'annotation');
+    if(annotations.length > 0) {
+      totalAnnotationsString += `
+      <tr id="user-defined-annotation-row">
+      <td>User_Defined</td>
+      <td>${annotations[0].accession}</td>
+      <td>${annotations[0].annotation}</td>
+      </tr>
+      `
+    }
   }
 
   $('#deepdive-modal-body').modal('show')

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -1033,14 +1033,6 @@ function addMetadataTag(genomeID, geneID, label) {
   return true;
 }
 
-function removeTagFromQueryTable(genomeID, geneID, label) {
-  let index = settings['display']['metadata'].findIndex(m => m.label == label && m.gene == geneID && m.genome == genomeID && m.type == 'tag');
-  settings['display']['metadata'].splice(index, 1);
-  if($('#query-results-table').children().length == 0) {
-    $('#query-results-head').empty();
-  }
-}
-
 function gatherTabularModalSelectedItems(action){
   let targetedGenes = []
   let curr_genome = $('.active')[1].id;

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -692,15 +692,17 @@ function showToolTip(event){
       `
     })
   }
-  let user_defined = settings['display']['metadata'].filter(m => m.genome == event.target.genomeID && m.gene == event.target.geneID && m.type == 'annotation');
-  if(user_defined.length > 0) {
-    totalAnnotationsString += `
-    <tr id="user-defined-annotation-row">
-    <td>User_Defined</td>
-    <td>${user_defined[0].accession}</td>
-    <td>${user_defined[0].annotation}</td>
-    </tr>
-    `
+  if(settings['display']['metadata']) {
+    let user_defined = settings['display']['metadata'].filter(m => m.genome == event.target.genomeID && m.gene == event.target.geneID && m.type == 'annotation');
+    if(user_defined.length > 0) {
+      totalAnnotationsString += `
+      <tr id="user-defined-annotation-row">
+      <td>User_Defined</td>
+      <td>${user_defined[0].accession}</td>
+      <td>${user_defined[0].annotation}</td>
+      </tr>
+      `
+    }
   }
   $('#mouseover-panel-table-body').append(`
     <tr>

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -500,6 +500,7 @@ function showDeepDiveToolTip(event){
     `<h2>Annotations</h2>
     <input id="annotation-deepdive-input" type="text" placeholder="User-defined annotation" size='50'>
     <button id='annotation-add' type='button' class="btn btn-default btn-sm">Add custom annotation</button>
+    <button id='annotation-remove' type='button' class="btn btn-default btn-sm">Remove custom annotation</button>
     <table class="table table-striped">
       <thead id="annotations-deepdive-header">
         <th>Source</th>
@@ -596,7 +597,7 @@ function showDeepDiveToolTip(event){
       $('#annotations-deepdive-header').append('<th>Tag</th><th>Query</th><th>Remove</th>')
     }
     $('#annotations-deepdive-body').append(`
-      <tr>
+      <tr id='user-defined-annotation-row'>
         <td>User_Defined</td>
         <td>${accession}</td>
         <td>${annotation}</td>
@@ -614,6 +615,14 @@ function showDeepDiveToolTip(event){
 
     // add remove button: remove from settings and accessionNum-- 
   })
+  $('#annotation-remove').on('click',function(){
+    if(!settings['display']['metadata']) return;
+
+    $('#user-defined-annotation-row').remove();
+    let index = settings['display']['metadata'].findIndex(m => m.gene == geneID && m.genome == genomeID && m.type == 'annotation');
+    if(index == -1) return;
+    settings['display']['metadata'].splice(index, 1);
+  });
   $('#picker_tooltip').colpick({
     layout: 'hex',
     submit: 0,

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -489,27 +489,27 @@ function showDeepDiveToolTip(event){
       <button   id='metadata-gene-note-save' type='button' class="btn btn-default btn-sm">Save Note</button>
       <br>
       <table class="table table-striped" id="metadata-deepdive-table">
-        <thead id="metadata-deepdive-header">${includeMetadataHeader ? '<th>metadata</th><th>action</th><th>remove</th>' : ''}</thead>
+        <thead id="metadata-deepdive-header">${includeMetadataHeader ? '<th>Tag</th><th>Query</th><th>Remove</th>' : ''}</thead>
         <tbody id="metadata-body">
          ${totalMetadataString}
         </tbody>
       </table>
   </div>
 
-  <h2>${event.target.functions ? 'Annotations' : ''}</h2>
-  <table class="table table-striped">
-    <thead id="annotations-deepdive-header">
-      ${event.target.functions ? `
+  ${event.target.functions ?
+    `<h2>Annotations</h2>
+    <input id="annotation-deepdive-input" type="text" placeholder="User-defined annotation" size='50'>
+    <button id='annotation-add' type='button' class="btn btn-default btn-sm">Add custom annotation</button>
+    <table class="table table-striped">
+      <thead id="annotations-deepdive-header">
         <th>Source</th>
         <th>Accession</th>
-        <th>Annotation</th>` 
-        : ''
-      }
-    </thead>
-    <tbody>
-      ${totalAnnotationsString}
-    </tbody>
-  </table>
+        <th>Annotation</th> 
+      </thead>
+      <tbody id="annotations-deepdive-body">
+        ${totalAnnotationsString}
+      </tbody>
+    </table>` : ''}
   `)
 
   if(geneNote){
@@ -579,6 +579,40 @@ function showDeepDiveToolTip(event){
   $('#metadata-gene-note-save').on('click', function(){
     addMetadataNote(genomeID, geneID, $('#metadata-gene-note').val());
   })
+  $('#annotation-add').on('click', function(){
+    let annotation = $('#annotation-deepdive-input').val();
+    if(annotation.trim().length == 0) return;
+
+    if(!settings['display']['metadata']) settings['display']['metadata'] = [];
+
+    if(settings['display']['metadata'].some(m => m.type == 'annotation' && m.gene == geneID && m.genome == genomeID)) {
+      toastr.warning(`Cannot add more than one annotation to gene ${geneID} of ${genomeID}`);
+      return;
+    }
+
+    let accession = 'UD_' + "0".repeat(5-settings['display']['accessionNum'].toString().length) + settings['display']['accessionNum'];
+
+    if(!event.target.functions && settings['display']['metadata'].filter(metadata => metadata.genome == genomeID && metadata.gene == geneID && metadata.type == 'annotation').length == 0) {
+      $('#annotations-deepdive-header').append('<th>Tag</th><th>Query</th><th>Remove</th>')
+    }
+    $('#annotations-deepdive-body').append(`
+      <tr>
+        <td>User_Defined</td>
+        <td>${accession}</td>
+        <td>${annotation}</td>
+      </tr>
+    `);
+
+    settings['display']['metadata'].push({
+      gene: geneID,
+      genome: genomeID,
+      accession: accession,
+      annotation: annotation,
+      type: 'annotation'
+    });
+    settings['display']['accessionNum']++;
+
+    // add remove button: remove from settings and accessionNum-- 
   })
   $('#picker_tooltip').colpick({
     layout: 'hex',

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -692,6 +692,16 @@ function showToolTip(event){
       `
     })
   }
+  let user_defined = settings['display']['metadata'].filter(m => m.genome == event.target.genomeID && m.gene == event.target.geneID && m.type == 'annotation');
+  if(user_defined.length > 0) {
+    totalAnnotationsString += `
+    <tr id="user-defined-annotation-row">
+    <td>User_Defined</td>
+    <td>${user_defined[0].accession}</td>
+    <td>${user_defined[0].annotation}</td>
+    </tr>
+    `
+  }
   $('#mouseover-panel-table-body').append(`
     <tr>
       <td> ${event.target.geneID}</td>

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -634,7 +634,7 @@ function showDeepDiveToolTip(event){
     });
     settings['display']['accessionNum']++;
 
-    // add remove button: remove from settings and accessionNum-- 
+    if($('#gene_label_source').val() == 'user') drawer.redrawSingleGenome(genomeID);
   })
   $('#annotation-remove').on('click',function(){
     if(!settings['display']['metadata']) return;
@@ -645,6 +645,8 @@ function showDeepDiveToolTip(event){
     settings['display']['metadata'].splice(index, 1);
 
     if($('#annotations-deepdive-body').children().length == 0) $('#annotations-deepdive-header').empty();
+
+    if($('#gene_label_source').val() == 'user') drawer.redrawSingleGenome(genomeID);
   });
   $('#picker_tooltip').colpick({
     layout: 'hex',
@@ -1120,6 +1122,7 @@ function gatherTabularModalSelectedItems(action){
         addAnnotation(gene['genomeID'], gene['geneID'], annotation);
       });
       $('#metadata-annotation-multiselect').val('');
+      if($('#gene_label_source').val() == 'user') drawer.draw();
       break;
     default:
       break;

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -606,6 +606,13 @@ function showDeepDiveToolTip(event){
     }
 
     let accession = 'UD_' + "0".repeat(5-settings['display']['accessionNum'].toString().length) + settings['display']['accessionNum'];
+    if(settings['display']['metadata']) {
+      let same_annotations = settings['display']['metadata'].filter(m => m.type == 'annotation' && m.annotation == annotation);
+      if(same_annotations.length > 0) {
+        accession = same_annotations[0].accession;
+        settings['display']['accessionNum']--; // compensate for increment so we stay at the same accession number
+      }
+    }
 
     if(!event.target.functions && settings['display']['metadata'].filter(metadata => metadata.genome == genomeID && metadata.gene == geneID && metadata.type == 'annotation').length == 0) {
       $('#annotations-deepdive-header').append('<tr><th>Source</th><th>Accession</th><th>Annotation</th></tr>')
@@ -1043,11 +1050,20 @@ function addAnnotation(genomeID, geneID, label){
     return false;
   }
 
+  let accession = 'UD_' + "0".repeat(5-settings['display']['accessionNum'].toString().length) + settings['display']['accessionNum'];
+  if(settings['display']['metadata']) {
+    let same_annotations = settings['display']['metadata'].filter(m => m.type == 'annotation' && m.annotation == label);
+    if(same_annotations.length > 0) {
+      accession = same_annotations[0].accession;
+      settings['display']['accessionNum']--; // compensate for increment so we stay at the same accession number
+    }
+  }
+
   if(!settings['display']['metadata']) settings['display']['metadata'] = []
   settings['display']['metadata'].push({
     genome : genomeID,
     gene   : geneID,
-    accession : 'UD_' + "0".repeat(5-settings['display']['accessionNum'].toString().length) + settings['display']['accessionNum'],
+    accession : accession,
     annotation : label,
     type   : 'annotation'
   })

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -582,6 +582,7 @@ function showDeepDiveToolTip(event){
   })
   $('#annotation-add').on('click', function(){
     let annotation = $('#annotation-deepdive-input').val();
+    $('#annotation-deepdive-input').val('');
     if(annotation.trim().length == 0) return;
 
     if(!settings['display']['metadata']) settings['display']['metadata'] = [];

--- a/anvio/data/interactive/js/genomeview/ui.js
+++ b/anvio/data/interactive/js/genomeview/ui.js
@@ -1664,7 +1664,7 @@ function buildGeneLabelsSelect(){
   })
   // while we're here, we add 'user-defined annotations' 'metadata' to the function_search_category dropdown select
   // TODO refactor naming convention to sequence_search_category, bc we're not just querying functions!
-  $('#function_search_category').append(new Option('User-defined', 'User-defined'))
+  $('#function_search_category').append(new Option('User-defined', 'metadata annotation'))
   $('#function_search_category').append(new Option('metadata tag', 'metadata tag'))
   $('#function_search_category').append(new Option('metadata note', 'metadata note'))
 }


### PR DESCRIPTION
This PR adds custom user-defined annotation functionality (creation, removal, querying, persistence, display as gene labels) to genome view. 
- Creation
  - Users can add a custom annotation via textbox in the deepdive menu, and a unique 5-digit accession value will be generated automatically (e.g. `UD_00018`)
  - They can also add the same annotation to multiple genes at once using the viewport menu.  
  - When a user adds a new custom annotation that matches an existing annotation, it will have the same accession value.
  - Only one custom annotation can be added per gene
- Querying
  - Users can query all user-defined annotations using either the accession value or the annotation description in the query pane
  - "Show all user-defined annotations" button and ability to navigate to them or remove them from query pane 
- Display as gene labels
  - Users can select 'user-defined' under 'gene label source' in settings to display user-defined annotations as gene labels on the canvas
- Display custom annotations on mouseover panel
- Persistence in state

The `redrawSingleGenome` function was also fixed/reintroduced so that we can more efficiently rerender specific genomes when something is changed