### PR TITLE
add  a conda `environment.yml` file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,33 @@
+name: anvio-dev
+channels:
+- conda-forge
+- bioconda
+- defaults
+dependencies:
+- python=3.7
+- sqlite
+- prodigal
+- idba
+- mcl
+- muscle=3.8.1551
+- hmmer
+- diamond
+- blast
+- megahit
+- spades
+- bowtie2
+- bwa
+- graphviz
+- "samtools>=1.9"
+- trimal
+- iqtree
+- trnascan-se
+- fasttree
+- vmatch
+- r-base
+- r-tidyverse
+- r-optparse
+- r-stringi
+- r-magrittr
+- bioconductor-qvalue
+- fastani


### PR DESCRIPTION
This environment.yml works for me on an M1 Mac w/mambaforge enabled like so:

```
conda config --env --set subdir osx-64
mamba env create -f environment.yml -n anvio-dev

conda activate anvio-dev
pip install -r requirements.txt

anvi-self-test --suite mini
```

Thanks @ahenoch for all your advice and recommendations!