### PR TITLE
V22 to v23 migration

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -4276,7 +4276,7 @@ class ContigsDatabase:
 
 
     def remove_data_from_db(self, tables_dict):
-        """This is quite an experimental function to clean up tables in contgis databases. Use with caution.
+        """This is quite an experimental function to clean up tables in contigs databases. Use with caution.
 
            The expected tables dict should follow this structure:
 

--- a/anvio/migrations/contigs/v22_to_v23.py
+++ b/anvio/migrations/contigs/v22_to_v23.py
@@ -31,7 +31,7 @@ def migrate(db_path):
 
     # usually we never need to do this, but in this case it is best practice to test if
     # we need an actual removal of the SCGs from a contigs-db since we released new SCGs
-    # in the master repository, and some poeople likely already updated their contigs-dbs.
+    # in the master repository, and some people likely already updated their contigs-dbs.
     # if they have already gone through that, we can save them the trouble.
     scg_taxonomy_was_run = contigs_db.get_meta_value('scg_taxonomy_was_run')
     scg_taxonomy_db_version = contigs_db.get_meta_value('scg_taxonomy_database_version')

--- a/anvio/migrations/contigs/v22_to_v23.py
+++ b/anvio/migrations/contigs/v22_to_v23.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+import sqlite3
+import argparse
+
+import anvio.dbinfo as dbinfo
+import anvio.terminal as terminal
+import anvio.constants as constants
+
+from anvio.errors import ConfigError
+
+current_version, next_version = [x[1:] for x in __name__.split('_to_')]
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+def migrate(db_path):
+    if db_path is None:
+        raise ConfigError("No database path is given.")
+
+    contigs_db_info = dbinfo.ContigsDBInfo(db_path)
+    if str(contigs_db_info.version) != current_version:
+        raise ConfigError(
+            f"The version of the provided contigs database is {contigs_db_info.version}, "
+            f"not the required version, {current_version}, so this script cannot upgrade the database.")
+
+    progress.new("Migrating")
+    progress.update("Removing old SCGs...")
+
+    self_table = contigs_db_info.get_self_table()
+    contigs_db = contigs_db_info.load_db()
+    
+    if self_table['scg_taxonomy_was_run']:
+        with sqlite3.connect(db_path) as connection:
+            cursor = connection.cursor()
+
+            # Construct the parameterized query for SCG removal
+            placeholders = ', '.join(['?'] * len(constants.default_scgs_for_taxonomy))
+            where_clause = f"gene_name NOT IN ({placeholders})"
+
+            # Execute the DELETE statement to remove old SCGs
+            cursor.execute(f"DELETE FROM scg_taxonomy WHERE {where_clause}", constants.default_scgs_for_taxonomy)
+
+    progress.update("Updating version")
+    contigs_db.remove_meta_key_value_pair('version')
+    contigs_db.set_version(next_version)
+
+    progress.update("Committing changes")
+    contigs_db.disconnect()
+
+    progress.end()
+
+    message = (
+        "Congratulations! Your contigs database is now version 23. This update removed the old SCGs "
+        "that anvi-estimate-scg-taxonomy used to use, and updated the version of the database."
+    )
+
+    run.info_single(message, nl_after=1, nl_before=1, mc='green')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=f"A simple script to upgrade an anvi'o contigs database from version {current_version} to version {next_version}")
+    parser.add_argument("contigs_db", metavar="CONTIGS_DB", help=f"An anvi'o contigs database of version {current_version}")
+    args, unknown = parser.parse_known_args()
+
+    try:
+        migrate(args.contigs_db)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -14,7 +14,7 @@ __maintainer__ = "A. Murat Eren"
 __email__ = "a.murat.eren@gmail.com"
 
 
-contigs_db_version = "22"
+contigs_db_version = "23"
 profile_db_version = "40"
 genes_db_version = "6"
 pan_db_version = "17"

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -19,7 +19,7 @@ from anvio.migrations import migration_scripts
 
 
 __description__ = "Migrates any anvi'o artifact, whether it is a database or a config file, to a newer version. Pure magic."
-__authors__ = ['meren', 'ozcan', 'ekiefl', 'ivagljiva', 'semiller10']
+__authors__ = ['meren', 'ozcan', 'ekiefl', 'ivagljiva', 'semiller10', 'mschecht']
 __requires__ = ["contigs-db", "profile-db", "pan-db", "genes-db", "genomes-storage-db", "structure-db", "modules-db", "workflow-config"]
 __provides__ = []
 
@@ -270,7 +270,7 @@ class Migrater(object):
                     shutil.move(self.artifact_path, self.artifact_path + '.broken')
 
                     raise ConfigError("Anvi'o has very bad news for you :( Your migration failed, and anvi'o has no backups to restore your "
-                                      "original file. The current artifact is likely in a broken state, and you will unlkely going to be "
+                                      "original file. The current artifact is likely in a broken state, and you will unlikely going to be "
                                       "able to use it. So anvi'o renamed it by adding a prefix '.broken' to its file name. We are very sorry "
                                       "for this error (and anvi'o will certainly not put salt on the wound by reminding you that you could "
                                       "have avoided it by using the `--migrate-safely` flag): \"%s\"." % e)
@@ -301,8 +301,8 @@ if __name__ == '__main__':
                         "all of the files that match to your filters.")
 
     groupB = parser.add_argument_group('SAFETY', "It is up to you. Safe things take much longer and boring. Unsafe things "
-                                                 "are fast, fun, and .. well, don't come to use if your computer loses power "
-                                                 "or somiething.")
+                                                 "are fast, fun, and .. well, don't come to us if your computer loses power "
+                                                 "or something.")
     groupB.add_argument(*anvio.A('migrate-safely'), **anvio.K('migrate-safely'))
     groupB.add_argument(*anvio.A('migrate-quickly'), **anvio.K('migrate-quickly'))
 


### PR DESCRIPTION
To address issue #2225 we implemented a [contig-db](https://anvio.org/help/7/programs/anvi-gen-contigs-database/) migration script. This script deletes scg-taxonomy tables within the contigs-db and users will have to re-run [anvi-estimate-scg-taxonomy](https://anvio.org/help/main/programs/anvi-estimate-scg-taxonomy/).