### PR TITLE
add GenBank file check for identical locus names

### DIFF
--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -775,8 +775,12 @@ class GenbankToAnvio:
 
         # The main loop to go through all records forreals.
         for genbank_record in self.get_genbank_file_object():
-            num_genbank_records_processed += 1
-            output_fasta[genbank_record.name] = str(genbank_record.seq)
+            if genbank_record.name in output_fasta:
+                raise ConfigError("Anvi'o is not able to convert this GenBank file because it contains sequences with identical "
+                                   "locus names :/. An example is locus '%s'." % genbank_record.name)
+            else:
+                num_genbank_records_processed += 1
+                output_fasta[genbank_record.name] = str(genbank_record.seq)
 
             genes = [gene for gene in genbank_record.features if gene.type =="CDS"] # focusing on features annotated as "CDS" by NCBI's PGAP
 


### PR DESCRIPTION
Adds a check and throws an error if the GenBank file used as input for anvi-script-process-genbank contains sequences with the same locus name, as this will cause the sequences to be overwritten in the output fasta.