### PR TITLE
Filter HMM hits based on length

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1397,6 +1397,20 @@ D = {
              'type': str,
              'help': "Characters to separate things (the default is whatever is most suitable)."}
                 ),
+    'ignore-genes-longer-than': (
+            ['--ignore-genes-longer-than'],
+            {'metavar': 'MAX_LENGTH',
+             'default': 0,
+             'type': int,
+             'help': "In some cases the gene calling step can identify open reading frames that span across extremely long "
+                     "stretches of genomes. Such mistakes can lead to downstream issues, especially when concatenate flag "
+                     "is used, including faliure to align genes. This flag allows anvi'o to ignore extremely long gene calls to "
+                     "avoid unintended issues (i.e., during phylogenomic analyses). If you use this flag, please carefully "
+                     "examine the output messages from the program to see which genes are removed from the analysis. "
+                     "Please note that the length parameter considers the nucleotide lenght of the open reading frame, "
+                     "even if you asked for amino acid sequences to be returned. Setting this parameter to small values, "
+                     "such as less than 10000 nucleotides may lead to the removal of geniune genes, so please use it carefully."}
+                ),
     'align-with': (
             ['--align-with'],
             {'metavar': 'ALIGNER',

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1404,12 +1404,12 @@ D = {
              'type': int,
              'help': "In some cases the gene calling step can identify open reading frames that span across extremely long "
                      "stretches of genomes. Such mistakes can lead to downstream issues, especially when concatenate flag "
-                     "is used, including faliure to align genes. This flag allows anvi'o to ignore extremely long gene calls to "
+                     "is used, including failure to align genes. This flag allows anvi'o to ignore extremely long gene calls to "
                      "avoid unintended issues (i.e., during phylogenomic analyses). If you use this flag, please carefully "
                      "examine the output messages from the program to see which genes are removed from the analysis. "
                      "Please note that the length parameter considers the nucleotide lenght of the open reading frame, "
                      "even if you asked for amino acid sequences to be returned. Setting this parameter to small values, "
-                     "such as less than 10000 nucleotides may lead to the removal of geniune genes, so please use it carefully."}
+                     "such as less than 10000 nucleotides may lead to the removal of genuine genes, so please use it carefully."}
                 ),
     'align-with': (
             ['--align-with'],

--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -323,6 +323,7 @@ if __name__ == '__main__':
 
     groupG = parser.add_argument_group('OPTIONAL', "Everything is optional, but some options are more optional than others.")
     groupG.add_argument(*anvio.A('return-best-hit'), **anvio.K('return-best-hit'))
+    groupG.add_argument(*anvio.A('ignore-genes-longer-than'), **anvio.K('ignore-genes-longer-than'))
     groupG.add_argument(*anvio.A('unique-genes'), **anvio.K('unique-genes'))
     groupG.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 

--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -321,11 +321,11 @@ if __name__ == '__main__':
                                   program with `--concatenate-genes` flag). The default is "XXX" for amino\
                                   acid sequences, and "NNN" for DNA sequences'}))
 
-    groupG = parser.add_argument_group('OPTIONAL', "Everything is optional, but some options are more optional than others.")
-    groupG.add_argument(*anvio.A('return-best-hit'), **anvio.K('return-best-hit'))
-    groupG.add_argument(*anvio.A('ignore-genes-longer-than'), **anvio.K('ignore-genes-longer-than'))
-    groupG.add_argument(*anvio.A('unique-genes'), **anvio.K('unique-genes'))
-    groupG.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
+    groupH = parser.add_argument_group('OPTIONAL', "Everything is optional, but some options are more optional than others.")
+    groupH.add_argument(*anvio.A('return-best-hit'), **anvio.K('return-best-hit'))
+    groupH.add_argument(*anvio.A('ignore-genes-longer-than'), **anvio.K('ignore-genes-longer-than'))
+    groupH.add_argument(*anvio.A('unique-genes'), **anvio.K('unique-genes'))
+    groupH.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     args = parser.get_args(parser)
 

--- a/bin/anvi-get-sequences-for-hmm-hits
+++ b/bin/anvi-get-sequences-for-hmm-hits
@@ -184,6 +184,16 @@ def main(args):
 
         run.info('Filtered hits', '%d hits remain after filtering for %d gene(s)' % (len(hmm_sequences_dict), len(gene_names)))
 
+    if args.ignore_genes_longer_than > 0:
+        hmm_sequences_dict, gene_calls_removed, bins_removed = s.filter_hmm_sequences_dict_for_genes_that_are_too_long(hmm_sequences_dict, int(args.ignore_genes_longer_than))
+        CHK()
+
+        if len(bins_removed):
+            bins_removed_for_any_reason.update(bins_removed)
+
+        if len(gene_calls_removed):
+            run.info('Filtered hits', '%d hits remain after filtering for %d genes longer than %d' % (len(hmm_sequences_dict), len(gene_calls_removed), args.ignore_genes_longer_than), nl_before=1)
+
     if args.max_num_genes_missing_from_bin is not None:
         hmm_sequences_dict, bins_removed = s.filter_hmm_sequences_dict_for_bins_that_lack_more_than_N_genes(hmm_sequences_dict, gene_names, int(args.max_num_genes_missing_from_bin))
         CHK()


### PR DESCRIPTION
This PR adds a new parameter to `anvi-get-sequences-for-hmm-hits`, called `--ignore-genes-longer-than`. Here is the help menu entry for this parameter:

```
(...)
  --ignore-genes-longer-than MAX_LENGTH
                        In some cases the gene calling step can
                        identify open reading frames that span across
                        extremely long stretches of genomes. Such
                        mistakes can lead to downstream issues,
                        especially when concatenate flag is used,
                        including failure to align genes. This flag
                        allows anvi'o to ignore extremely long gene
                        calls to avoid unintended issues (i.e., during
                        phylogenomic analyses). If you use this flag,
                        please carefully examine the output messages
                        from the program to see which genes are
                        removed from the analysis. Please note that
                        the length parameter considers the nucleotide
                        lenght of the open reading frame, even if you
                        asked for amino acid sequences to be returned.
                        Setting this parameter to small values, such
                        as less than 10000 nucleotides may lead to the
                        removal of genuine genes, so please use it
                        carefully.
```

Closes #2000.