### PR TITLE
Allow external genomes input to anvi-estimate-scg-taxonomy

### DIFF
--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -494,6 +494,7 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
         self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
 
 
+    def estimate_for_metagenomes(self):
         if not self.metagenomes:
             self.init_metagenomes()
             self.run.info("Num metagenomes", len(self.metagenome_names))

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -471,7 +471,29 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
         self.progress.end()
 
 
-    def estimate(self):
+    def estimate_for_genomes(self):
+        if not self.metagenomes:
+            self.init_external_genomes()
+            self.run.info("Num genomes", len(self.metagenome_names))
+
+        self.run.info("Taxonomic level of interest", self.user_taxonomic_level or "(None specified by the user, so 'all levels')")
+        self.run.info("Output file prefix", self.output_file_prefix)
+        self.run.info("Output in matrix format", self.matrix_format)
+        self.run.info("Output raw data", self.raw_output)
+        self.run.info("SCG coverages will be computed?", self.compute_scg_coverages)
+
+        if self.report_scg_frequencies_path:
+            self.report_scg_frequencies_as_TAB_delimited_file()
+            return
+
+        scg_taxonomy_super_dict_multi = self.get_scg_taxonomy_super_dict_for_metagenomes()
+
+        if self.sequences_file_path_prefix:
+            self.store_sequences_for_items_multi(scg_taxonomy_super_dict_multi)
+
+        self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
+
+
         if not self.metagenomes:
             self.init_metagenomes()
             self.run.info("Num metagenomes", len(self.metagenome_names))

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -682,7 +682,9 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
                     coverages_list = list(d[item]['coverages'].items())
 
                     if len(coverages_list) > 1:
-                        raise ConfigError("The codebase is not ready to handle this :(")
+                        raise ConfigError("We found more than one coverage value per SCG, which means you gave anvi'o a merged profile "
+                        "database (containing multiple samples) associated with your contigs database. The codebase is not ready to "
+                        "handle this :(  You need to provide single profiles instead of merged ones.")
 
                     d[item]['coverage'] = coverages_list[0][1]
                     d[item].pop('coverages')

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -532,6 +532,17 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
         self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
 
 
+    def estimate(self):
+        
+        if self.args.metagenomes:
+            self.estimate_for_metagenomes()
+        elif self.args.external_genomes:
+            self.estimate_for_genomes()
+        else:
+            raise ConfigError("Anvi'o is not sure how things got to this point, but somehow we find ourselves without input for the "
+                              "SCGTaxonomyEstimatorMulti class's estimate() function.")
+
+
     def store_sequences_for_items_multi(self, scg_taxonomy_super_dict_multi):
         """Report sequences for items if possible"""
 

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -491,7 +491,10 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
         if self.sequences_file_path_prefix:
             self.store_sequences_for_items_multi(scg_taxonomy_super_dict_multi)
 
-        self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
+        if self.output_file_path:
+            self.store_scg_taxonomy_super_dict_multi_output_file(scg_taxonomy_super_dict_multi)
+        if self.output_file_prefix:
+            self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
 
 
     def estimate_for_metagenomes(self):
@@ -529,7 +532,10 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
         if self.sequences_file_path_prefix:
             self.store_sequences_for_items_multi(scg_taxonomy_super_dict_multi)
 
-        self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
+        if self.output_file_path:
+            self.store_scg_taxonomy_super_dict_multi_output_file(scg_taxonomy_super_dict_multi)
+        if self.output_file_prefix:
+            self.store_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
 
 
     def estimate(self):

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -21,7 +21,7 @@ import anvio.filesnpaths as filesnpaths
 from anvio.errors import ConfigError
 from anvio.dbops import ContigsDatabase, ContigsSuperclass
 from anvio.drivers.diamond import Diamond
-from anvio.genomedescriptions import MetagenomeDescriptions
+from anvio.genomedescriptions import GenomeDescriptions, MetagenomeDescriptions
 
 from anvio.taxonomyops import AccessionIdToTaxonomy
 from anvio.taxonomyops import TaxonomyEstimatorSingle

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -183,7 +183,7 @@ class SanityCheck(object):
             if self.__class__.__name__ in ['SCGTaxonomyEstimatorSingle']:
                 if self.metagenomes:
                     raise ConfigError("Taxonomy estimation classes have been initiated with a single contigs database, but your "
-                            "arguments also include input for metagenomes. It is a no no. Please choose either. ")
+                            "arguments also include an input file for multiple (meta)genomes. It is a no no. Please choose either. ")
 
                 if self.output_file_prefix:
                     raise ConfigError("When using SCG taxonomy estimation in this mode, you must provide an output file path "
@@ -272,9 +272,13 @@ class SanityCheck(object):
             ###########################################################
             if self.__class__.__name__ in ['SCGTaxonomyEstimatorMulti']:
                 if self.args.contigs_db or self.args.profile_db:
-                    raise ConfigError("Taxonomy estimation classes have been initiated with files for metagenomes, but your arguments "
-                                      "include also a single contigs or profile database path. You make anvi'o nervous. "
-                                      "Please run this program either with a metagenomes file or contigs/profile databases.")
+                    raise ConfigError("Taxonomy estimation classes have been initiated with files for multiple (meta)genomes, but "
+                                      "your arguments include also a single contigs or profile database path. You make anvi'o nervous. "
+                                      "Please run this program either with a (meta)genomes file or individual contigs/profile databases.")
+                
+                if self.args.external_genomes and self.args.metagenomes:
+                    raise ConfigError("More than one input file type (external genomes AND metagenomes) has been given to the "
+                                      "taxonomy estimation classes. Please run this program with only one input type at a time.")
 
                 if self.output_file_path:
                     raise ConfigError("When using SCG taxonomy estimation in this mode, you must provide an output file prefix rather "

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -280,13 +280,8 @@ class SanityCheck(object):
                     raise ConfigError("More than one input file type (external genomes AND metagenomes) has been given to the "
                                       "taxonomy estimation classes. Please run this program with only one input type at a time.")
 
-                if self.output_file_path:
-                    raise ConfigError("When using SCG taxonomy estimation in this mode, you must provide an output file prefix rather "
-                                      "than an output file path. Anvi'o will use your prefix and will generate many files that start "
-                                      "with that prefix but ends with different names for each taxonomic level.")
-
-                if not self.output_file_prefix:
-                    raise ConfigError("When using SCG taxonomy estimation in this mode, you must provide an output file prefix :/")
+                if not self.output_file_prefix and not self.output_file_path:
+                    raise ConfigError("When using SCG taxonomy estimation in this mode, you must provide an output file path or prefix :/")
 
                 if self.raw_output and self.matrix_format:
                     raise ConfigError("Please don't request anvi'o to report the output both in raw and matrix format. Anvi'o shall "

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -898,6 +898,25 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
 
             self.run.info('Output matrix for "%s"' % taxonomic_level, output_file_path)
 
+    
+    def store_scg_taxonomy_super_dict_multi_output_file(self, scg_taxonomy_super_dict_multi):
+        """Generates an output just like TaxonomyEstimatorSingle.store_items_taxonomy_super_dict(), but for multiple inputs."""
+        d = self.get_print_friendly_scg_taxonomy_super_dict_multi(scg_taxonomy_super_dict_multi)
+
+        headers = ['name', 'total_scgs', 'supporting_scgs']
+        headers += self.ctx.levels_of_taxonomy
+
+        with open(self.output_file_path, 'w') as output:
+            output.write('\t'.join(headers) + '\n')
+            for metagenome in d:
+                for name in d[metagenome]:
+                    # should be only one element in the innermost dictionary
+                    line = [name] + [d[metagenome][name][h] for h in headers[1:]]
+
+                    output.write('\t'.join([str(f) for f in line]) + '\n')
+
+        self.run.info("Output file", self.output_file_path, nl_before=1)
+
 
     def report_scg_frequencies_as_TAB_delimited_file(self):
         scgs_ordered_based_on_frequency, contigs_dbs_ordered_based_on_num_scgs, scg_frequencies = self.get_scg_frequencies()

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -1002,8 +1002,8 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
                                      "taxonomy in metagenome mode. So be it. SCG name is set to %s." \
                                         % (self.scg_name_for_metagenome_mode), nl_after=1)
             else:
-                self.run.info_single("Your metagenome file DOES NOT contain profile databases, and you haven't asked anvi'o to "
-                                     "work in `--metagenome-mode`. Your contigs databases will be treated as geomes rather than "
+                self.run.info_single("Your (meta)genome file DOES NOT contain profile databases, and you haven't asked anvi'o to "
+                                     "work in `--metagenome-mode`. Your contigs databases will be treated as genomes rather than "
                                      "metagenomes.", nl_after=1)
 
         self.progress.new("Recovering tax super dict", progress_total_items=len(self.metagenome_names))

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -418,7 +418,7 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
 
 
     def init_metagenomes(self):
-        self.progress.new("Initializing contigs DBs")
+        self.progress.new("Initializing contigs DBs for metagenomes")
         self.progress.update("...")
         g = MetagenomeDescriptions(self.args, run=run_quiet, progress=self.progress)
         g.load_metagenome_descriptions(skip_sanity_check=True)
@@ -430,13 +430,16 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
 
         metagenomes_without_scg_taxonomy = [m for m in g.metagenomes if not g.metagenomes[m]['scg_taxonomy_was_run']]
         if metagenomes_without_scg_taxonomy:
-            if len(metagenomes_without_scg_taxonomy) == len(g.metagenomes):
+            n_metagenomes = len(g.metagenomes)
+            n_without_tax = len(metagenomes_without_scg_taxonomy)
+            if n_without_tax == n_metagenomes:
                 self.progress.end()
-                raise ConfigError("Surprise! None of the %d genomes had no SCG taxonomy information." % len(g.metagenomes))
+                raise ConfigError(f"Surprise! None of the {n_metagenomes} metagenomes had SCG taxonomy information.")
             else:
                 self.progress.end()
-                raise ConfigError("%d of your %d genomes has no SCG taxonomy information. Here is the list: '%s'." % \
-                        (len(metagenomes_without_scg_taxonomy), len(g.metagenomes), ', '.join(metagenomes_without_scg_taxonomy)))
+                m_str = ', '.join(metagenomes_without_scg_taxonomy)
+                raise ConfigError(f"{n_without_tax} of your {n_metagenomes} metagenomes has no SCG taxonomy information. "
+                                  f"Here is the list of metagenomes you need to run `anvi-run-scg-taxonomy` on:: '{m_str}'.")
 
         # if we are here, it means SCGs were run for all metagenomes. here we will quickly check if versions agree
         # with each other and with the installed version of SCG taxonomy database

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -477,8 +477,11 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
             self.run.info("Num genomes", len(self.metagenome_names))
 
         self.run.info("Taxonomic level of interest", self.user_taxonomic_level or "(None specified by the user, so 'all levels')")
-        self.run.info("Output file prefix", self.output_file_prefix)
-        self.run.info("Output in matrix format", self.matrix_format)
+        if self.output_file_path:
+            self.run.info("Output file path", self.output_file_path)
+        if self.output_file_prefix:
+            self.run.info("Output file prefix", self.output_file_prefix)
+            self.run.info("Output in matrix format", self.matrix_format)
         self.run.info("Output raw data", self.raw_output)
         self.run.info("SCG coverages will be computed?", self.compute_scg_coverages)
 
@@ -503,8 +506,11 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
             self.run.info("Num metagenomes", len(self.metagenome_names))
 
         self.run.info("Taxonomic level of interest", self.user_taxonomic_level or "(None specified by the user, so 'all levels')")
-        self.run.info("Output file prefix", self.output_file_prefix)
-        self.run.info("Output in matrix format", self.matrix_format)
+        if self.output_file_path:
+            self.run.info("Output file path", self.output_file_path)
+        if self.output_file_prefix:
+            self.run.info("Output file prefix", self.output_file_prefix)
+            self.run.info("Output in matrix format", self.matrix_format)
         self.run.info("Output raw data", self.raw_output)
         self.run.info("SCG coverages will be computed?", self.compute_scg_coverages)
 

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -283,6 +283,9 @@ class SanityCheck(object):
                 if not self.output_file_prefix and not self.output_file_path:
                     raise ConfigError("When using SCG taxonomy estimation in this mode, you must provide an output file path or prefix :/")
 
+                if self.output_file_path and not self.output_file_prefix and self.matrix_format:
+                    raise ConfigError("Matrix format output only works if you provide an output file prefix.")
+
                 if self.raw_output and self.matrix_format:
                     raise ConfigError("Please don't request anvi'o to report the output both in raw and matrix format. Anvi'o shall "
                                       "not be confused :(")

--- a/bin/anvi-estimate-scg-taxonomy
+++ b/bin/anvi-estimate-scg-taxonomy
@@ -31,7 +31,7 @@ progress = terminal.Progress()
 
 @terminal.time_program
 def main(args):
-    if args.metagenomes:
+    if args.metagenomes or args.external_genomes:
         t = scgtaxonomyops.SCGTaxonomyEstimatorMulti(args)
     else:
         t = scgtaxonomyops.SCGTaxonomyEstimatorSingle(args)
@@ -57,9 +57,10 @@ if __name__ == '__main__':
     groupB.add_argument(*anvio.A('profile-db'), **anvio.K('profile-db', {'required': False}))
     groupB.add_argument(*anvio.A('collection-name'), **anvio.K('collection-name'))
 
-    groupC = parser.add_argument_group('INPUT #3', "You can also work with a metagenomes file, assuming that you have multiple metagenomes\
-                                                    with or without associated mapping results, and anvi'o would generate a singe output\
-                                                    file for all.")
+    groupC = parser.add_argument_group('INPUT #3', "You can also work with a external genomes or metagenomes file, assuming that you\
+                                                    have multiple (meta)genomes with or without associated mapping results, and anvi'o would\
+                                                    generate a single output file for all.")
+    groupC.add_argument(*anvio.A('external-genomes'), **anvio.K('external-genomes'))
     groupC.add_argument(*anvio.A('metagenomes'), **anvio.K('metagenomes'))
 
     groupD = parser.add_argument_group('OUTPUT AND FORMATTING', "Anvi'o will do its best to offer you some fancy output tables for your viewing \


### PR DESCRIPTION
This PR addresses #1689, as requested by @FlorianTrigodet and the members of the Bigelow Institute's single-cell genomics workshop (two years in a row, sorry for the delay).

I added only `--external-genomes` input to the program, since internal genomes are much more tricky (you would need to write new functions to extract only the SCG hits within a given bin). But external genomes was easy to add; I simply copied the existing strategy for working with multiple metagenomes, which enforces certain flags and then initializes/runs an instance of the `EstimatorSingle` class for each individual genome (and gathers the output afterwards). 

For external genomes, `--metagenome-mode` is enforced to be off, and we don't allow the use of profile db input (and downstream features that depend on profile dbs) since those doesn't get read by the `GenomeDescriptions` class when you load an external genomes file.

I tested on a small external genomes file containing one B. adolescentis genome and one E. faecalis genome, and it worked. Here is the species-level matrix output as evidence :)
```
taxon	E_faecalis_6240	isolate
Bifidobacterium adolescentis	0.00	1.00
Enterococcus faecalis	1.00	0.00
```

Side note, when I tried to test on the Infant Gut Tutorial to make sure that I didn't break anything with the metagenomes file input, I got this cryptic error (`The codebase is not ready to handle this :(`). The comments in the codebase that this was because we supposedly don't allow the use of merged profile databases in the case of multiple metagenome input:

(from line ~673 of `scg.py`)
```
# NOTE: what is happening down below might look stupid, because it really is. items of `d` here
            # contain a dictionary with the key 'coverages' where the coverage value of a given gene or bin
            # is kept per sample. to simplify downstream data wrangling operations, here we replace the
            # coverages dictionary with a single 'coverage': value entry to `d`. The
            # only reason we can do this here is becasue we only allow the user to use single profiles
            # with their metagenome descriptions and we are certain that there will be only a single entry in the
            # coverages dictionary.
```

Which is weird, because you can definitely run this program on the Infant Gut Tutorial when you use the single db input option, despite the profile being merged. Confusing. Maybe @meren has some insight on whether this is something that needs to be fixed for the `--metagenomes-file` input case.

Regardless, there is no sanity check in the class loading the metagenome descriptions that enforces single profile dbs, which means that everyone who tries this with multiple metagenomes and their merged profiles gets this very cryptic error. So I just updated the error text to be a bit more specific about what is going on. Still, I think that this should probably be changed to allow the use of merged profiles -- If you can do something with the single estimator class, you should be able to also do it with the multi-estimator class.

Anyway, currently hunting down a single profile db for a metagenome that I can use to make sure outputs are the same between the old version of the code and this branch.