### PR TITLE
anvi-estimate-metabolism --metagenome-mode memory fix

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -726,7 +726,10 @@ D = {
             ['-m', '--metagenome-mode'],
             {'default': False,
              'action': 'store_true',
-             'help': "Treat a given contigs database as a metagenome rather than treating it as a single genome."}
+             'help': "[PER-CONTIG ESTIMATION] Treat a given contigs database as an unbinned metagenome rather than "
+                     "treating it as a single genome. Since we don't know which contigs go together, we'll estimate "
+                     "metabolism for each contig independently. Can be resource-intensive (particularly with memory). "
+                     "Not recommended to combine with --matrix-format or --get-raw-data-as-json."}
                 ),
     'scg-name-for-metagenome-mode': (
             ['-S','--scg-name-for-metagenome-mode'],

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -3046,6 +3046,13 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
         
         self.run.info('Mode (what we are estimating metabolism for)', estimation_mode, quiet=self.quiet)
 
+        # a warning for high memory usage with metagenome mode in certain situations
+        if self.metagenome_mode and (self.matrix_format or self.json_output_file_path):
+            self.run.warning("ALERT! You are running this program in --metagenome-mode, which can have a VERY LARGE "
+                             "memory footprint when used with --matrix-format or --get-raw-data-as-json, since both "
+                             "of those options require storing all the per-contig data in memory. You have been warned. "
+                             "The OOM-Killer may strike.")
+
 
         if self.contigs_db_path:
             utils.is_contigs_db(self.contigs_db_path)

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -4922,16 +4922,16 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
 
 
             if not self.store_json_without_estimation:
+                single_contig_module_superdict = {contig: self.estimate_for_list_of_splits(metabolism_dict_for_contig, bin_name=contig)}
+                if return_superdicts:
+                    metagenome_metabolism_superdict[contig] = single_contig_module_superdict[contig]
+                    metagenome_ko_superdict[contig] = ko_dict_for_contig
+            else:
                 if not return_superdicts:
                     raise ConfigError("Uh oh. Someone requested JSON-formatted estimation data from estimate_for_contigs_db_for_metagenome() "
                                       "without setting 'return_superdicts' parameter to True. ")
-                metagenome_metabolism_superdict[contig] = self.estimate_for_list_of_splits(metabolism_dict_for_contig, bin_name=contig)
-                single_contig_module_superdict = {contig: metagenome_metabolism_superdict[contig]}
+                metagenome_metabolism_superdict[contig] = metabolism_dict_for_contig
                 metagenome_ko_superdict[contig] = ko_dict_for_contig
-            else:
-                if return_superdicts:
-                    metagenome_metabolism_superdict[contig] = metabolism_dict_for_contig
-                    metagenome_ko_superdict[contig] = ko_dict_for_contig
                 single_contig_module_superdict = {contig: metabolism_dict_for_contig}
 
 

--- a/bin/anvi-estimate-metabolism
+++ b/bin/anvi-estimate-metabolism
@@ -54,7 +54,11 @@ if __name__ == '__main__':
                                                    "The minimum you must provide this program is a contigs database. In which case "
                                                    "anvi'o will attempt to estimate metabolism for all contigs in it, assuming that "
                                                    "the contigs database represents a single genome. If the contigs database is actually "
-                                                   "a metagenome, you should use the `--metagenome` flag to explicitly declare that.")
+                                                   "an unbinned metagenome and you want per-contig estimates instead, you can use the "
+                                                   "`--metagenome` flag to explicitly declare that. It is also acceptable to run this "
+                                                   "program on metagenomes without using metagenome mode if you want community-level "
+                                                   "metabolism estimates (ie, combining information across all contigs from different "
+                                                   "populations in the community).")
     groupI.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db', {'required': False}))
     groupI.add_argument(*anvio.A('metagenome-mode'), **anvio.K('metagenome-mode'))
 
@@ -69,11 +73,14 @@ if __name__ == '__main__':
 
     groupM = parser.add_argument_group('INPUT #3 - MULTI-MODE', "If you have multiple contigs databases to work with, you can put them all into a file. "
                                                    "Then anvi'o will run estimation separately on each database and generate a single output file for all. "
-                                                   "There are 3 types of input files to choose from depending on whether you have single genomes (external), "
-                                                   "genomes in collections (internal), or metagenomes in your contigs DBs.")
+                                                   "There are 3 types of input files to choose from depending on whether you want to treat your DBs as "
+                                                   "single genomes (external), genomes in collections (internal), or unbinned metagenomes (for contig-level "
+                                                   "estimates, i.e. 'metagenome mode') in your contigs DBs.")
     groupM.add_argument(*anvio.A('external-genomes'), **anvio.K('external-genomes'))
     groupM.add_argument(*anvio.A('internal-genomes'), **anvio.K('internal-genomes'))
-    groupM.add_argument(*anvio.A('metagenomes'), **anvio.K('metagenomes'))
+    groupM.add_argument(*anvio.A('metagenomes'), **anvio.K('metagenomes', {'help': "Same format as an external genomes file, but choosing this option "
+                                                                                "ensures each DB in the input file is analyzed "
+                                                                                "with 'metagenome mode' for per-contig estimates."}))
 
     groupX = parser.add_argument_group('INPUT #4 - ESTIMATION ON A LIST OF ENZYMES',
                                                    "If all you have is a list of enzymes, you can use them to estimate metabolism "


### PR DESCRIPTION
This PR addresses the memory issues with `--metagenome-mode` from #2228 with the solutions proposed therein, namely:

- by adding a flag variable to the `estimate_for_contigs_db_for_metagenome()` so that it doesn't store the per-contig estimation data unless we really have to (it is necessary only for storing output in matrix or JSON format)
- by updating the program's help menu to make it clear that `--metagenome-mode` does contig-level estimates, and to clarify that using the `-M` flag turns this mode on
- by adding a warning to the user about potential high memory usage when they request `--metagenome-mode` with matrix- or JSON-formatted output

I have tested the fix as described in #2228, and it enables the program to run in `--metagenome-mode` without being killed for excessive memory usage on a large metagenome with 20Gb of memory.