### PR TITLE
Searching for motifs in inverted repeats

### DIFF
--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -958,7 +958,7 @@ class Inversions:
             # get start and stop of IRs + 20bp on each side
             first_start = entry['first_start'] - 20
             first_end = entry['first_end'] + 20
-            second_start = entry['second_end'] - 20
+            second_start = entry['second_start'] - 20
             second_end = entry['second_end'] + 20
 
             contig_sequence = self.contig_sequences[contig_name]['sequence']

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -977,10 +977,10 @@ class Inversions:
             meme_log = os.path.join(output, "run-MEME.log")
 
             with open(fasta_path, 'w') as file:
-                file.write('>{inverion_id}_first_IR\n' + first_IR + '\n'
-                           '>{inverion_id}_first_IR_rc\n' + first_IR_rc + '\n'
-                           '>{inverion_id}_second_IR\n' + second_IR + '\n'
-                           '>{inverion_id}_second_IR_rc\n' + second_IR_rc + '\n')
+                file.write(f'>{inversion_id}_first_IR\n' + first_IR + '\n'
+                           f'>{inversion_id}_first_IR_rc\n' + first_IR_rc + '\n'
+                           f'>{inversion_id}_second_IR\n' + second_IR + '\n'
+                           f'>{inversion_id}_second_IR_rc\n' + second_IR_rc + '\n')
 
             self.use_motif_finder(fasta_path, meme_output, meme_log, num_motifs = "3")
 

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -124,7 +124,10 @@ class Inversions:
         self.skip_recovering_genomic_context = A('skip_recovering_genomic_context')
         self.gene_caller_to_consider_in_context = A('gene_caller') or 'prodigal'
         self.num_genes_to_consider_in_context = A('num_genes_to_consider_in_context') or 3
+
+        # paramters for motif search
         self.skip_search_for_motifs = A('skip_search_for_motifs')
+        self.num_of_motifs = A('num_of_motifs')
 
         # be talkative or not
         self.verbose = A('verbose')
@@ -949,6 +952,10 @@ class Inversions:
         if self.skip_search_for_motifs:
             return
 
+        # how many motifs should we look for?
+        if not self.num_of_motifs:
+            self.num_of_motifs = len(self.consensus_inversions)
+
         # for each inversion, run MEME with num_motifs = 3
         individual_fasta_paths = []
         for entry in self.consensus_inversions:
@@ -1001,7 +1008,7 @@ class Inversions:
                         file.write(line)
 
         # search for as many motifs as inversions. Can be time consuming.
-        self.use_motif_finder(fasta_path, meme_output, meme_log, num_motifs = len(self.consensus_inversions))
+        self.use_motif_finder(fasta_path, meme_output, meme_log, num_motifs = self.num_of_motifs)
 
         self.run.info('Reporting motifs in inverted repeats', output, nl_after=1)
 

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -971,7 +971,6 @@ class Inversions:
 
             # create output dir and files
             output = os.path.join(self.output_directory, "PER_INV", inversion_id)
-            filesnpaths.gen_output_directory(output)
             fasta_path = os.path.join(output, "inverted_repeats.fasta")
             meme_output = os.path.join(output, "MEME")
             meme_log = os.path.join(output, "run-MEME.log")
@@ -1543,20 +1542,22 @@ class Inversions:
             return
 
         # we are in business
-        genes_output_path = os.path.join(self.output_directory, 'INVERSIONS-CONSENSUS-SURROUNDING-GENES.txt')
-        functions_output_path = os.path.join(self.output_directory, 'INVERSIONS-CONSENSUS-SURROUNDING-FUNCTIONS.txt')
-
         genes_output_headers = ["gene_callers_id", "start", "stop", "direction", "partial", "call_type", "source", "version", "contig"]
         functions_output_headers = ["gene_callers_id", "source", 'accession', 'function']
 
-        with open(genes_output_path, 'w') as genes_output, open(functions_output_path, 'w') as functions_output:
-            genes_output.write("inversion_id\tentry_type\t%s\n" % '\t'.join(genes_output_headers))
-            functions_output.write("inversion_id\t%s\n" % '\t'.join(functions_output_headers))
+        for v in self.consensus_inversions:
+            # this is the inversion id we are working with here:
+            inversion_id = v['inversion_id']
 
-            for v in self.consensus_inversions:
+            # create ouput directory
+            filesnpaths.gen_output_directory(os.path.join(self.output_directory, "PER_INV", inversion_id))
 
-                # this is the inversion id we are working with here:
-                inversion_id = v['inversion_id']
+            genes_output_path = os.path.join(self.output_directory, 'PER_INV', inversion_id, 'SURROUNDING-GENES.txt')
+            functions_output_path = os.path.join(self.output_directory, 'PER_INV', inversion_id, 'SURROUNDING-FUNCTIONS.txt')
+
+            with open(genes_output_path, 'w') as genes_output, open(functions_output_path, 'w') as functions_output:
+                genes_output.write("inversion_id\tentry_type\t%s\n" % '\t'.join(genes_output_headers))
+                functions_output.write("inversion_id\t%s\n" % '\t'.join(functions_output_headers))
 
                 # but we will first create fake gene call entries for inversions:
                 d = dict([(h, '') for h in genes_output_headers])
@@ -1586,5 +1587,5 @@ class Inversions:
                     else:
                         functions_output.write(f"{inversion_id}\t{gene_call['gene_callers_id']}\t\t\t\n")
 
-        self.run.info('Reporting file on gene context', genes_output_path)
-        self.run.info('Reporting file on functional context', functions_output_path, nl_after=1)
+            self.run.info('Reporting file on gene context', genes_output_path)
+            self.run.info('Reporting file on functional context', functions_output_path, nl_after=1)

--- a/anvio/tests/run_component_tests_for_inversions.sh
+++ b/anvio/tests/run_component_tests_for_inversions.sh
@@ -92,3 +92,10 @@ anvi-report-inversions -P bams-and-profiles.txt \
                        -m 1 \
                        --process-only-inverted-reads \
                        --quiet
+
+INFO "Running the analysis and searching for only one motif (quietly)"
+anvi-report-inversions -P bams-and-profiles.txt \
+                       -o INVERSION_ONE_MOTIF \
+                       -m 1 \
+                       --num-of-motifs 1 \
+                       --quiet

--- a/anvio/tests/run_component_tests_for_inversions.sh
+++ b/anvio/tests/run_component_tests_for_inversions.sh
@@ -29,10 +29,11 @@ INFO "Running the base analysis (without reporting the activity or genomic conte
 anvi-report-inversions -P bams-and-profiles.txt \
                        -o INVERSION_BASIC \
                        --skip-compute-inversion-activity \
-                       --skip-recovering-genomic-context
+                       --skip-recovering-genomic-context \
+                       --skip-search-for-motifs
 
 SHOW_FILE INVERSION_BASIC/INVERSIONS-CONSENSUS.txt
-SHOW_FILE INVERSION_BASIC/INVERSIONS-IN-S01.txt
+SHOW_FILE INVERSION_BASIC/PER_SAMPLE/INVERSIONS-IN-S01.txt
 SHOW_FILE INVERSION_BASIC/ALL-STRETCHES-CONSIDERED.txt
 
 INFO "Running the analysis with 1 mismatch allowed in palindromes"
@@ -40,7 +41,8 @@ anvi-report-inversions -P bams-and-profiles.txt \
                        -o INVERSION_MISMATCH \
                        -m 1 \
                        --skip-compute-inversion-activity \
-                       --skip-recovering-genomic-context
+                       --skip-recovering-genomic-context \
+                       --skip-search-for-motifs
 
 SHOW_FILE INVERSION_MISMATCH/INVERSIONS-CONSENSUS.txt
 
@@ -50,7 +52,8 @@ anvi-report-inversions -P bams-and-profiles.txt \
                        -m 1 \
                        --palindrome-search-algorithm BLAST \
                        --skip-compute-inversion-activity \
-                       --skip-recovering-genomic-context
+                       --skip-recovering-genomic-context \
+                       --skip-search-for-motifs
 
 INFO "Running the complete analysis (with --verbose)"
 anvi-report-inversions -P bams-and-profiles.txt \
@@ -59,8 +62,8 @@ anvi-report-inversions -P bams-and-profiles.txt \
                        --verbose
 
 SHOW_FILE INVERSION_COMPLETE/INVERSION-ACTIVITY.txt
-SHOW_FILE INVERSION_COMPLETE/INVERSIONS-CONSENSUS-SURROUNDING-FUNCTIONS.txt
-SHOW_FILE INVERSION_COMPLETE/INVERSIONS-CONSENSUS-SURROUNDING-GENES.txt
+SHOW_FILE INVERSION_COMPLETE/PER_INV/INV_0001/SURROUNDING-FUNCTIONS.txt
+SHOW_FILE INVERSION_COMPLETE/PER_INV/INV_0001/SURROUNDING-GENES.txt
 
 INFO "Re-computing inversion activity using previous results (quietly)"
 anvi-report-inversions -P bams-and-profiles.txt \

--- a/bin/anvi-report-inversions
+++ b/bin/anvi-report-inversions
@@ -136,7 +136,8 @@ if __name__ == '__main__':
                     "report whatever it can.", metavar="INT")
     groupG.add_argument(*anvio.A('gene-caller'), **anvio.K('gene-caller', {'help': "The gene caller to show gene calls "
                     "from."}))
-
+    groupG.add_argument('--skip-search-for-motifs', default=False, action="store_true", help="Skip the search for "
+                    "conserved motifs in inverted repeats.")
 
     groupH = parser.add_argument_group('TARGETED SEARCH & PROCESSING', "By default anvi'o process every region of every "
                     "contig it is given. Using the following three parameters, you can limit your search to a particular "

--- a/bin/anvi-report-inversions
+++ b/bin/anvi-report-inversions
@@ -136,8 +136,17 @@ if __name__ == '__main__':
                     "report whatever it can.", metavar="INT")
     groupG.add_argument(*anvio.A('gene-caller'), **anvio.K('gene-caller', {'help': "The gene caller to show gene calls "
                     "from."}))
-    groupG.add_argument('--skip-search-for-motifs', default=False, action="store_true", help="Skip the search for "
+    
+    groupM = parser.add_argument_group('KEY ALGORITHMIC COMPONENT 06: FINDING MOTIFS IN INVERTED REPEATS',
+                    "Site-specific inversions are carried out by site-specific recombinases which recognize "
+                    "imperfect palindromic sequences on each end of an inversion. They appear as a single pair "
+                    "of inverted repeats, the one anvi'o report in the consensus output. We can use DNA motif search "
+                    "to connect inversions that are potentially inverted by the same site-specific recombinase.")
+    groupM.add_argument('--skip-search-for-motifs', default=False, action="store_true", help="Skip the search for "
                     "conserved motifs in inverted repeats.")
+    groupM.add_argument('--num-of-motifs', default=None, type=int, help="By default anvi'o will search for as many motifs as "
+                    "inversions. It can be time consuming if you have a lot of inversions. You can use that flag to "
+                    "search for less motifs.", metavar="INT")
 
     groupH = parser.add_argument_group('TARGETED SEARCH & PROCESSING', "By default anvi'o process every region of every "
                     "contig it is given. Using the following three parameters, you can limit your search to a particular "


### PR DESCRIPTION
I have added some functions to anvi-report-inversions to use MEME and search for DNA motifs in the inverted repeats surrounding the inversions. 

To do that, I needed to create a fasta file for each inversions. In that fasta, there are 4 sequences: the left and right inverted repeat (padded with 20bp) and their reverse complement. The motif search is constrained to palindromic motifs only. Works like a charm to find site-specific recombinase DNA binding site. 

I have also re-organised the output directory as follow:

```
|-- ALL-STRETCHES-CONSIDERED.txt
|-- INVERSION-ACTIVITY.txt
|-- INVERSIONS-CONSENSUS.txt
|-- PER_INV
|   |-- ALL_INVERSIONS
|   |   |-- MEME
|   |   |   |-- logo1.eps
|   |   |   |-- [...]
|   |   |   |-- logo_rc2.png
|   |   |   |-- meme.html
|   |   |   |-- meme.txt
|   |   |   `-- meme.xml
|   |   |-- inverted_repeats.fasta
|   |   `-- run-MEME.log
|   |-- INV_0001
|   |   |-- MEME
|   |   |   |-- logo1.eps
|   |   |   |-- [...]
|   |   |   |-- logo_rc3.png
|   |   |   |-- meme.html
|   |   |   |-- meme.txt
|   |   |   `-- meme.xml
|   |   |-- SURROUNDING-FUNCTIONS.txt
|   |   |-- SURROUNDING-GENES.txt
|   |   |-- inverted_repeats.fasta
|   |   `-- run-MEME.log
|   `-- INV_0002
|       |-- MEME
|       |   |-- logo1.eps
|       |   |-- [..]
|       |   |-- logo_rc3.png
|       |   |-- meme.html
|       |   |-- meme.txt
|       |   `-- meme.xml
|       |-- SURROUNDING-FUNCTIONS.txt
|       |-- SURROUNDING-GENES.txt
|       |-- inverted_repeats.fasta
|       `-- run-MEME.log
`-- PER_SAMPLE
    |-- INVERSIONS-IN-S01.txt
    |-- INVERSIONS-IN-S02.txt
    `-- INVERSIONS-IN-S03.txt
```

We used to have a single `SURROUNDING-FUNCTIONS.txt` and `SURROUNDING-GENES.txt` for all inversions. I split them per inversion. 

The motif search is for for each inversion, and also by pooling all inversion (that's how you find which are linked together by the same recombinase). 

At this moment, there is no need for a dedicated MEME driver. But it is possible that we will eventually need one that will include functions to parse MEME outputs, especially to generate an html output. And of course if we want to use MEME elsewhere in anvi'o. 

If you want to test it, you need to have MEME installed in your anvi'o installation. You will maybe need to reinstall anvi'o and add meme in your list of conda package. 