### PR TITLE
Export locus hmm hits

### DIFF
--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -1275,7 +1275,7 @@ class LocusSplitter:
         for entry_id in hmm_hits_table_dict:
             hmm_hits_table_dict[entry_id]['gene_callers_id'] = G(hmm_hits_table_dict[entry_id]['gene_callers_id'])
 
-        entries = [[key] + list(value.values()) for key, value in hmm_hits_table_dict.items()]
+        entries = [[k] + list(v.values()) for k, v in hmm_hits_table_dict.items()]
         locus_db.insert_many(t.hmm_hits_table_name, entries=entries)
 
         # hmm_hits_info table

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -9,7 +9,6 @@ import os
 import sys
 import copy
 import argparse
-import pandas as pd
 
 from collections import Counter
 
@@ -28,14 +27,13 @@ import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
 import anvio.auxiliarydataops as auxiliarydataops
 
-from anvio.errors import ConfigError
 from anvio.panops import Pangenome
-from anvio.clusteringconfuguration import ClusteringConfiguration
+from anvio.errors import ConfigError
+from anvio.tables.views import TablesForViews
 from anvio.tables.kmers import KMerTablesForContigsAndSplits
 from anvio.tables.collections import TablesForCollections
 from anvio.tables.genefunctions import TableForGeneFunctions
-from anvio.tables.hmmhits import TablesForHMMHits
-from anvio.tables.views import TablesForViews
+from anvio.clusteringconfuguration import ClusteringConfiguration
 
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"

--- a/anvio/tests/run_component_tests_for_export_locus.sh
+++ b/anvio/tests/run_component_tests_for_export_locus.sh
@@ -28,3 +28,6 @@ anvi-export-locus -c CONTIGS.db --gene-caller-id 8616 -o test/ -n 7,30 -O metage
 
 INFO "Running anvi-export-locus in flank-mode"
 anvi-export-locus -c CONTIGS.db --gene-caller-id 68,78 -o test/ -O metagenome_68_78 --flank-mode
+
+INFO "Running anvi-export-locus in default-mode using HMM to find a BIG locus in a genome"
+anvi-export-locus -c P_marinus_CCMP1375.db --use-hmm --hmm-sources Bacteria_71 --search-term "Exonuc_VII_L" -n 500,500 -o test/ -O P_marinus_CCMP1375

--- a/bin/anvi-self-test
+++ b/bin/anvi-self-test
@@ -42,6 +42,7 @@ tests = {'mini'                  : ['run_component_tests_for_minimal_metagenomic
          'database-migrations'   : ['run_migration_tests_for_ancient_anvio_databases.sh'],
          'workflow-sra-download' : ['run_workflow_tests_for_sra_download.sh'],
          'run-cazymes'           : ['run_component_tests_for_cazymes.sh'],
+         'export-locus'          : ['run_component_tests_for_export_locus.sh'],
          }
 
 run = terminal.Run()


### PR DESCRIPTION
This PR is an improvement to [anvi-export-locus](https://anvio.org/help/7/programs/anvi-export-locus/) to additionally export `hmm-hits` tables from the input `contigs-db` to the output locus `contigs-db`. The program can now smoothly interface with other anvio tools such as [anvi-get-sequences-for-hmm-hits](https://anvio.org/help/main/programs/anvi-get-sequences-for-hmm-hits/)!