### PR TITLE
Show user genomes with missing hmm-source

### DIFF
--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -216,8 +216,8 @@ class GenomeDescriptions(object):
                             genomes_missing_any.add(genome_name)
 
                 raise ConfigError(f"Bad news. {P('An HMM source', len(hmm_sources_missing), alt='Some HMM sources')} "
-                                  f"you really need ({', '.join(hmm_sources_missing)}) {P('is', len(hmm_sources_missing), alt='are')} "
-                                  f"missing from some of your contigs databases :/ Here is the list: [{', '.join(genomes_missing_any)}].")
+                                  f"you requested ({', '.join(hmm_sources_missing)}) {P('is', len(hmm_sources_missing), alt='are')} "
+                                  f"missing from {'all' if len(genomes_missing_any) == len(self.genomes) else 'some'} of your contigs databases :/ Here is the list: {', '.join(genomes_missing_any)}")
 
 
         return hmm_sources_in_all_genomes

--- a/anvio/tests/run_component_tests_for_metagenomics.sh
+++ b/anvio/tests/run_component_tests_for_metagenomics.sh
@@ -971,6 +971,11 @@ anvi-pan-genome -g $output_dir/TEST-GENOMES.db \
                 --description $output_dir/example_description.md \
                 --no-progress \
                 $thread_controller
+                
+INFO "Generating hmm-hits matrix"
+anvi-script-gen-hmm-hits-matrix-across-genomes -o $output_dir/TEST/GENOME_MATRIX.txt \
+                                               -e $output_dir/external-genomes.txt \
+                                               --hmm-source Bacteria_71 
 
 INFO "Testing anvi-analyze-synteny with default parameters using a pangenome for annotations"
 anvi-analyze-synteny -g $output_dir/TEST-GENOMES.db \

--- a/sandbox/anvi-script-gen-hmm-hits-matrix-across-genomes
+++ b/sandbox/anvi-script-gen-hmm-hits-matrix-across-genomes
@@ -33,10 +33,10 @@ def main(args):
     hmm_source = A('hmm_source') or set([])
     output_file_path = A('output_file')
 
-    s = hmmopswrapper.SequencesForHMMHitsWrapperForMultipleContigs(args, set([]))
-
     if not hmm_source:
         raise ConfigError("You need to declare an HMM source for this to work :/")
+
+    s = hmmopswrapper.SequencesForHMMHitsWrapperForMultipleContigs(args, hmm_sources=set([hmm_source]))
 
     HMM_sources_common_to_all = s.get_HMM_sources_common_to_all_genomes()
     if not len(HMM_sources_common_to_all):


### PR DESCRIPTION
This PR gives [anvi-script-gen-hmm-hits-matrix-across-genomes](https://anvio.org/help/main/programs/anvi-script-gen-hmm-hits-matrix-across-genomes/) a more informative error that tells users which genomes do not contain the hmm-source of interest. In the cases of a large `external-genomes.txt`, this will allow the user to quickly assess which genomes require the `anvi-run-hmms`.

You can reproduce the upgrade with the `metagenomics-full` component tests. (Comment out most of the component test script to isolate this test.)

```
anvi-self-test --suite metagenomics-full --output-dir metagenomics-full --force-overwrite

cd metagenomics-full

anvi-delete-hmms -c E_faecalis_6563.db --hmm-source Bacteria_71

$ anvi-script-gen-hmm-hits-matrix-across-genomes -o TEST/GENOME_MATRIX.txt 
                                               -e external-genomes.txt 
                                               --hmm-source Bacteria_71

Config Error: Bad news. An HMM source you requested (Bacteria_71) is missing from some of your
              contigs databases :/ Here is the list: E_faecalis_6563
```