### PR TITLE
Fix overinflated stepwise copy number values from multiple annotations on same gene

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -4568,7 +4568,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         return contains_indirect
 
     
-    def get_dereplicated_enzyme_hits_for_step_in_module(self, meta_dict_for_mnum: dict, step_to_focus_on: str):
+    def get_dereplicated_enzyme_hits_for_step_in_module(self, meta_dict_for_mnum: dict, step_to_focus_on: str, mnum: str):
         """This function returns a dictionary of enzyme accessions matched to the number of hits, with duplicate hits to the 
         same gene removed, for the provided step in a metabolic pathway.
 
@@ -4581,6 +4581,8 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             metabolism completeness dict for the current bin and metabolic module
         step_to_focus_on : string
             which step in the module to resolve alternative enzymes for, passed as a definition string for the step.
+        mnum : string
+            module ID (used only for warning output)
         
         RETURNS
         =======
@@ -4609,13 +4611,13 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
                     enz_str = ", ".join(enzymes)
                     self.run.warning(f"The gene call {gcid} has multiple annotations to alternative enzymes "
                                      f"within the same step of a metabolic pathway ({enz_str}), and these enzymes "
-                                     f"unfortunately have a complex relationship. We don't know the pathway ID, but "
+                                     f"unfortunately have a complex relationship. The affected module is {mnum}, and "
                                      f"here is the step in question: {step_to_focus_on}. We arbitrarily kept only one of "
                                      f"the annotations to this gene in order to avoid inflating the step's copy number, "
                                      f"but due to the complex relationship between these alternatives, this could mean "
                                      f"that the copy number for this step is actually too low. Please heed this warning "
-                                     f"and double check the stepwise copy number results for pathways containing gene call "
-                                     f"{gcid}.")
+                                     f"and double check the stepwise copy number results for {mnum} and other pathways "
+                                     f"containing gene call {gcid}.")
 
         return derep_enzyme_hits
 
@@ -4645,7 +4647,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         for key in meta_dict_for_bin[mnum]["top_level_step_info"]:
             if not meta_dict_for_bin[mnum]["top_level_step_info"][key]["includes_modules"]:
                 step_string = meta_dict_for_bin[mnum]["top_level_step_info"][key]["step_definition"]
-                enzyme_hits_dict = self.get_dereplicated_enzyme_hits_for_step_in_module(meta_dict_for_bin[mnum], step_string)
+                enzyme_hits_dict = self.get_dereplicated_enzyme_hits_for_step_in_module(meta_dict_for_bin[mnum], step_string, mnum)
 
                 step_copy_num = self.get_step_copy_number(step_string, enzyme_hits_dict)
                 meta_dict_for_bin[mnum]["top_level_step_info"][key]["copy_number"] = step_copy_num

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -4485,7 +4485,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
                 min_step_count = None
                 for s in and_splits:
                     s_count = self.get_step_copy_number(s, enzyme_hit_counts)
-                    if not min_step_count:
+                    if min_step_count is None:
                         min_step_count = s_count # make first step the minimum
                     min_step_count = min(min_step_count, s_count)
                 return min_step_count


### PR DESCRIPTION
This very simple PR fixes issue #2173 and another bug that I found along the way. The fix and its caveats are detailed in #2173, but to summarize:

- in most cases, multiple annotations to the same gene are direct alternatives in a given pathway, which means that we can arbitrarily keep one annotation and ignore the rest of them. This is what the new function `get_dereplicated_enzyme_hits_for_step_in_module()` does before each step's copy number is calculated from the annotation data.
- an edge case occurs when the multiple enzyme annotations to that one gene are in a more complex relationship with each other. The simplistic fix might undercount the step copy number in this case, depending on which enzyme annotation was arbitrarily kept for the dereplicated annotation set
- I couldn't figure out a better algorithm that handles the edge case properly, so I settled for warning the user about it instead
- the other new function `are_enzymes_indirect_alternatives_within_step` is used to detect the edge cases. It does NOT perfectly detect all indirect relationships between all enzymes in a step and should not be used generally for that purpose, but it works okay for the limited use-case of warning the user about specific overlapping annotations. See #2173 for an example warning.

In short, stepwise copy numbers will no longer be inflated when one gene has multiple annotations. In the worst case, they may be too low rather than too high.

Finally, there was another bug that was also contributing to the inflation of step copy numbers in some cases -- missing annotations for direct alternatives were not counted as 0s if they were the first out of all the alternatives to be considered. This and its fix are also described in #2173, and I will note that it is perhaps the more important of the two fixes because it was not obvious and it affected more modules (15, in my test data, compared to 8 for the multiple annotations bug).