### PR TITLE
Inversions activity issue

### DIFF
--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -938,18 +938,20 @@ class Inversions:
 
             for inversion_id in self.summary['inversions']:
                 for sample in self.summary['inversions'][inversion_id]['activity']:
-                    for inversion_id, activity in sum_freq.items():
-                        for oligo_primer, all_oligo in activity.items():
-                            ref_id = all_oligo['reference']
-                            previous_width = self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][ref_id]['width']
-                            for i, x in all_oligo['non_reference']:
-                                i_start = previous_width
-                                if i not in self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer]:
-                                    continue
-                                i_width = i_start + self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][i]['relative_frequency']*1000
-                                previous_width = i_width
-                                self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][i]['start'] = i_start
-                                self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][i]['width'] = i_width
+                    for oligo_primer, all_oligo in sum_freq[inversion_id].items():
+                        # check if oligo primer is found in the current sample
+                        if oligo_primer not in self.summary['inversions'][inversion_id]['activity'][sample]:
+                            continue
+                        ref_id = all_oligo['reference']
+                        previous_width = self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][ref_id]['width'];
+                        for i, x in all_oligo['non_reference']:
+                            i_start = previous_width
+                            if i not in self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer]:
+                                continue
+                            i_width = i_start + self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][i]['relative_frequency']*1000
+                            previous_width = i_width
+                            self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][i]['start'] = i_start
+                            self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][i]['width'] = i_width
 
         # add motif info
         if self.skip_search_for_motifs:

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -1423,7 +1423,7 @@ class Inversions:
                 # if the reference oligo has no frequency but reads were found for other oligo
                 # then add reference oligo with a frequency of 0
                 oligo_reference = primers_dict[primer_name]['oligo_reference']
-                if oligo_reference not in oligos_frequency_dict and reads_found:
+                if oligo_reference not in sample_counts and reads_found:
                     sample_counts.append((sample_name, primer_name, oligo_reference, True, 0, 0))
 
             output_queue.put(sample_counts)


### PR DESCRIPTION
I added a check if activity is missing for one oligo_primer (first or second).
The main fix is the second commit. We need to always have an entry for the reference oligo in the activity table. And if there is no activity (short reads) matching the reference oligo, we create an entry with frequency 0. We also have a filter with a min frequency value to report the activity (avoid very rare and likely irrelevant oligo). In rare cases, a ref oligo can have a frequency below the threshold and is not included in the final table, and no entry with frequency 0 is created. 
The html part of the code expect an entry for the ref oligo. I corrected and tested the fix and it works 🎉 