### PR TITLE
Newick rooting with branch support value

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -1425,6 +1425,7 @@ class BottleApplication(Bottle):
     def reroot_tree(self):
         # Get the Newick tree string from the form data
         newick = request.forms.get('newick')
+        internal_node = request.forms.get('internal_node')
 
         # Create an Ete3 Tree object from the Newick string, specifying format=1
         # which means that branch support values are stored as node.name and
@@ -1445,12 +1446,13 @@ class BottleApplication(Bottle):
         branch_support_value = {1:''}
         unique_index = 1
 
+        if not internal_node:
         # for every node that is not leaf or root, associate with a unique index
-        for node in tree.traverse():
-            if not node.is_leaf() and not node.is_root():
-                unique_index += 1
-                branch_support_value[unique_index] = node.name
-                node.support = unique_index
+            for node in tree.traverse():
+                if not node.is_leaf() and not node.is_root():
+                    unique_index += 1
+                    branch_support_value[unique_index] = node.name
+                    node.support = unique_index
 
         # Find the leftmost and rightmost nodes based on the provided names
         left_most = tree.search_nodes(name=request.forms.get('left_most'))[0]
@@ -1462,10 +1464,11 @@ class BottleApplication(Bottle):
         # Set the new root as the outgroup
         tree.set_outgroup(new_root)
 
-        # Assign support values as node names for non-leaf and non-root nodes
-        for node in tree.traverse():
-            if not node.is_leaf() and not node.is_root():
-                node.name = branch_support_value[node.support]
+        if not internal_node:
+            # Assign support values as node names for non-leaf and non-root nodes
+            for node in tree.traverse():
+                if not node.is_leaf() and not node.is_root():
+                    node.name = branch_support_value[node.support]
 
         # Encode node names using base32 encoding
         for node in tree.traverse('preorder'):

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -1426,21 +1426,6 @@ class BottleApplication(Bottle):
         # Get the Newick tree string from the form data
         newick = request.forms.get('newick')
         internal_node = request.forms.get('internal_node')
-
-        # Create an Ete3 Tree object from the Newick string, specifying format=1
-        # which means that branch support values are stored as node.name and
-        # a default support value is made for each node ('1')
-        # When rooting, some branch support values have to be moved around (see issue #2043)
-        # but node.name won't! We trick the system by replace the default support value with a unique
-        # number (unique index) and we keep track of node.name + its unique number in branch_support_value dict.
-        # After rooting, we simply go through every node, look at support value and rename the node accordingly.
-        # Wonderful you say? YES. But one big problem that is not really a problem: if the user provide a tree
-        # where the node name are ACTUALLY node names and not support value. Those are not supposed to be moved after rooting.
-        # It would be very bad. Most people would use support value and not node name, but we should be ready for any
-        # situation. TO-DO: either 1) update the help page to explain the situation and NO ONE can use trees with node name
-        # or 2) when someone click on rooting in the interface, we have a popup asking if they want their node name to be
-        # considered support values (therefore moved around) or accutal node name and they should not move.
-        # Then we change the code here to root according to what the user wants.
         tree = Tree(newick, format=1)
 
         branch_support_value = {1:''}

--- a/anvio/data/interactive/css/main.css
+++ b/anvio/data/interactive/css/main.css
@@ -1035,6 +1035,12 @@ div#tooltip_content tr:nth-child(odd) {background: rgba(220,220,220,0.1);}
     max-width: 42px;
 }
 
+#second_support_symbol_color{
+    display: none;
+    background-color:#2bab00;
+    min-width: 16px;
+}
+
 @keyframes glowing {
     0% { background-position: 0 0; }
     50% { background-position: 400% 0; }

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -645,10 +645,10 @@
                                                 >
                                         </div>
                                     </div>
-                                    <div class="form-group form-margin" id='show_font_size'>
-                                        <label class="col-md-4 settings-label" for="support_font_size" data-help="support-value-input">Font Size:</label>
-                                        <div class="col-md-8">
-                                            <input type="number" id="support_font_size" style="width: 60px;" value='24' max='128' min='1'>
+                                    <div class="form-group form-margin align-items-center" id='show_font_size' style="display: flex;">
+                                        <label class="col-2 settings-label d-flex" for="support_font_size" data-help="support-value-input">Font Size:</label>
+                                        <div class="col-6 align-items-center input-align d-flex">
+                                            <input class="form-control input-xs col-3" type="number" id="support_font_size" style="width: 60px;" value='24' max='128' min='1'>
                                         </div>
                                     </div>
                                     <div class="form-group form-margin d-flex align-items-center" id='show_text_rotation'>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -583,7 +583,7 @@
                                                 onclick="checkMaxSupportValueSeen();"
                                                 onchange="if (this.checked) { $('#support_value_params').show();} else { $('#support_value_params').hide(); } "
                                                 id="support_value_checkbox"
-                                                value="true"
+                                                value="false"
                                                 >
                                         </input>
                                     </div>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -583,7 +583,6 @@
                                                 onclick="checkMaxSupportValueSeen();"
                                                 onchange="if (this.checked) { $('#support_value_params').show();} else { $('#support_value_params').hide(); } "
                                                 id="support_value_checkbox"
-                                                value="false"
                                                 >
                                         </input>
                                     </div>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -624,6 +624,9 @@
                                                 <div class="col-1 input-align d-flex">
                                                     <div id="support_symbol_color" class="colorpicker" color="#AA0000" style="background-color:#AA0000; min-width: 16px;"></div>
                                                 </div>
+                                                <div class="input-align d-flex">
+                                                    <div id="second_support_symbol_color" class="colorpicker" color="#2bab00" style="background-color:#2bab00; min-width: 16px;"></div>
+                                                </div>
                                             </div>
                                         </div>
                                         <div class="form-group form-margin" style="display: flex;">

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -618,6 +618,12 @@
                                                 <input type="checkbox" id="support_invert_symbol" style="float: left;" name="invert-symbol">
                                             </div>
                                         </div>
+                                        <div class="form-group form-margin" id="support_symbol" style="display: flex;">
+                                            <label class="col-3 settings-label d-flex" for="multiple_support_symbol" data-help="support-value-checkbox">Multiple Support:</label>
+                                            <div class="col-4 input-align d-flex">
+                                                <input type="checkbox" id="multiple_support_symbol" style="float: left;" name="multiple-support-symbol" onclick="if (this.checked) { $('#second_support_symbol_color').show();} else { $('#second_support_symbol_color').hide(); }">
+                                            </div>
+                                        </div>
                                         <div class="form-group form-margin">
                                             <div class="form-group form-margin" style="display: flex;">
                                                 <label class="col-3 settings-label d-flex" for="support_invert_symbol" data-help="support-value-checkbox">Symbol Color:</label>
@@ -625,7 +631,11 @@
                                                     <div id="support_symbol_color" class="colorpicker" color="#AA0000" style="background-color:#AA0000; min-width: 16px;"></div>
                                                 </div>
                                                 <div class="input-align d-flex">
-                                                    <div id="second_support_symbol_color" class="colorpicker" color="#2bab00" style="background-color:#2bab00; min-width: 16px;"></div>
+                                                    <div id="second_support_symbol_color"
+                                                        class="colorpicker"
+                                                        color="#2bab00"
+                                                        >
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -621,8 +621,8 @@
                                         <div class="form-group form-margin">
                                             <div class="form-group form-margin" style="display: flex;">
                                                 <label class="col-3 settings-label d-flex" for="support_invert_symbol" data-help="support-value-checkbox">Symbol Color:</label>
-                                                <div class="col-4 input-align d-flex">
-                                                    <div id="support_symbol_color" class="colorpicker" color="#AA0000" style="background-color:#AA0000; margin-left: 15x;"></div>
+                                                <div class="col-1 input-align d-flex">
+                                                    <div id="support_symbol_color" class="colorpicker" color="#AA0000" style="background-color:#AA0000; min-width: 16px;"></div>
                                                 </div>
                                             </div>
                                         </div>

--- a/anvio/data/interactive/js/bin.js
+++ b/anvio/data/interactive/js/bin.js
@@ -924,9 +924,14 @@ Bins.prototype.RedrawBins = function() {
     }
 
     var bin = document.getElementById('bin');
-    while (bin.hasChildNodes()) {
-        bin.removeChild(bin.lastChild);
+    if (bin !== null) {
+        while (bin.hasChildNodes()) {
+            bin.removeChild(bin.lastChild);
+        }
+    } else {
+        console.error("bin DOM doesnt exit or null.");
     }
+    
 
     // draw new bins
     var show_grid = $('#show_grid_for_bins')[0].checked;

--- a/anvio/data/interactive/js/context-menu.js
+++ b/anvio/data/interactive/js/context-menu.js
@@ -27,7 +27,8 @@ ContextMenu = function(options) {
     this.node = options.node;
     this.layer = options.layer;
     this.isSample = options.isSample;
-    let all = options.all
+    let all = options.all;
+    let internal_node = true;
 
     this.menu_items = {
         'select': {
@@ -244,7 +245,7 @@ ContextMenu = function(options) {
                         'newick': clusteringData,
                         'left_most': left_most.label,
                         'right_most': right_most.label,
-                        'internal_node': internal_node_value
+                        'internal_node': internal_node
                     },
                     success: function(data) {
                         collapsedNodes = [];

--- a/anvio/data/interactive/js/context-menu.js
+++ b/anvio/data/interactive/js/context-menu.js
@@ -228,8 +228,35 @@ ContextMenu = function(options) {
                 drawTree();
             }
         },
-        'reroot': {
-            'title': 'Reroot the tree/denrogram here',
+        'reroot_disabled': {
+            'title': 'Reroot the tree/dendogram here'
+        },
+        'reroot_with_internal_node': {
+            'title': 'Tree has internal node names',
+            'action': (node, layer, param) => {
+                let [left_most, right_most] = this.node.GetBorderNodes();
+
+                $.ajax({
+                    type: 'POST',
+                    cache: false,
+                    url: '/data/reroot_tree',
+                    data: {
+                        'newick': clusteringData,
+                        'left_most': left_most.label,
+                        'right_most': right_most.label,
+                        'internal_node': internal_node_value
+                    },
+                    success: function(data) {
+                        collapsedNodes = [];
+                        clusteringData = data['newick'];
+                        $('#tree_modified_warning').show();
+                        drawTree();
+                    }
+                });
+            }
+        },
+        'reroot_with_support_values': {
+            'title': 'Tree has branch support values',
             'action': (node, layer, param) => {
                 let [left_most, right_most] = this.node.GetBorderNodes();
 
@@ -480,12 +507,11 @@ ContextMenu.prototype.BuildMenu = function() {
                 menu.push('blastx_refseq_protein');
             }
 
-            // tree/dendrogram operations
-            // FIXME: this option should not appear when there is no
-            //        tree/dendrogram available
-            menu.push('divider');
-            menu.push('reroot');
-
+            else if (mode == 'manual'){
+                menu.push('reroot_disabled');
+                menu.push('reroot_with_internal_node');
+                menu.push('reroot_with_support_values');
+            }
         }
         else
         {
@@ -500,7 +526,11 @@ ContextMenu.prototype.BuildMenu = function() {
 
                 menu.push('collapse');
                 menu.push('rotate');
-                menu.push('reroot');
+
+                menu.push('divider');
+                menu.push('reroot_disabled');
+                menu.push('reroot_with_internal_node');
+                menu.push('reroot_with_support_values');
             }
         }
 
@@ -524,6 +554,8 @@ ContextMenu.prototype.Show = function() {
     for (const item of this.BuildMenu()) {
         if (item == 'divider') {
             list.innerHTML += `<li class="dropdown-divider"></li>`;
+        } else if (item.includes('disabled')){
+            list.innerHTML += `<li><a class="dropdown-item disabled bold" href="#">${this.menu_items[item]['title']}</a></li>`;
         } else {
             list.innerHTML += `<li><a class="dropdown-item" href="#" item-name="${item}">${this.menu_items[item]['title']}</a></li>`;
         }

--- a/anvio/data/interactive/js/drawer.js
+++ b/anvio/data/interactive/js/drawer.js
@@ -839,7 +839,7 @@ Drawer.prototype.draw_internal_node = function(p) {
                 }
             
                 if (max_branch_support_value_seen === null || max_support > max_branch_support_value_seen) {
-                    max_branch_support_value_seen = max_support - 0.01;
+                    max_branch_support_value_seen = max_support;
                 } else {
                     this.max_support = null;
                 }
@@ -853,6 +853,7 @@ Drawer.prototype.draw_internal_node = function(p) {
                 p.branch_support < min_branch_support_value_seen ? min_branch_support_value_seen = p.branch_support : null;
         }
 
+        this.settings['show-support-values'] ? drawSupportValue(this.tree_svg_id, p, p0, p1, supportValueData) : null;
         drawCircleArc(this.tree_svg_id, p, p0, p1, p.radius, large_arc_flag);
 
         let arc = drawCircleArc(this.tree_svg_id, p, p0, p1, p.radius, large_arc_flag);
@@ -908,7 +909,7 @@ Drawer.prototype.draw_internal_node = function(p) {
                 }
             
                 if (max_branch_support_value_seen === null || max_support > max_branch_support_value_seen) {
-                    max_branch_support_value_seen = max_support - 0.01;
+                    max_branch_support_value_seen = max_support;
                 } else {
                     this.max_support = null;
                 }

--- a/anvio/data/interactive/js/drawer.js
+++ b/anvio/data/interactive/js/drawer.js
@@ -782,6 +782,7 @@ Drawer.prototype.draw_internal_node = function(p) {
         invertSymbol : this.settings['support-symbol-invert'],
         maxRadius : this.settings['support-symbol-size'],
         symbolColor : this.settings['support-symbol-color'],
+        secondSymbolColor : this.settings['second-support-symbol-color'],
         fontSize : this.settings['support-font-size'],
         textRotation : this.settings['support-text-rotation']
     }

--- a/anvio/data/interactive/js/drawer.js
+++ b/anvio/data/interactive/js/drawer.js
@@ -789,6 +789,37 @@ Drawer.prototype.draw_internal_node = function(p) {
     {
         var p0 = [];
         var p1 = [];
+        const branch_support_values = [];
+
+        if (typeof p.branch_support === 'string' && p.branch_support.includes('/')) {
+            const [branch_support_value0, branch_support_value1] = p.branch_support.split('/').map(parseFloat);
+            
+            branch_support_values.push(branch_support_value0, branch_support_value1);
+
+            if (branch_support_values.length > 0) {
+                const min_support = Math.min(...branch_support_values);
+                const max_support = Math.max(...branch_support_values);
+            
+                if (min_branch_support_value_seen === null || min_support < min_branch_support_value_seen) {
+                    min_branch_support_value_seen = min_support;
+                } else {
+                    this.min_support = null;
+                }
+            
+                if (max_branch_support_value_seen === null || max_support > max_branch_support_value_seen) {
+                    max_branch_support_value_seen = max_support - 0.01;
+                } else {
+                    this.max_support = null;
+                }
+            } 
+
+        } else {
+                // If there are no string branch support value like '100/100':
+                min_branch_support_value_seen == null ? min_branch_support_value_seen = p.branch_support : null;
+                max_branch_support_value_seen == null ? max_branch_support_value_seen = p.branch_support : null;
+                p.branch_support > max_branch_support_value_seen ? max_branch_support_value_seen = p.branch_support : null;
+                p.branch_support < min_branch_support_value_seen ? min_branch_support_value_seen = p.branch_support : null;
+        }
 
         p0['x'] = p.xy['x'];
         p0['y'] = p.xy['y'];
@@ -809,11 +840,6 @@ Drawer.prototype.draw_internal_node = function(p) {
 
             drawLine(this.tree_svg_id, p, p0, p1);
 
-            // support value business happens here:
-            min_branch_support_value_seen == null ? min_branch_support_value_seen = p.branch_support : null;
-            max_branch_support_value_seen == null ? max_branch_support_value_seen = p.branch_support : null;
-            p.branch_support > max_branch_support_value_seen ? max_branch_support_value_seen = p.branch_support : null;
-            p.branch_support < min_branch_support_value_seen ? min_branch_support_value_seen = p.branch_support : null;
             this.settings['show-support-values'] ? drawSupportValue(this.tree_svg_id, p, p0, p1, supportValueData) : null;
 
             let line = drawLine(this.tree_svg_id, p, p0, p1);
@@ -997,7 +1023,7 @@ Drawer.prototype.draw_categorical_layers = function() {
 
             if ((layer.is_categorical && layer.get_visual_attribute('type') == 'color') || layer.is_parent)
             {
-                if(this.layerdata_dict[q.label] && this.layerdata_dict[q.label][layer.index]){
+                if(this.layerdata_dict[q.label][layer.index]){
                     layer_items.push(this.layerdata_dict[q.label][layer.index]);
                 }
             }

--- a/anvio/data/interactive/js/drawer.js
+++ b/anvio/data/interactive/js/drawer.js
@@ -997,7 +997,7 @@ Drawer.prototype.draw_categorical_layers = function() {
 
             if ((layer.is_categorical && layer.get_visual_attribute('type') == 'color') || layer.is_parent)
             {
-                if(this.layerdata_dict[q.label][layer.index]){
+                if(this.layerdata_dict[q.label] && this.layerdata_dict[q.label][layer.index]){
                     layer_items.push(this.layerdata_dict[q.label][layer.index]);
                 }
             }

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2806,7 +2806,7 @@ function processState(state_name, state) {
     }
 
     // bootstrap values
-    if (state.hasOwnProperty('show-support-values')){
+    if (!(state.hasOwnProperty('show-support-values'))){
         $('#support_value_checkbox').prop('checked', state['show-support-values'])
         if ($('#support_value_checkbox').is(':checked')){
             $('#support_value_params').show()
@@ -3146,7 +3146,7 @@ function checkMaxSupportValueSeen() {
             // we know nothing Jon Snow.
             return;
         }
-    } else if (max_branch_support_value_seen === 0 && $('#support_value_checkbox').is(':checked')) {
+    } else if (max_branch_support_value_seen == 0 && $('#support_value_checkbox').is(':checked')) {
         // this means we alrady know min/max values for branch support (`max_branch_support_value_seen`
         // is not `null`) but the max is zero. bad news.
         $('#max_branch_support_value_seen_is_zero_warning').show();

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -3146,7 +3146,7 @@ function checkMaxSupportValueSeen() {
             // we know nothing Jon Snow.
             return;
         }
-    } else if (max_branch_support_value_seen == 0 && $('#support_value_checkbox').is(':checked')) {
+    } else if (max_branch_support_value_seen === 0 && $('#support_value_checkbox').is(':checked')) {
         // this means we alrady know min/max values for branch support (`max_branch_support_value_seen`
         // is not `null`) but the max is zero. bad news.
         $('#max_branch_support_value_seen_is_zero_warning').show();

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -1604,6 +1604,7 @@ function serializeSettings(use_layer_names) {
     state['support-display-number'] = $('#support_display_number').is(':checked')
     state['support-symbol-size'] = $('#support_symbol_size').val()
     state['support-symbol-color'] = $('#support_symbol_color').attr('color')
+    state['second-support-symbol-color'] = $('#second_support_symbol_color').attr('color')
     state['support-font-size'] = $('#support_font_size').val()
     state['support-text-rotation'] = $('#support_text_rotation').val()
 
@@ -2830,6 +2831,10 @@ function processState(state_name, state) {
     if (state.hasOwnProperty('support-symbol-color')){
         $('#support_symbol_color').attr('color', state['support-symbol-color'])
         $('#support_symbol_color').css('background-color', state['support-symbol-color'])
+    }
+    if (state.hasOwnProperty('second-support-symbol-color')){
+        $('#second_support_symbol_color').attr('color', state['second-support-symbol-color'])
+        $('#second_support_symbol_color').css('background-color', state['second-support-symbol-color'])
     }
     if (state.hasOwnProperty('support-symbol-size')){
         $('#support_symbol_size').val(state['support-symbol-size'])

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -247,11 +247,18 @@ function drawLayerLegend(_layers, _view, _layer_order, top, left) {
 }
 
 function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
-    function checkInRange(){ // check to see if SV data point is within user specified range
-        if(p.branch_support >= supportValueData.numberRange[0] && p.branch_support <= supportValueData.numberRange[1]){
-            return true
+    function checkInRange(){
+        /**
+         * Check if the branch support values fall within the given number range.
+         * @return {bool}    True if the branch support values are within the specified range, False otherwise.
+        */
+        if (typeof p.branch_support === 'string' && p.branch_support.includes('/')) {
+            const [branch_support_value0, branch_support_value1] = p.branch_support.split('/').map(parseFloat);
+            const min_support = Math.min(branch_support_value0, branch_support_value1);
+            const max_support = Math.max(branch_support_value0, branch_support_value1);
+            return min_support >= supportValueData.numberRange[0] && max_support <= supportValueData.numberRange[1];
         } else {
-            return false
+            return p.branch_support >= supportValueData.numberRange[0] && p.branch_support <= supportValueData.numberRange[1];
         }
     }
 

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -340,8 +340,10 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         if (typeof p.branch_support === 'string' && p.branch_support.includes('/')) {
             let branch_support_values = p.branch_support.split('/').map(parseFloat);
             first_circle = makeCircle(branch_support_values[0], 0);
+            first_circle.setAttribute('transform', 'translate(-10, -10)'); // Should change
             second_circle = makeCircle(branch_support_values[1], 1);
-            second_circle.setAttribute('transform', 'translate(30, 0)');
+            second_circle.setAttribute('fill', supportValueData.secondSymbolColor);
+            second_circle.setAttribute('transform', 'translate(10,10)'); // Should change
         } else {
             first_circle = makeCircle(p.branch_support, 0);
         }

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -340,10 +340,12 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
         if (typeof p.branch_support === 'string' && p.branch_support.includes('/')) {
             let branch_support_values = p.branch_support.split('/').map(parseFloat);
             first_circle = makeCircle(branch_support_values[0], 0);
-            first_circle.setAttribute('transform', 'translate(-10, -10)'); // Should change
             second_circle = makeCircle(branch_support_values[1], 1);
             second_circle.setAttribute('fill', supportValueData.secondSymbolColor);
-            second_circle.setAttribute('transform', 'translate(10,10)'); // Should change
+
+            let firstCircleCx = parseFloat(first_circle.getAttribute('cx'));
+            let updatedCx = firstCircleCx + maxRadius * 2;
+            second_circle.setAttributeNS(null, 'cx', updatedCx.toString());
         } else {
             first_circle = makeCircle(p.branch_support, 0);
         }

--- a/anvio/data/interactive/js/svg-helpers.js
+++ b/anvio/data/interactive/js/svg-helpers.js
@@ -265,15 +265,15 @@ function drawSupportValue(svg_id, p, p0, p1, supportValueData) {
     if( supportValueData.showNumber && checkInRange()){ // only render text if in range AND selected by user
         if($('#tree_type').val() == 'circlephylogram'){
             if(supportValueData.textRotation == '0'){
-                drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'right', 'black', 'baseline', true)
+                drawText(svg_id, p.xy, p.branch_support, supportValueData.fontSize, 'Roboto' ,'black', '' , 'baseline')
             } else {
-                drawRotatedText(svg_id, p.xy, p.branch_support, parseInt(supportValueData.textRotation), 'right', supportValueData.fontSize, 'black', 'baseline', true)
+                drawRotatedText(svg_id, p.xy, p.branch_support, parseInt(supportValueData.textRotation), 'right', supportValueData.fontSize, 'Roboto' ,'black', '' , 'baseline')
             }
         } else {
             if(supportValueData.textRotation == '0'){
-                drawRotatedText(svg_id, p.xy, p.branch_support, -90, 'left', supportValueData.fontSize, 'black', 'baseline', true)
+                drawRotatedText(svg_id, p.xy, p.branch_support, -90, 'left', supportValueData.fontSize, 'Roboto' ,'black', '' , 'baseline')
             } else {
-                drawRotatedText(svg_id, p.xy, p.branch_support, parseInt(supportValueData.textRotation), 'left', supportValueData.fontSize, 'black', 'baseline', true)
+                drawRotatedText(svg_id, p.xy, p.branch_support, parseInt(supportValueData.textRotation), 'left', supportValueData.fontSize, 'Roboto' ,'black', '' , 'baseline')
             }
         }
     }

--- a/anvio/data/interactive/js/tree.js
+++ b/anvio/data/interactive/js/tree.js
@@ -34,7 +34,7 @@ function Node(label) {
     this.depth = 0;
     this.order = null;
     this.max_child_path = 0;
-    this.branch_support = "";
+    this.branch_support = 0;
 }
 
 

--- a/anvio/data/interactive/js/tree.js
+++ b/anvio/data/interactive/js/tree.js
@@ -34,7 +34,7 @@ function Node(label) {
     this.depth = 0;
     this.order = null;
     this.max_child_path = 0;
-    this.branch_support = 0;
+    this.branch_support = "";
 }
 
 
@@ -186,6 +186,7 @@ Tree.prototype.Parse = function(str, edge_length_norm) {
     str = str.replace(/:/g, "|:|");
     str = str.replace(/;/g, "|;|");
     str = str.replace(/\|\|/g, "|");
+    str = str.replace(/\//g, "/");
     str = str.replace(/^\|/, "");
     str = str.replace(/\|$/, "");
 
@@ -204,15 +205,24 @@ Tree.prototype.Parse = function(str, edge_length_norm) {
         switch (state) {
             case 0:
                 if (ctype_alnum(token[i].charAt(0)) || token[i].charAt(0) == "'" || token[i].charAt(0) == '"' || token[i].charAt(0) == '_') {
-                    if (isNumber(token[i]) && mode != 'gene') {
+                    if (isNumber(token[i]) && mode != 'gene' && !isNaN(token[i])) {
                         curnode.branch_support = parseFloat(token[i]);
                         this.has_branch_supports = true;
+                        i++;
+                    } else if (token[i + 1] && token[i + 1] === '/') {
+                        if (isNumber(token[i]) && isNumber(token[i + 2])) {
+                            curnode.branch_support = token[i] + '/' + token[i + 2];
+                            this.has_branch_supports = true;
+                            i += 3;
+                        } else {
+                            state = 99;
+                            this.error = 1; // syntax
+                        }
                     } else {
                         this.label_to_leaves[token[i]] = curnode;
                         curnode.label = token[i];
+                        i++;
                     }
-
-                    i++;
                     state = 1;
                 } else {
                     switch (token[i]) {
@@ -317,13 +327,30 @@ Tree.prototype.Parse = function(str, edge_length_norm) {
 
             case 3: // finishchildren
                 if (ctype_alnum(token[i].charAt(0)) || token[i].charAt(0) == "'" || token[i].charAt(0) == '"' || token[i].charAt(0) == '_') {
-                    if (isNumber(token[i]) && mode != 'gene') {
+                    if (isNumber(token[i]) && mode != 'gene' && !isNaN(token[i])) {
                         curnode.branch_support = parseFloat(token[i]);
                         this.has_branch_supports = true;
+                        i++;
+                    } else if (token[i + 1] && token[i + 1] === '/') {
+                        if (isNumber(token[i]) && isNumber(token[i + 2])) {
+                            curnode.branch_support = token[i] + '/' + token[i + 2];
+                            console.log(curnode.has_branch_supports);
+                            this.has_branch_supports = true;
+                            i += 3;
+                        } else {
+                            state = 99;
+                            this.error = 1; // syntax
+                        }
                     } else {
-                        curnode.label = token[i];
+                        if (token[i] != 'R' && token[i] == '100/100'){
+                            console.log(token[i]);
+                            this.has_branch_supports = true;
+                            curnode.has_branch_supports = token[i];
+                        }else{
+                            curnode.label = token[i];
+                        }
+                        i++;
                     }
-                    i++;
                 } else {
                     switch (token[i]) {
                         case ':':

--- a/anvio/data/interactive/js/tree.js
+++ b/anvio/data/interactive/js/tree.js
@@ -186,7 +186,6 @@ Tree.prototype.Parse = function(str, edge_length_norm) {
     str = str.replace(/:/g, "|:|");
     str = str.replace(/;/g, "|;|");
     str = str.replace(/\|\|/g, "|");
-    str = str.replace(/\//g, "/");
     str = str.replace(/^\|/, "");
     str = str.replace(/\|$/, "");
 
@@ -205,24 +204,15 @@ Tree.prototype.Parse = function(str, edge_length_norm) {
         switch (state) {
             case 0:
                 if (ctype_alnum(token[i].charAt(0)) || token[i].charAt(0) == "'" || token[i].charAt(0) == '"' || token[i].charAt(0) == '_') {
-                    if (isNumber(token[i]) && mode != 'gene' && !isNaN(token[i])) {
-                        curnode.branch_support = parseFloat(token[i]);
+                    if (isNumber(token[i]) && mode != 'gene' || isNaN(token[i] && mode != 'gene')){
+                        curnode.branch_support = token[i];
                         this.has_branch_supports = true;
-                        i++;
-                    } else if (token[i + 1] && token[i + 1] === '/') {
-                        if (isNumber(token[i]) && isNumber(token[i + 2])) {
-                            curnode.branch_support = token[i] + '/' + token[i + 2];
-                            this.has_branch_supports = true;
-                            i += 3;
-                        } else {
-                            state = 99;
-                            this.error = 1; // syntax
-                        }
-                    } else {
+                    } 
+                    else {
                         this.label_to_leaves[token[i]] = curnode;
                         curnode.label = token[i];
-                        i++;
                     }
+                    i++;
                     state = 1;
                 } else {
                     switch (token[i]) {
@@ -325,32 +315,16 @@ Tree.prototype.Parse = function(str, edge_length_norm) {
                 }
                 break;
 
-            case 3: // finishchildren
+                case 3: // finishchildren
                 if (ctype_alnum(token[i].charAt(0)) || token[i].charAt(0) == "'" || token[i].charAt(0) == '"' || token[i].charAt(0) == '_') {
-                    if (isNumber(token[i]) && mode != 'gene' && !isNaN(token[i])) {
+                    if (isNaN(token[i]) && mode != 'gene') {
+                        curnode.branch_support = token[i];
+                        this.has_branch_supports = true;
+                    } else {
                         curnode.branch_support = parseFloat(token[i]);
                         this.has_branch_supports = true;
-                        i++;
-                    } else if (token[i + 1] && token[i + 1] === '/') {
-                        if (isNumber(token[i]) && isNumber(token[i + 2])) {
-                            curnode.branch_support = token[i] + '/' + token[i + 2];
-                            console.log(curnode.has_branch_supports);
-                            this.has_branch_supports = true;
-                            i += 3;
-                        } else {
-                            state = 99;
-                            this.error = 1; // syntax
-                        }
-                    } else {
-                        if (token[i] != 'R' && token[i] == '100/100'){
-                            console.log(token[i]);
-                            this.has_branch_supports = true;
-                            curnode.has_branch_supports = token[i];
-                        }else{
-                            curnode.label = token[i];
-                        }
-                        i++;
                     }
+                    i++;
                 } else {
                     switch (token[i]) {
                         case ':':
@@ -580,5 +554,3 @@ PreorderIterator.prototype.Next = function()
     }
     return this.cur;
 };
-
-


### PR DESCRIPTION
Hello everyone and welcome for our new and final episode of the newick tree branch support value problem!

# Background
The problem: when rooting a tree, some branch support values have to be moved around. See the issue #2043 for more information and link to a paper explaining the situation. 

The origin of the problem is that the "support values" were stored as node.name and not node.support in bottleroutes.py's reroot_tree. ete3 is perfectly capable of replacing branch support values (and that's a good news!).

# The solution
You could be tempted to just copy node.name (which contains the real support value) into node.support, root the tree and maybe rename node.name with node.support after they were moved appropriately by ete3. And it would work. As long as your support values are float. 

But the world is complex and Tom's support values looks like that: '100/99.6'. Basically a string. It is ok, in the code below you will see a hack™ that pair unique integer to node.name, use unique integer as support value, track their movement after rooting and rename node.name accordingly. Now, support value format is not a problem and Tom's tree can be properly rooted and rerooted, the support value will be rightfully placed. 

# Test case
You don't need to trust me, you just need to test with the following example which is directly copied from the paper mentioned earlier. The fist digit of the string test case matches the 1, 2, and 3 support value of the original test case:
```
# support value as number
echo "((C,D)1,(A,(B,X)3)2,E)R;" > tree_support_as_number.newick
anvi-interactive --manual -t tree_support_as_number.newick -p profile_support_as_number.db

# or support value as string
echo "((C,D)1/98.5,(A,(B,X)3/777)2/5546,E)R;" > tree_support_as_string.newick
anvi-interactive --manual -t tree_support_as_string.newick -p profile_support_as_string.db
```

Original anvi'o (WRONG) behavior after rooting using X:

<img width="1453" alt="Screenshot 2024-02-16 at 10 45 06" src="https://github.com/merenlab/anvio/assets/10922896/6f0d08db-f222-4827-86d1-266ebe5eb75d">

Now:
<img width="1453" alt="Screenshot 2024-02-16 at 10 45 32" src="https://github.com/merenlab/anvio/assets/10922896/34db99a6-58a2-40da-ad4d-86970773978c">

Also works if support value is a string, but we cannot display it (more on that later), but using the panel Data, one can see that there is no problem and the string starting with "2" is in the lower branch compared to the wrong behavior:
<img width="1583" alt="Screenshot 2024-02-16 at 10 50 42" src="https://github.com/merenlab/anvio/assets/10922896/79f2faf3-61ab-4f6a-901c-a41c49ae5397">

# Improvement needed
## The zeros
We can see some 0 where we don't have support value. This is a default behavior in anvi'o and as nothing to do with the rooting. To be fair, if one has support values for their tree, they have values for every branch and it shouldn't be a problem. Anyway, there should be nothing displayed.

## What is node.name is REALY the node's name
Let's imagine the user has a tree with no support values, but the non-leaf node have a name. Then you don't want to move the node's name like we move the support values after rooting!!!

I propose the following: 
<img width="709" alt="Screenshot 2024-02-16 at 10 21 47" src="https://github.com/merenlab/anvio/assets/10922896/a3583d3e-9a3e-48b5-87e7-c2b8699c9452">

If you click on the first option, the string associated with each node is considered support value and will be reassigned after rooting. The second option will not move the node's name. 

## What if I have BOTH node name and support value
Then I don't like you and it is personal at this point. 
But seriously, it is not possible. These info are stored in the same location in the newick tree structure. You either treat it as node name OR support value. So we are good. 

## I want to display my support value when they look like Tom's (100/99.6)
Me too. I have checked the code a little bit, and I have noticed that there is a js function that check if branch support value as a min and max value. If not, you get this warning when you want to display the support values:
<img width="559" alt="Screenshot 2024-02-16 at 11 10 45" src="https://github.com/merenlab/anvio/assets/10922896/359ecd99-e8b1-4c8d-b106-41d1009ae7ab">

The need to check for max and min are for two things: define range of value to display and display a symbol (round shape) proportional to the support value:
<img width="1564" alt="Screenshot 2024-02-16 at 11 12 07" src="https://github.com/merenlab/anvio/assets/10922896/9a2bdada-2806-46c7-a1b2-27d1789464a0">

Now, I would like the front end to check if branch support is number or string. If number, show the same as above. But if non digit character, display the text only (no range filtering, no display symbol):
<img width="585" alt="Screenshot 2024-02-16 at 10 26 29" src="https://github.com/merenlab/anvio/assets/10922896/4f1aab32-5845-49b7-bdf8-bb4ddd439576">
<img width="1404" alt="Screenshot 2024-02-16 at 11 15 27" src="https://github.com/merenlab/anvio/assets/10922896/556d9168-f2ba-47ab-8513-b26b317af3b2">

# Summary TODO
- [ ] Right click option to root with branch support or node name
- [ ] adapt reroot_tree in bottle root to behave according to above option
- [ ] diplay support value/node name with non-digit character
- [ ] [optional] get rid of default '0' value when no support value given in the original tree



