### PR TITLE
A solution for prodigal segmentation fault errors

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -310,6 +310,19 @@ D = {
                      "frames in contigs by running a bacterial gene caller. Declaring this flag will by-pass that "
                      "process. If you prefer, you can later import your own gene calling results into the database."}
                 ),
+    'prodigal-single-mode': (
+            ['--prodigal-single-mode'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "By default, anvi'o will use prodigal for gene calling (unless you skipped gene calling, or provided "
+                     "anvi'o with external gene calls). One of the flags anvi'o includes in prodigal run is `-p meta`, which "
+                     "optimizes prodigal's ability to identify genes in metagenomic assemblies. In some rare cases, for a "
+                     "given set of contigs prodigal will yield a segmentation fault error due to one or more genes in your "
+                     "collections will confuse the program when it is used with the `-p meta` flag. While anvi'o developers "
+                     "are not quite sure under what circumstances this happens, we realized that removal of this flag often "
+                     "solves this issue. If you are dealing with such cyrptic errors, the inclusion of `--skip-prodigal-meta-flag` "
+                     "will instruct anvi'o to run prodigal without the `-meta` flag, and may resolve this issue for you."}
+                ),
     'remove-partial-hits': (
             ['--remove-partial-hits'],
             {'default': False,

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -4316,6 +4316,7 @@ class ContigsDatabase:
         ignore_internal_stop_codons = A('ignore_internal_stop_codons')
         skip_predict_frame= A('skip_predict_frame')
         prodigal_translation_table = A('prodigal_translation_table')
+        prodigal_single_mode = A('prodigal_single_mode')
 
         if external_gene_calls_file_path:
             filesnpaths.is_proper_external_gene_calls_file(external_gene_calls_file_path)
@@ -4516,6 +4517,8 @@ class ContigsDatabase:
         if external_gene_calls_file_path:
             self.run.info('External gene calls file have AA sequences?', external_gene_calls_include_amino_acid_sequences, mc='green')
             self.run.info('Proper frames will be predicted?', (not skip_predict_frame), mc='green')
+        else:
+            self.run.info('Is prodigal run in single mode?', ('YES' if prodigal_single_mode else 'NO'), mc='green')
 
         self.run.info('Ignoring internal stop codons?', ignore_internal_stop_codons)
         self.run.info('Splitting pays attention to gene calls?', (not skip_mindful_splitting))

--- a/anvio/drivers/prodigal.py
+++ b/anvio/drivers/prodigal.py
@@ -35,10 +35,10 @@ class Prodigal:
         self.progress = progress
         self.run = run
         self.args = args
-
         A = lambda x: (args.__dict__[x] if x in args.__dict__ else None) if args else None
         self.prodigal_translation_table = A('prodigal_translation_table')
         self.num_threads = A('num_threads')
+        self.prodigal_single_mode = A('prodigal_single_mode')
 
         self.run.info('Num threads for gene calling', self.num_threads)
 
@@ -89,6 +89,7 @@ class Prodigal:
 
         return hit
 
+
     def check_version(self):
         """checks the installed version of prodigal, sets the parser"""
 
@@ -105,6 +106,7 @@ class Prodigal:
         self.installed_version = version_found
         self.parser = self.available_parsers[version_found]
 
+
     def process(self, fasta_file_path, output_dir):
         """Take the fasta file, run prodigal on it, and make sense of the output
 
@@ -116,15 +118,16 @@ class Prodigal:
         self.genes_in_contigs = os.path.join(output_dir, 'contigs.genes')
         self.amino_acid_sequences_in_contigs = os.path.join(output_dir, 'contigs.amino_acid_sequences')
 
-        # Put some nice logging info.
-        self.run.warning('', header='Finding ORFs in contigs', lc='green')
-        self.run.info('Genes', self.genes_in_contigs)
-        self.run.info('Amino acid sequences', self.amino_acid_sequences_in_contigs)
-        self.run.info('Log file', log_file_path)
-
         self.run.warning("Anvi'o will use 'prodigal' by Hyatt et al (doi:10.1186/1471-2105-11-119) to identify open "
                          "reading frames in your data. When you publish your findings, please do not forget to "
                          "properly credit their work.", lc='green', header="CITATION")
+
+        # Put some nice logging info.
+        self.run.warning('', header='Finding ORFs in contigs using prodigal', lc='green')
+        self.run.info('Procedure', 'single' if self.prodigal_single_mode else 'meta')
+        self.run.info('Genes', self.genes_in_contigs)
+        self.run.info('Amino acid sequences', self.amino_acid_sequences_in_contigs)
+        self.run.info('Log file', log_file_path)
 
         self.progress.new('Processing')
         self.progress.update(f"Identifying ORFs using {terminal.pluralize('thread', self.num_threads)}.")
@@ -153,7 +156,8 @@ class Prodigal:
                                   logger=terminal.Logger(progress=self.progress, run=self.run),
                                   installed_version=self.installed_version,
                                   parser=self.parser,
-                                  translation_table=self.prodigal_translation_table)
+                                  translation_table=self.prodigal_translation_table,
+                                  prodigal_single_mode=self.prodigal_single_mode)
 
         prodigal_runner = ThreadedProdigalRunner(args)
 

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -495,7 +495,24 @@ class TablesForGeneCalls(Table):
 
         gene_caller = genecalling.GeneCaller(self.contigs_fasta, gene_caller=gene_caller, args=self.args, debug=self.debug)
 
-        gene_calls_dict, amino_acid_sequences = gene_caller.process()
+        try:
+            gene_calls_dict, amino_acid_sequences = gene_caller.process()
+        except Exception as e:
+            if 'prodigal' in e.e:
+                self.run.warning("There was a problem with your gene calling, and the error seems to be related to 'prodigal'. Please "
+                                 "find additional details below. It is difficult to determine what caused this error, but if you would "
+                                 "like to be certain, you can literally copy the command shown below into a single line, and run on "
+                                 "the same machine manually (or re-run the same command you run to get this error with the `--debug` flag "
+                                 "to keep all the original log files from profigal). If this error is due to a 'segmentation fault', "
+                                 "please consider including `--prodigal-single-mode` flag `anvi-gen-contigs-database` command. More "
+                                 "information `--prodigal-single-mode` is available in the help menu of `anvi-gen-contigs-database`.",
+                                 header="💀 PRODIGAL FAILED 💀")
+
+            # remove the unfinished contigs-db file
+            os.remove(self.db_path)
+
+            # show the user the actual error from down below
+            raise ConfigError(f"{e}")
 
         if not self.debug and remove_fasta_after_processing:
             os.remove(self.contigs_fasta)

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -484,7 +484,7 @@ class TablesForGeneCalls(Table):
 
         if not self.contigs_fasta:
             self.contigs_fasta = filesnpaths.get_temp_file_path()
-            utils.export_sequences_from_contigs_db(self.contigs_db_path,
+            utils.export_sequences_from_contigs_db(self.db_path,
                                                    output_file_path=self.contigs_fasta,
                                                    run=self.run)
             remove_fasta_after_processing = True

--- a/anvio/threadingops.py
+++ b/anvio/threadingops.py
@@ -448,8 +448,14 @@ class ThreadedProdigalRunner(ThreadedCommandRunner):
                         "you are reading this message, then please contact an anvi'o developer."
                         % str(self.translation_table))
             else:
-                # Use 'meta' mode if no translation tables are given.
-                command.extend(['-p', 'meta'])
+                if self.prodigal_single_mode:
+                    # the user explicitly requested to not use the `-p meta` flag to run
+                    # prodigal (the default procedure is single, so prodigal will fall back
+                    # to 'single' mode in this case)
+                    pass
+                else:
+                    # Use 'meta' mode if no translation tables are given.
+                    command.extend(['-p', 'meta'])
 
             self.commands.append(command)
 

--- a/anvio/threadingops.py
+++ b/anvio/threadingops.py
@@ -357,7 +357,7 @@ class ThreadedProdigalRunner(ThreadedCommandRunner):
         A = lambda x: args.__dict__[x] if x in args.__dict__ else None
 
         required_args = ['input_file_path', 'collated_output_file_paths', 'number_of_splits', 'log_file_path',
-                         'installed_version', 'parser']
+                         'installed_version', 'parser', 'prodigal_single_mode']
 
         # Check that the required arguments are present.
         for arg in required_args:
@@ -370,6 +370,7 @@ class ThreadedProdigalRunner(ThreadedCommandRunner):
                          log_file_path=A('log_file_path'),
                          logger=A('logger'))
 
+        self.prodigal_single_mode = A('prodigal_single_mode')
         self.installed_version = A('installed_version')
         self.parser = A('parser')
 
@@ -379,6 +380,7 @@ class ThreadedProdigalRunner(ThreadedCommandRunner):
             translation_table = str(translation_table)
 
         self.translation_table = translation_table
+
 
     # Implement the abstract methods
     #
@@ -400,6 +402,7 @@ class ThreadedProdigalRunner(ThreadedCommandRunner):
         self.input_file_splits = utils.split_fasta(self.input_file_path, parts=self.number_of_splits, shuffle=True)
 
         return State(input_file_splits=self.input_file_splits)
+
 
     def _make_commands(self):
         """Make commands and store them in `self.commands`.

--- a/bin/anvi-gen-contigs-database
+++ b/bin/anvi-gen-contigs-database
@@ -53,6 +53,7 @@ if __name__ == '__main__':
 
     groupD = parser.add_argument_group('GENES IN CONTIGS', 'Expert thingies.')
     groupD.add_argument(*anvio.A('skip-gene-calling'), **anvio.K('skip-gene-calling'))
+    groupD.add_argument(*anvio.A('prodigal-single-mode'), **anvio.K('prodigal-single-mode'))
     groupD.add_argument(*anvio.A('prodigal-translation-table'), **anvio.K('prodigal-translation-table'))
     groupD.add_argument(*anvio.A('external-gene-calls'), **anvio.K('external-gene-calls'))
     groupD.add_argument(*anvio.A('ignore-internal-stop-codons'), **anvio.K('ignore-internal-stop-codons'))


### PR DESCRIPTION
We recently have been hearing about some prodigal issues from our users that led to errors similar to this one:

```
  gene_calls_dict, amino_acid_sequences_dict = gene_caller.process(self.fasta_file_path, output_dir) 
 
  File folderpath/github/anvio/anvio/drivers/prodigal.py", line 161, in process 
    state = prodigal_runner.run() 
 
  File " folderpath/github/anvio/anvio/threadingops.py", line 182, in run 
    **self._run_commands(), 
 
  File folderpath /github/anvio/anvio/threadingops.py", line 291, in _run_commands 
    self._check_threads_for_errors() 
 
  File "folderpath/github/anvio/anvio/threadingops.py", line 333, in _check_threads_for_errors raise thread.target_return_value 
 
anvio.errors.CommandError: 

Command Error: Command failed to run. What command, you say? This: 'prodigal -m -i
folderpath/sample.fasta.0 -o  folderpath/contigs.genes.split_0  -a folderpath/contigs.amino_acid_sequences.split_0 -p meta'
```

By going down in the error logs with `--debug` flag and through manual attempts I realized that this was related to some weird memory issues on prodigal side:

```
$ prodigal -m -i err.fa -o genes.txt -a aa.txt -p meta
-------------------------------------
PRODIGAL v2.6.3 [February, 2016]
Univ of Tenn / Oak Ridge National Lab
Doug Hyatt, Loren Hauser, et al.
-------------------------------------
Request:  Metagenomic, Phase:  Training
Initializing training files...done!
-------------------------------------
Request:  Metagenomic, Phase:  Gene Finding
Finding genes in sequence #1 (841195 bp)...Segmentation fault: 11
```

I further realized that the removal of `-p meta` parameter solved the issues for the same exact file:

```
$ prodigal -m -i err.fa -o genes.txt -a aa.txt
-------------------------------------
PRODIGAL v2.6.3 [February, 2016]
Univ of Tenn / Oak Ridge National Lab
Doug Hyatt, Loren Hauser, et al.
-------------------------------------
Request:  Single Genome, Phase:  Training
Reading in the sequence(s) to train...841195 bp seq created, 57.83 pct GC
Locating all potential starts and stops...84766 nodes
Looking for GC bias in different frames...frame bias scores: 0.71 0.24 2.05
Building initial set of genes to train from...done!
Creating coding model and scoring nodes...done!
Examining upstream regions and training starts...done!
-------------------------------------
Request:  Single Genome, Phase:  Gene Finding
Finding genes in sequence #1 (841195 bp)...done!
```

This problem caused only by some files in contigs fasta files, but it fails the entire process when it happens. There is no good solution for that, but this PR adds a new parameter to `anvi-gen-contigs-db`, `--prodigal-single-mode`, which omits the use of `-p meta` and solves the issue.

We included `-p meta` by default, since it seemed to perform better for metagenomic assemblies compared to `-p single`. But this cases shows that we have to have an option to prevent this weird problem.

I thank @tdelmont who brought this up the first time, and all the others who helped us diagnose it in anvi'o Discord channel.