### PR TITLE
Compute inversion activity from pre-computed inversions

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -403,10 +403,16 @@ D = {
                 ),
     'bams-and-profiles': (
             ['-P', '--bams-and-profiles'],
-            {'metavar': 'FILE_PATH',
+            {'metavar': 'BAMS-AND-PROFILES-FILE',
              'help': "A four-column TAB-delimited flat text file. The header line must contain these columns: 'name', "
                      "'contigs_db_path', 'profile_db_path', and 'bam_file_path'. See the profiles-and-bams.txt artifact "
                      "for the details of the file."}
+                ),
+    'pre-computed-inversions': (
+            ['--pre-computed-inversions'],
+            {'metavar': 'INVERSIONS-FILE',
+             'help': "A TAB-delimited file that lists sample-specific or consensus inversions identified by the program "
+                     "`anvi-report-inversions`."}
                 ),
     'gene-caller': (
             ['--gene-caller'],

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -982,6 +982,30 @@ class Inversions:
             output_queue.put(sample_counts)
 
 
+    def populate_consensus_inversions_from_input_file(self):
+        """Get the consensus inversions from a previously generated output file"""
+
+        # these are the keys we are interested in finding in that file. NOTE that these keys are not ALL
+        # keys, but the minimum set that co-occur both sample-specific and consensus inversion reports.
+        # this way, the user can attempt to characterize the activity of inversions found in a single
+        # sample if they wish:
+        keys_of_interest = [('contig_name', str), ('first_seq', str), ('midline', str), ('second_seq', str),
+                            ('first_start', int), ('first_end', int), ('first_oligo_primer', str),
+                            ('first_oligo_reference', str), ('second_start', int), ('second_end', int),
+                            ('second_oligo_primer', str), ('second_oligo_reference', str), ('num_mismatches', int),
+                            ('num_gaps', int), ('length', int), ('distance', int)]
+
+        inversions_dict = utils.get_TAB_delimited_file_as_dictionary(self.pre_computed_inversions_path)
+
+        self.consensus_inversions = []
+
+        for inversion_id in sorted(list(inversions_dict.keys())):
+            entry = OrderedDict({'inversion_id': inversion_id})
+            for tpl in keys_of_interest:
+                entry[tpl[0]] = tpl[1](inversions_dict[inversion_id][tpl[0]])
+            self.consensus_inversions.append(entry)
+
+
     def compute_inversion_activity(self):
         """Go back to the raw metagenomic reads to compute activity of inversions"""
 

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -115,6 +115,7 @@ class Inversions:
 
         # compute inversion activity across samples?
         self.skip_compute_inversion_activity = A('skip_compute_inversion_activity') or False
+        self.pre_computed_inversions_path = A('pre_computed_inversions')
 
         # stop inversion activity computation early for testing?
         self.end_primer_search_after_x_hits = A('end_primer_search_after_x_hits')
@@ -267,6 +268,7 @@ class Inversions:
             # and if there are no coverage stretches long enough, stop:
             if not coverage_stretches_in_contigs[contig_name]:
                 continue
+
             # now it is time to merge those stretches of coverage if they are close to one another to avoid
             # over-splitting areas of coverage due to short regions with low-coverage in the middle like this,
             # where we wish to identify A and B together in a single stretch:
@@ -1271,6 +1273,15 @@ class Inversions:
 
     def sanity_check(self):
         """Basic checks for a smooth operation"""
+
+        if self.pre_computed_inversions_path:
+            if self.skip_compute_inversion_activity:
+                raise ConfigError("You can't provide consensus inversions to calculate inversion activity, and then ask "
+                                  "anvi'o to skip calculating inversion activity :/")
+
+            if not self.raw_r1_r2_reads_are_present:
+                raise ConfigError("You asked anvi'o to calculate inversion activity across samples, but your bams-and-profiles-txt "
+                                  "does not include raw R1/R2 reads :(")
 
         if not self.skip_recovering_genomic_context:
             if not dbops.ContigsDatabase(self.contigs_db_path, run=run_quiet, progress=progress_quiet).meta['genes_are_called']:

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -1021,14 +1021,14 @@ class Inversions:
 
         # let the user know what is going on
         msg = (f"Now anvi'o will compute in-sample activity of consensus {PL('inversion', len(self.consensus_inversions))} "
-              f"across {PL('sample', num_samples)}. Brace yourself and please not that this can "
-              f"take a very long time since for each sample, anvi'o will go through each short read to search for two "
-              f"sequences per inversion. IF IT COMES TO A POINT WHERE you (or your job on your HPC) can't continue running "
-              f"it, this process can be killed without any loss of data from the previous steps, as your primary output "
-              f"files must have already been reported. You can always skip this step and search for individual primers "
-              f"listed in the consensus output file using the program `anvi-search-primers` with the parameter "
-              f"`--min-remainder-length 6` and the flag `--only-report-remainders` to explore inversion activity "
-              f"manually")
+               f"across {PL('sample', num_samples)}. Brace yourself and please note that this can "
+               f"take a very long time since for each sample, anvi'o will go through each short read to search for two "
+               f"sequences per inversion. IF IT COMES TO A POINT WHERE you (or your job on your HPC) can't continue running "
+               f"it, this process can be killed without any loss of data from the previous steps, as your primary output "
+               f"files must have already been reported. You can always skip this step and search for individual primers "
+               f"listed in the consensus output file using the program `anvi-search-primers` with the parameter "
+               f"`--min-remainder-length 6` and the flag `--only-report-remainders` to explore inversion activity "
+               f"manually")
         self.run.warning(None, header="PERFORMANCE NOTE", lc="yellow")
         if num_samples > self.num_threads:
             self.run.info_single(f"You have {PL('sample', num_samples)} but {PL('thread', self.num_threads)}. Not all samples will be processed "

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -1207,6 +1207,21 @@ class Inversions:
         self.run.info("[General] R1/R2 for raw reads present?", "True" if self.raw_r1_r2_reads_are_present else "False")
         self.run.info("[General] Be talkative (--verbose)?", "True" if self.verbose else "False", nl_after=1)
 
+        # do we have a previously computed list of consensus inversions to focus for inversion
+        # activity calculations?
+        if self.pre_computed_inversions_path:
+            self.run.warning("Anvi'o is taking a shortcut to calculate inversion activity using the inversions you have "
+                             "provided in the 'consensus inversions' file. There is nothing for you to be concerned about "
+                             "-- except the fact that some very fancy coding is at play here and catastrophic failures "
+                             "are not a remote possibility. Still, anvi'o prints this message in green for positive "
+                             "vibes 🥲", header="🌈 PRE-COMPUTED INVERSIONS FOUND 🌈", lc="green")
+
+            self.populate_consensus_inversions_from_input_file()
+            self.compute_inversion_activity()
+
+            # WE'RE DOnE HERE. DoNe.
+            return
+
         self.run.info("[Defining stretches] Min FF/RR coverage to qualify", self.min_coverage_to_define_stretches)
         self.run.info("[Defining stretches] Min length", self.min_stretch_length)
         self.run.info("[Defining stretches] Min dist between independent stretches", self.min_distance_between_independent_stretches)

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -249,7 +249,7 @@ class Inversions:
             # but if there aren't any regions covered enough we want to stop:
             if not regions_of_contig_covered_enough.any():
                 continue
-            
+
             regions_of_contig_covered_enough_diff = np.diff(regions_of_contig_covered_enough.astype(int))
             cov_stretch_start_positions = np.where(regions_of_contig_covered_enough_diff == 1)[0]
             cov_stretch_end_positions = np.where(regions_of_contig_covered_enough_diff == -1)[0]
@@ -263,11 +263,10 @@ class Inversions:
 
                 if (cov_stretch_end - cov_stretch_start) >= self.min_stretch_length:
                     coverage_stretches_in_contigs[contig_name].append((cov_stretch_start, cov_stretch_end),)
-            
+
             # and if there are no coverage stretches long enough, stop:
             if not coverage_stretches_in_contigs[contig_name]:
                 continue
-                
             # now it is time to merge those stretches of coverage if they are close to one another to avoid
             # over-splitting areas of coverage due to short regions with low-coverage in the middle like this,
             # where we wish to identify A and B together in a single stretch:

--- a/anvio/tests/run_component_tests_for_inversions.sh
+++ b/anvio/tests/run_component_tests_for_inversions.sh
@@ -62,6 +62,11 @@ SHOW_FILE INVERSION_COMPLETE/INVERSION-ACTIVITY.txt
 SHOW_FILE INVERSION_COMPLETE/INVERSIONS-CONSENSUS-SURROUNDING-FUNCTIONS.txt
 SHOW_FILE INVERSION_COMPLETE/INVERSIONS-CONSENSUS-SURROUNDING-GENES.txt
 
+INFO "Re-computing inversion activity using previous results (quietly)"
+anvi-report-inversions -P bams-and-profiles.txt \
+                       --pre-computed-inversions INVERSION_COMPLETE/INVERSIONS-CONSENSUS.txt \
+                       --quiet
+
 INFO "Running the analysis on a target region (quietly)"
 anvi-report-inversions -P bams-and-profiles.txt \
                        -o INVERSION_TARGET \

--- a/bin/anvi-report-inversions
+++ b/bin/anvi-report-inversions
@@ -38,7 +38,7 @@ if __name__ == '__main__':
                     "sample-specific inversions (i.e., 'INVERSIONS-IN-[SAMPLE-NAME].txt') calculated. This input option will "
                     "use the existing inversions reported in the input file and recalculate the inversion activity output. It is "
                     "a great way to calculate inversions or refine them from a smaller set of genomes / metagenomes, and scale "
-                    "up the characterizations of their activity to thousansds of metagenomes quickly (*chough* cheater *chough*). "
+                    "up the characterizations of their activity to thousands of metagenomes quickly (*cough* cheater *cough*). "
                     "Please note that if you use this flag, most other options EXCEPT those that are listed below 'KEY ALGORITHMIC "
                     "COMPONENT 04: COMPUTING INVERSION ACTIVITY' will be irrelevant, so you can skip all and take a look at the "
                     "parameters there.")

--- a/bin/anvi-report-inversions
+++ b/bin/anvi-report-inversions
@@ -33,31 +33,42 @@ if __name__ == '__main__':
     groupA = parser.add_argument_group('INPUT DATA', "Essentially a BAMs and profiles file and nothing more.")
     groupA.add_argument(*anvio.A('bams-and-profiles'), **anvio.K('bams-and-profiles'))
 
-    groupB = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 01: IDENTIFYING REGIONS OF INTERSET', "How should anvi'o identify regions of interest "
+    groupB = parser.add_argument_group('CALCULATE ACTIVITY FROM KNOWN INVERSIONS?', "This input option is ONLY relevant to those who have "
+                    "already run the entire workflow and have their consensus inversions (i.e., 'CONSENSUS-INVERSIONS.txt') or "
+                    "sample-specific inversions (i.e., 'INVERSIONS-IN-[SAMPLE-NAME].txt') calculated. This input option will "
+                    "use the existing inversions reported in the input file and recalculate the inversion activity output. It is "
+                    "a great way to calculate inversions or refine them from a smaller set of genomes / metagenomes, and scale "
+                    "up the characterizations of their activity to thousansds of metagenomes quickly (*chough* cheater *chough*). "
+                    "Please note that if you use this flag, most other options EXCEPT those that are listed below 'KEY ALGORITHMIC "
+                    "COMPONENT 04: COMPUTING INVERSION ACTIVITY' will be irrelevant, so you can skip all and take a look at the "
+                    "parameters there.")
+    groupB.add_argument(*anvio.A('pre-computed-inversions'), **anvio.K('pre-computed-inversions'))
+
+    groupC = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 01: IDENTIFYING REGIONS OF INTERSET', "How should anvi'o identify regions of interest "
                     "based on REV/REV and FWD/FWD paired-end reads? Defaults will be good for most cases.")
-    groupB.add_argument('--min-coverage-to-define-stretches', default=10, type=int, help="Value to break up contigs into 'stretches' of "
+    groupC.add_argument('--min-coverage-to-define-stretches', default=10, type=int, help="Value to break up contigs into 'stretches' of "
                     "high-coverage regions of FWD/FWD and REV/REV reads. The lower the value, the more noise. This acts as a low-pass "
                     "filter if it helps you imagine how it works.", metavar="INT")
-    groupB.add_argument('--min-stretch-length', default=50, type=int, help="These are not the stretches you are looking for (unless they "
+    groupC.add_argument('--min-stretch-length', default=50, type=int, help="These are not the stretches you are looking for (unless they "
                     "are longer than this, obv).", metavar="INT")
-    groupB.add_argument('--min-distance-between-independent-stretches', default=2000, type=int, help="Our 'low pass' filter may break a "
+    groupC.add_argument('--min-distance-between-independent-stretches', default=2000, type=int, help="Our 'low pass' filter may break a "
                     "single stretch of reasonable coverage of FWD/FWD and REV/REV reads into multiple pieces. To recover from that, we "
                     "wish to merge the fragmented ones if they are closer to one another than this value.", metavar="INT")
-    groupB.add_argument('--num-nts-to-pad-a-stretch', default=100, type=int, help="Some leeway towards upstream and downstream context "
+    groupC.add_argument('--num-nts-to-pad-a-stretch', default=100, type=int, help="Some leeway towards upstream and downstream context "
                     "that is essential to not miss key information due to coverage variation that may influence the beginnings and ends "
                     "of final stretches.", metavar="INT")
 
-    groupC = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 02: FINDING PALINDROMES', "Some essential parameters to find palindromes in sequence "
+    groupD = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 02: FINDING PALINDROMES', "Some essential parameters to find palindromes in sequence "
                     "stretches anvi'o identified in the previous step")
-    groupC.add_argument(*anvio.A('min-palindrome-length'), **anvio.K('min-palindrome-length'))
-    groupC.add_argument(*anvio.A('max-num-mismatches'), **anvio.K('max-num-mismatches'))
-    groupC.add_argument(*anvio.A('min-distance'), **anvio.K('min-distance'))
-    groupC.add_argument(*anvio.A('min-mismatch-distance-to-first-base'), **anvio.K('min-mismatch-distance-to-first-base'))
-    groupC.add_argument(*anvio.A('palindrome-search-algorithm'), **anvio.K('palindrome-search-algorithm'))
+    groupD.add_argument(*anvio.A('min-palindrome-length'), **anvio.K('min-palindrome-length'))
+    groupD.add_argument(*anvio.A('max-num-mismatches'), **anvio.K('max-num-mismatches'))
+    groupD.add_argument(*anvio.A('min-distance'), **anvio.K('min-distance'))
+    groupD.add_argument(*anvio.A('min-mismatch-distance-to-first-base'), **anvio.K('min-mismatch-distance-to-first-base'))
+    groupD.add_argument(*anvio.A('palindrome-search-algorithm'), **anvio.K('palindrome-search-algorithm'))
 
-    groupD = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 03: CONFIRMING INVERSIONS', "Which palindromes are inversions? A one million dollar "
+    groupE = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 03: CONFIRMING INVERSIONS', "Which palindromes are inversions? A one million dollar "
                     "question that is quite difficult to get right (but as anvi'o does get it right frequently).")
-    groupD.add_argument('--check-all-palindromes', default=False, action="store_true", help="In a given 'stretch' "
+    groupE.add_argument('--check-all-palindromes', default=False, action="store_true", help="In a given 'stretch' "
                     "anvi'o has identified as a region of interest due to the coverage of FWD/FWD and REV/REV reads "
                     "(see KEY ALGORITHMIC COMPONENT 01), there may be multiple palindromic sequences. By default, "
                     "anvi'o will stop its search as soon as it finds evidence among short reads in the BAM file "
@@ -67,7 +78,7 @@ if __name__ == '__main__':
                     "are multiple inversions in a single stretch, which is extremely unlikely. But using this this "
                     "you can instruct anvi'o to test ALL palindromes in a stretch. We understand -- we are "
                     "unreasonable people, too.")
-    groupD.add_argument('--process-only-inverted-reads', default=False, action="store_true", help="At one point, "
+    groupE.add_argument('--process-only-inverted-reads', default=False, action="store_true", help="At one point, "
                     "anvi'o will have all the regions of interest in contigs that include palindromes that look "
                     "promising. At that point, it will access to short reads in the BAM file to determine which "
                     "palindromes in fact represent active inversions by searching for unique constructs that "
@@ -84,13 +95,13 @@ if __name__ == '__main__':
                     "paired-end reads and assert your authority. You do you and turn on the flag, you rebellious "
                     "scientist who will likely miss a lot of additoinal inversions like a boss.")
 
-    groupE = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 04: COMPUTING INVERSION ACTIVITY', "What is the "
+    groupF = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 04: COMPUTING INVERSION ACTIVITY', "What is the "
                     "proportion of invertible repeat orientation across samples? A two million dollars question "
                     "that anvi'o WILL answer for you IF you have `r1` and `r2` columns in your `bams-and-profiles-txt` "
                     "file that points to raw FASTQ reads you have used to generate your BAM files for each sample. "
                     "Truly cray stuff.")
-    groupE.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
-    groupE.add_argument('--oligo-primer-base-length', default=12, type=int, help="Calculating inversion ratios "
+    groupF.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
+    groupF.add_argument('--oligo-primer-base-length', default=12, type=int, help="Calculating inversion ratios "
                     "require anvi'o to 'design' an in silico primer based on palindromes associated with inersions "
                     "and the upstream/downstream genomic context to search for short reads in raw sequenicng data"
                     "to find the ratio of inversion activity per sample. This variable is to control how much of "
@@ -99,46 +110,46 @@ if __name__ == '__main__':
                     "if it is too long, then there will not be enough reads to 'keep' depending on the minimum "
                     "short read length of the sequencing. The default value will probably good for the vast "
                     "majority of cases.", metavar="INT")
-    groupE.add_argument('--skip-compute-inversion-activity', default=False, action="store_true", help="This flag "
+    groupF.add_argument('--skip-compute-inversion-activity', default=False, action="store_true", help="This flag "
                     "will help you skip computing inversion activity, which is an extremely costly step, even if "
                     "your `bams-and-profiles-txt` contains `r1` and `r2` entries. It may be a good idea to first "
                     "run the workflow without computing activity, take a look at the CONSENSUS file to make sure "
                     "everything looks alright, and then run the workflow without this flag.")
-    groupE.add_argument('--end-primer-search-after-x-hits', default=None, type=int, help="For very large "
+    groupF.add_argument('--end-primer-search-after-x-hits', default=None, type=int, help="For very large "
                     "datasets, primer search can take a very long time. By setting a small integer here, you can ask "
                     "anvi'o to stop searching primers after a few hits. Once the total number of primer hits reach to "
                     "number for a given sample, anvi'o will stop searching further and continue with the next sample. "
                     "This flag is only good for testing, since it will prematurely end the search without testting "
                     "all primers")
 
-    groupF = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 05: REPORTING GENOMIC CONTEXT AROUND INVERSIONS',
+    groupG = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 05: REPORTING GENOMIC CONTEXT AROUND INVERSIONS',
                     "Once the consensus inversions are computed, anvi'o can go back to contigs on which they are "
                     "found, and for each inversion site report the surrounding genes and their functions as flat "
                     "text files in the output directory so you can actually take quick look at them.")
-    groupF.add_argument('--skip-recovering-genomic-context', default=False, action="store_true", help="Of course "
+    groupG.add_argument('--skip-recovering-genomic-context', default=False, action="store_true", help="Of course "
                     "you can skip this step because why should anyone have nice things.")
-    groupF.add_argument('--num-genes-to-consider-in-context', default=3, type=int, help="With this parameter you "
+    groupG.add_argument('--num-genes-to-consider-in-context', default=3, type=int, help="With this parameter you "
                     "can adjust the number of genes anvi'o should consider to characterize the genomic context "
                     "surrounding inversions. If you set nothing here, anvi'o will go 3 genes upstream from the "
                     "first palindrome of the inversion and 3 genes downstream from the second. If there are not "
                     "enough genes in the contig given the position of either of the palindromes, anvio' will "
                     "report whatever it can.", metavar="INT")
-    groupF.add_argument(*anvio.A('gene-caller'), **anvio.K('gene-caller', {'help': "The gene caller to show gene calls "
+    groupG.add_argument(*anvio.A('gene-caller'), **anvio.K('gene-caller', {'help': "The gene caller to show gene calls "
                     "from."}))
 
 
-    groupG = parser.add_argument_group('TARGETED SEARCH & PROCESSING', "By default anvi'o process every region of every "
+    groupH = parser.add_argument_group('TARGETED SEARCH & PROCESSING', "By default anvi'o process every region of every "
                     "contig it is given. Using the following three parameters, you can limit your search to a particular "
                     "contig, start position, or end position. You can use ANY COMBINATION of these three. For instance, "
                     "if you focus on a particular contig only, all regions identified in it by FWD/FWD or REV/REV reads. "
                     "You can limit the search space on that contig using target region start and end parameters.")
-    groupG.add_argument(*anvio.A('verbose'), **anvio.K('verbose'))
-    groupG.add_argument(*anvio.A('target-contig'), **anvio.K('target-contig'))
-    groupG.add_argument(*anvio.A('target-region-start'), **anvio.K('target-region-start'))
-    groupG.add_argument(*anvio.A('target-region-end'), **anvio.K('target-region-end'))
+    groupH.add_argument(*anvio.A('verbose'), **anvio.K('verbose'))
+    groupH.add_argument(*anvio.A('target-contig'), **anvio.K('target-contig'))
+    groupH.add_argument(*anvio.A('target-region-start'), **anvio.K('target-region-start'))
+    groupH.add_argument(*anvio.A('target-region-end'), **anvio.K('target-region-end'))
 
-    groupG = parser.add_argument_group('OUTPUT DIRECTORY', "Where to put all the output files.")
-    groupG.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir'))
+    groupH = parser.add_argument_group('OUTPUT DIRECTORY', "Where to put all the output files.")
+    groupH.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir'))
 
     args = parser.get_args(parser)
 


### PR DESCRIPTION
This PR adds a new flag to the program `anvi-report-inversions`, `--pre-computed-inversions`, which takes in a previously reported inversions file, and calculates their activity. The help menu explains it:


```
CALCULATE ACTIVITY FROM KNOWN INVERSIONS?
  This input option is ONLY relevant to those who have already run the
  entire workflow and have their consensus inversions (i.e., 'CONSENSUS-
  INVERSIONS.txt') or sample-specific inversions (i.e., 'INVERSIONS-
  IN-[SAMPLE-NAME].txt') calculated. This input option will use the existing
  inversions reported in the input file and recalculate the inversion
  activity output. It is a great way to calculate inversions or refine them
  from a smaller set of genomes / metagenomes, and scale up the
  characterizations of their activity to thousands of metagenomes quickly
  (*cough* cheater *cough*). Please note that if you use this flag, most
  other options EXCEPT those that are listed below 'KEY ALGORITHMIC
  COMPONENT 04: COMPUTING INVERSION ACTIVITY' will be irrelevant, so you can
  skip all and take a look at the parameters there.

  --pre-computed-inversions INVERSIONS-FILE
                        A TAB-delimited file that lists sample-specific or
                        consensus inversions identified by the program `anvi-
                        report-inversions`. (default: None)
```

The PR does **NOT** include an update to the [help docs for the program](https://anvio.org/help/main/programs/anvi-report-inversions/), but we need to update the section "Computing inversion activity".