### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/daily-component-tests-and-migrations.yaml
+++ b/.github/workflows/daily-component-tests-and-migrations.yaml
@@ -13,8 +13,8 @@ jobs:
         python-version: ["3.10"]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         miniconda-version: 'latest'
         auto-update-conda: true
@@ -26,7 +26,7 @@ jobs:
       run: |
         conda info
         conda list
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: "Install anvi'o from the codebase"
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
Hi @meren,

this PR bumps the versions of the used GitHub Actions, which will get rid of the warnings (e.g. Node.js 16 actions are deprecated. [...] in the [Annotations section under Actions](https://github.com/merenlab/anvio/actions/runs/8982635907).