### PR TITLE
Add checksum checking for NCI downloads in `anvi-setup-ncbi-cogs`

### DIFF
--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -853,7 +853,7 @@ class COGsSetup:
         checksums = {}
         for line in open(input_file_path, 'rU').readlines():
             stripped = line.strip('\n').split(' ')
-            file_name = stripped[-1].strip('*')[-1]
+            file_name = stripped[-1].strip('*')
             checksums[file_name] = stripped[0]
 
         # Print warning if checksums are not provided by NCBI
@@ -868,6 +868,11 @@ class COGsSetup:
             # Check file exists
             if not os.path.exists(file_path):
                 raise ConfigError("Something is wrong :/ Raw files are not in place...")
+
+            # Check file present in checksum
+            if not file_name in checksums.keys():
+                self.run.warning(f"The file {file_name} is not present in the checksum file. You should be able to" 
+                                 f"continue despite this, but it is not expected.")
 
             # Check checksum
             if self.COG_version == 'COG20' and file_name != "checksum.md5.txt":

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -853,7 +853,7 @@ class COGsSetup:
         checksums = {}
         for line in open(input_file_path, 'rU').readlines():
             stripped = line.strip('\n').split(' ')
-            file_name = stripped[-1]
+            file_name = stripped[-1].strip('*')[-1]
             checksums[file_name] = stripped[0]
 
         # Print warning if checksums are not provided by NCBI

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -870,8 +870,8 @@ class COGsSetup:
                 raise ConfigError("Something is wrong :/ Raw files are not in place...")
 
             # Check checksum
-            if self.COG_version == 'COG20':
-                if not hashlib.md5(open(file_path, "rU").read()).hexdigest() == checksums[file_name]:
+            if self.COG_version == 'COG20' and file_name != "checksum.md5.txt":
+                if not hashlib.md5(open(file_path, "rb").read()).hexdigest() == checksums[file_name]:
                     raise ConfigError(
                         f"Something is wrong :/ The checksum of {file_name} does not match the checksum provided by NCBI. "
                         f"This is most likely due to an interrupted download. NCBI server often interrupt downloads midway."

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -834,7 +834,7 @@ class COGsSetup:
 
     def setup_raw_data(self):
         # Check hash of downloaded files before any setup
-        self.check_raw_data_hash(J(self.raw_NCBI_files_dir, "checksum.md5.txt"),
+        self.check_raw_data_hash_and_existence(J(self.raw_NCBI_files_dir, "checksum.md5.txt"),
                             J(self.COG_data_dir, self.files["checksum.md5.txt"]['formatted_file_name']))
 
         for file_name in self.files:
@@ -845,7 +845,7 @@ class COGsSetup:
 
             self.files[file_name]['func'](file_path, J(self.COG_data_dir, self.files[file_name]['formatted_file_name']))
 
-    def check_raw_data_hash(self, input_file_path, output_file_path):
+    def check_raw_data_hash_and_existence(self, input_file_path, output_file_path):
         """Checks the cheksum of each downloaded file to ensure succesful download."""
         progress.new('Checking checksums and file existence')
 
@@ -871,7 +871,7 @@ class COGsSetup:
 
             # Check checksum
             if self.COG_version == 'COG20':
-                if not hashlib.md5(file_path) == checksums[file_name]:
+                if not hashlib.md5(open(file_path, "rU").read()).hexdigest() == checksums[file_name]:
                     raise ConfigError(
                         f"Something is wrong :/ The checksum of {file_name} does not match the checksum provided by NCBI. "
                         f"This is most likely due to an interrupted download. NCBI server often interrupt downloads midway."

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -493,7 +493,7 @@ class COGsSetup:
                                   'formatted_file_name': 'CATEGORIES.txt'},
                               'checksum.md5.txt': {
                                    'url': 'ftp://ftp.ncbi.nih.gov//pub/COG/COG2020/data/checksums.md5.txt',
-                                   'func': None,
+                                   'func': self.check_cog_hash,
                                    'type': 'essential',
                                    'formatted_file_name': 'CHECKSUMS.txt'},
                               'cog-20.fa.gz': {
@@ -759,10 +759,6 @@ class COGsSetup:
 
 
     def format_protein_db(self, input_file_path, output_file_path):
-        # Check hash of download DB
-        essential_file_paths = self.get_essential_file_paths()
-        self.check_cog_hash(essential_file_paths['CHECKSUMS.txt'], None)
-
         progress.new('Formatting raw files')
         progress.update('Decompressing protein sequences')
 
@@ -864,6 +860,10 @@ class COGsSetup:
 
 
     def setup_raw_data(self):
+        # Check hash of downloaded files before any setup
+        self.check_cog_hash(J(self.raw_NCBI_files_dir, "checksum.md5.txt"),
+                            J(self.COG_data_dir, self.files["checksum.md5.txt"]['formatted_file_name']))
+
         for file_name in self.files:
             file_path = J(self.raw_NCBI_files_dir, file_name)
 
@@ -873,4 +873,6 @@ class COGsSetup:
             if not os.path.exists(file_path):
                 raise ConfigError("Something is wrong :/ Raw files are not in place...")
 
+            if file_path == "checksum.md5.txt":
+                continue
             self.files[file_name]['func'](file_path, J(self.COG_data_dir, self.files[file_name]['formatted_file_name']))

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -873,7 +873,7 @@ class COGsSetup:
             if self.COG_version == 'COG20' and file_name != "checksum.md5.txt":
                 if not hashlib.md5(open(file_path, "rb").read()).hexdigest() == checksums[file_name]:
                     raise ConfigError(
-                        f"Something is wrong :/ The checksum of {file_name} does not match the checksum provided by NCBI. "
+                        f"Error. The checksum of {file_name} does not match the checksum provided by NCBI. "
                         f"This is most likely due to an interrupted download. NCBI server often interrupt downloads midway."
                         f" Please try again with the --reset flag.")
 

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -871,7 +871,7 @@ class COGsSetup:
 
             # Check file present in checksum
             if not file_name in checksums.keys() and file_name != "checksum.md5.txt":
-                self.run.warning(f"The file {file_name} is not present in the checksum file. You should be able to" 
+                self.run.warning(f"The file {file_name} is not present in the checksum file. You should be able to " 
                                  f"continue despite this, but it is not expected.")
 
             # Check checksum

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -870,7 +870,7 @@ class COGsSetup:
                 raise ConfigError("Something is wrong :/ Raw files are not in place...")
 
             # Check file present in checksum
-            if not file_name in checksums.keys():
+            if not file_name in checksums.keys() and file_name != "checksum.md5.txt":
                 self.run.warning(f"The file {file_name} is not present in the checksum file. You should be able to" 
                                  f"continue despite this, but it is not expected.")
 

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -491,18 +491,18 @@ class COGsSetup:
                                   'func': self.format_categories,
                                   'type': 'essential',
                                   'formatted_file_name': 'CATEGORIES.txt'},
+                              'checksum.md5.txt': {
+                                   'url': 'ftp://ftp.ncbi.nih.gov//pub/COG/COG2020/data/checksums.md5.txt',
+                                   'func': None,
+                                   'type': 'essential',
+                                   'formatted_file_name': 'CHECKSUMS.txt'},
                               'cog-20.fa.gz': {
                                   'url': 'ftp://ftp.ncbi.nih.gov/pub/COG/COG2020/data/cog-20.fa.gz',
                                   'func': self.format_protein_db,
                                   'type': 'database',
                                   'formatted_file_name': 'IGNORE_THIS_AND_SEE_THE_FUNCTION'},
-                              'checksum.md5.txt': {
-                                  'url': 'ftp://ftp.ncbi.nih.gov//pub/COG/COG2020/data/checksums.md5.txt',
-                                  'func': self.check_hash,
-                                  'type': 'essential',
-                                  'formatted_file_name': 'checksums.txt'}
                              },
-                            },
+                        }
 
         A = lambda x: args.__dict__[x] if x in args.__dict__ else None
         self.num_threads = A('num_threads') or 1
@@ -759,6 +759,10 @@ class COGsSetup:
 
 
     def format_protein_db(self, input_file_path, output_file_path):
+        # Check hash of download DB
+        essential_file_paths = self.get_essential_file_paths()
+        self.check_cog_hash(essential_file_paths['CHECKSUMS.txt'], None)
+
         progress.new('Formatting raw files')
         progress.update('Decompressing protein sequences')
 


### PR DESCRIPTION
I added checksum verification to `anvi-setup-ncbi-cogs`. If fails, it prints an error. This handles the fact that `COG2014` does not have a checksum file as well. This feature is to handle the incorrect downloads often placing this command due to NCBI servers. See #1738. 

While not added here, I find it surprising that the function `download_file` in `utils.py` does not ever check if `file_size == downloaded_size`. I leave it up to the maintainer to determine if that check is necessary, or if it exists elsewhere. 

PS: I was able to test both successful and unsuccesful.