### PR TITLE
anvi-export-locus updates

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1496,6 +1496,21 @@ D = {
             {'metavar': 'SEARCH_TERMS',
              'help': "Search terms. Multiple of them can be declared separated by a delimiter (the default is a comma)."}
                 ),
+    'case-sensitive': (
+            ['--case-sensitive'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "When declared, anvi'o will perform a search that is case sensitive."}
+                ),
+    'exact-match': (
+            ['--exact-match'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "By default, anvi'o will search for a given string in anywhere within function description or "
+                     "accession IDs. If you declare this flag, then anvi'o will look for 'exact' matches of the search "
+                     "string in its entirety in a given field. This can be very useful if you are CERTAIN about the "
+                     "function or accession id you are interested in, and you want to get nothing but that exact match."}
+                ),
     'gene-caller-ids': (
             ['--gene-caller-ids'],
             {'metavar': 'GENE_CALLER_IDS',

--- a/anvio/docs/programs/anvi-search-functions.md
+++ b/anvio/docs/programs/anvi-search-functions.md
@@ -1,33 +1,316 @@
-This program **searches for keywords in the function annotations of your database.** 
+You can use this program to search for genes that encode specific functions in a %(contigs-db)s, %(genomes-storage-db)s or %(pan-db)s.
 
-You can use this program to look for specific functon keywords in a %(contigs-db)s, %(genomes-storage-db)s or %(pan-db)s. For example, say you wanted your %(contigs-db)s to search for genes that encoded some type of kinase. You could call 
+## Search
+
+For example, you could search for all genes in a given %(contigs-db)s that encode a function related to the keyword 'kinase' the following way:
 
 {{ codestart }}
 anvi-search-functions -c %(contigs-db)s \
                       --search-terms kinase
 {{ codestop }}
 
-By default, the output will be a fairly barren %(functions-txt)s, only telling you which contigs contain genes that matched your search. This will be most helpful as an additional layer in the anvi'o interactive interface, so you can quickly see where the kinase-encoding genes are in the genome. To do this, run %(anvi-interactive)s with the `--aditional-layer` parameter with the %(functions-txt)s. 
-
-However, you can also request a much more comprehensive output that contains much more information, including the matching genes' caller id, functional annotation source and full function name. 
-
-For example, to run the same search as above, but with a more comprehensive output, you could call 
+If you include `--verbose` flag in your command, %(anvi-search-functions)s will offer you a quick look at the matching function names:
 
 {{ codestart }}
 anvi-search-functions -c %(contigs-db)s \
-                      --search-terms kinase \
-                      --full-report kinase_information.txt \
-                      --include-sequences \
+                      --search-terms Phage \
                       --verbose
 {{ codestop }}
 
-Following this run, the file `kinase_information.txt` will contain comprehensive information about the matching genes, including their sequences. 
+```
+Searching in Contigs Database ................: CONTIGS.db
+Contigs DB ...................................: Initialized: CONTIGS.db (v. 23)
+Search terms .................................: 1 found: 'Phage'
+Case sensitive search? .......................: False
+Exact match? .................................: False
 
-You can also search for multiple terms at the same time, or for terms from only specific annotation sources. For example, if you only wanted Pfam hits with functions related to kinases or phosphatases, you could call 
+Matches ......................................: 380 unique genes contained the search term "Phage"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* Mobilome: prophages, transposons; Mobilome: prophages, transposons :: X; X within 'COG20_CATEGORY'
+* Mobilome: prophages, transposons :: X within 'COG20_CATEGORY'
+* Phage terminase-like protein, large subunit, contains N-terminal HTH domain (YmfN) :: COG4626 within 'COG20_FUNCTION'
+* Phage-related protein (PblB) :: COG4926 within 'COG20_FUNCTION'
+* Putative phage head morphogenesis protein, F of phage Mu or gp7 of SPP1 :: COG5585 within 'COG20_FUNCTION'
+* Phage portal protein BeeE (BeeE) :: COG4695 within 'COG20_FUNCTION'
+* Replication, recombination and repair; Mobilome: prophages, transposons :: L; X within 'COG20_CATEGORY'
+* Abortive infection bacteriophage resistance protein (AbiF) :: COG4823 within 'COG20_FUNCTION'
+* Phage-related holin (Lysis protein) :: COG4824 within 'COG20_FUNCTION'
+* Phage terminase large subunit (XtmB) (PDB:4IDH) :: COG1783 within 'COG20_FUNCTION'
+* Uncharacterized membrane protein YhgE, phage infection protein (PIP) family (YhgE) :: COG1511 within 'COG20_FUNCTION'
+* Cell wall/membrane/envelope biogenesis; Mobilome: prophages, transposons :: M; X within 'COG20_CATEGORY'
+* Prophage pi2 protein 07 :: COG4707 within 'COG20_FUNCTION'
+* Prophage antirepressor :: COG3617 within 'COG20_FUNCTION'
+* Phage antirepressor protein YoqD, KilAC domain (KilAC) :: COG3645 within 'COG20_FUNCTION'
+* phage shock protein E :: K03972 within 'KOfam'
+* Escherichia/Staphylococcus phage prohead protease :: K06904 within 'KOfam'
+* putative DNA-invertase from lambdoid prophage Rac :: K14060 within 'KOfam'
+* DNA primase, phage- or plasmid-associated :: COG3378 within 'COG20_FUNCTION'
+* phage terminase large subunit :: K06909 within 'KOfam'
+* Phage-related protein :: COG5412 within 'COG20_FUNCTION'
+* phage terminase small subunit :: K07474 within 'KOfam'
+* Phage head maturation protease :: COG3740 within 'COG20_FUNCTION'
+* Phage-related replication protein YjqB, UPF0714/DUF867 family (YjqB) (PDB:3A9L) :: COG4195 within 'COG20_FUNCTION'
+* phage shock protein C :: K03973 within 'KOfam'
+
+Items additional data compatible output ......: search_results.txt
+```
+
+By default, the search is case insensitive. But you can make it case sensitive with the flag `--case-sensitive`:
 
 {{ codestart }}
 anvi-search-functions -c %(contigs-db)s \
-                      --search-terms kinase,phosphatase \
-                      --annotation-sources Pfam \ 
-                      --full-report kinase_phosphatase_information.txt
+                      --search-terms Phage \
+                      --case-sensitive \
+                      --verbose
+{{ codestop }}
+
+```
+Searching in Contigs Database ................: CONTIGS.db
+Contigs DB ...................................: Initialized: CONTIGS.db (v. 23)
+Search terms .................................: 1 found: 'Phage'
+Case sensitive search? .......................: True
+Exact match? .................................: False
+
+Matches ......................................: 109 unique genes contained the search term "Phage"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* Phage terminase-like protein, large subunit, contains N-terminal HTH domain (YmfN) :: COG4626 within 'COG20_FUNCTION'
+* Phage-related replication protein YjqB, UPF0714/DUF867 family (YjqB) (PDB:3A9L) :: COG4195 within 'COG20_FUNCTION'
+* Phage antirepressor protein YoqD, KilAC domain (KilAC) :: COG3645 within 'COG20_FUNCTION'
+* Phage anti-repressor protein Ant (PUBMED:27099293); Phage antirepressor protein YoqD, KilAC domain (KilAC) :: COG3561; COG3645 within 'COG20_FUNCTION'
+* Phage terminase large subunit (XtmB) (PDB:4IDH) :: COG1783 within 'COG20_FUNCTION'
+* Phage-related protein YomH (YomH) (PDB:2X8K) :: COG4722 within 'COG20_FUNCTION'
+* Phage portal protein BeeE (BeeE) :: COG4695 within 'COG20_FUNCTION'
+* Phage-related protein :: COG5412 within 'COG20_FUNCTION'
+* Phage repressor protein C, contains Cro/C1-type HTH and peptisase s24 domains :: COG2932 within 'COG20_FUNCTION'
+* Phage-related protein (PblB) :: COG4926 within 'COG20_FUNCTION'
+* Phage shock protein PspC (stress-responsive transcriptional regulator) (PspC) :: COG1983 within 'COG20_FUNCTION'
+* Murein DD-endopeptidase MepM and murein hydrolase activator NlpD, contains LysM domain (NlpD) (PDB:2GU1); Phage-related protein :: COG0739; COG5412 within 'COG20_FUNCTION'
+* Phage-related holin (Lysis protein) :: COG4824 within 'COG20_FUNCTION'
+* Phage head-tail adaptor (PDB:2Y3D) :: COG5614 within 'COG20_FUNCTION'
+* Phage-related minor tail protein (YqbO); Phage-related protein :: COG5280; COG5412 within 'COG20_FUNCTION'
+* Phage-related tail protein :: COG5283 within 'COG20_FUNCTION'
+* Phage regulatory protein Rha (pRha) :: COG3646 within 'COG20_FUNCTION'
+* Phage head maturation protease :: COG3740 within 'COG20_FUNCTION'
+* Phage terminase, small subunit (XtmA) (PDB:4ZC3) :: COG3728 within 'COG20_FUNCTION'
+* Prophage antirepressor; Phage antirepressor protein YoqD, KilAC domain (KilAC) :: COG3617; COG3645 within 'COG20_FUNCTION'
+* Phage terminase, small subunit :: COG3747 within 'COG20_FUNCTION'
+* Murein DD-endopeptidase MepM and murein hydrolase activator NlpD, contains LysM domain (NlpD) (PDB:2GU1); SLT domain protein (SLT) (PUBMED:15608122); Phage-related minor tail protein (YqbO); Phage-related protein :: COG0739; COG3953; COG5280; COG5412 within 'COG20_FUNCTION'
+* Phage shock protein A (PspA) (PDB:4WHE) :: COG1842 within 'COG20_FUNCTION'
+* Transcriptional regulator, contains XRE-family HTH domain (HipB) (PDB:1ADR); Phage repressor protein C, contains Cro/C1-type HTH and peptisase s24 domains :: COG1396; COG2932 within 'COG20_FUNCTION'
+
+Items additional data compatible output ......: search_results.txt
+```
+
+By defult the search term is searched anywhere in the function. The `--exact-match` flag change that behavior, and will only return matches if the entire field of text matches to the search term:
+
+{{ codestart }}
+anvi-search-functions -c %(contigs-db)s \
+                      --search-terms "Phage head maturation protease" \
+                      --exact-match \
+                      --verbose
+{{ codestop }}
+
+```
+Searching in Contigs Database ................: CONTIGS.db
+Contigs DB ...................................: Initialized: CONTIGS.db (v. 23)
+Search terms .................................: 1 found: 'Phage head maturation protease'
+Case sensitive search? .......................: False
+Exact match? .................................: True
+
+Matches ......................................: 3 unique genes contained the search term "Phage head maturation protease"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* Phage head maturation protease :: COG3740 within 'COG20_FUNCTION'
+
+Items additional data compatible output ......: search_results.txt
+```
+
+By default, all function annotation sources are included in the search, however, the parameter `--annotation-sources` can be used to limit the search to one or more specific annotation sources:
+
+{{ codestart }}
+anvi-search-functions -c %(contigs-db)s \
+                      --search-terms Phage \
+                      --annotation-sources KOfam \
+                      --verbose
+{{ codestop }}
+
+```
+Searching in Contigs Database ................: CONTIGS.db
+Contigs DB ...................................: Initialized: CONTIGS.db (v. 23)
+Search terms .................................: 1 found: 'Phage'
+Case sensitive search? .......................: False
+Exact match? .................................: False
+
+Matches ......................................: 51 unique genes contained the search term "Phage"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* putative DNA-invertase from lambdoid prophage Rac :: K14060 within 'KOfam'
+* phage terminase small subunit :: K07474 within 'KOfam'
+* phage shock protein E :: K03972 within 'KOfam'
+* DNA polymerase bacteriophage-type [EC:2.7.7.7] :: K02334 within 'KOfam'
+* phage terminase large subunit :: K06909 within 'KOfam'
+* macrophage erythroblast attacher :: K18624 within 'KOfam'
+* Escherichia/Staphylococcus phage prohead protease :: K06904 within 'KOfam'
+* phage shock protein A :: K03969 within 'KOfam'
+* phage shock protein C :: K03973 within 'KOfam'
+
+Items additional data compatible output ......: search_results.txt
+```
+
+Similar to functions, accession IDs can be searched, as well:
+
+{{ codestart }}
+anvi-search-functions -c %(contigs-db)s \
+                      --search-terms COG4824,COG5614 \
+                      --verbose
+{{ codestop }}
+
+```
+Searching in Contigs Database ................: CONTIGS.db
+Contigs DB ...................................: Initialized: CONTIGS.db (v. 23)
+Search terms .................................: 2 found: 'COG4824|COG5614'
+Case sensitive search? .......................: False
+Exact match? .................................: False
+
+Matches ......................................: 8 unique genes contained the search term "COG4824"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* Phage-related holin (Lysis protein) :: COG4824 within 'COG20_FUNCTION'
+
+Matches ......................................: 1 unique genes contained the search term "COG5614"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* Phage head-tail adaptor (PDB:2Y3D) :: COG5614 within 'COG20_FUNCTION'
+
+Items additional data compatible output ......: search_results.txt
+```
+
+## Output
+
+By default, the output will be a fairly barren, and will only show which contigs contain genes that matched to a given. This output file will be most helpful as an additional layer in the anvi'o interactive interface to quickly see the items that include genes with functions that match to the search terms.
+
+However, generating a more comprehensive report is also an option through the parameter `--full-report`:
+
+{{ codestart }}
+anvi-search-functions -c %(contigs-db)s \
+                      --search-terms Phage \
+                      --full-report phage-results.txt \
+                      --verbose
+{{ codestop }}
+
+```
+anvi-search-functions -c CONTIGS.db --search-terms Phage --verbose --full-report phage-reuslts.txt
+Searching in Contigs Database ................: CONTIGS.db
+Contigs DB ...................................: Initialized: CONTIGS.db (v. 23)
+Search terms .................................: 1 found: 'Phage'
+Case sensitive search? .......................: False
+Exact match? .................................: False
+
+Matches ......................................: 380 unique genes contained the search term "Phage"
+
+Sneak peak into matching functions (up to 25)
+===============================================
+* Uncharacterized membrane protein YhgE, phage infection protein (PIP) family (YhgE) :: COG1511 within 'COG20_FUNCTION'
+* Phage-related holin (Lysis protein) :: COG4824 within 'COG20_FUNCTION'
+* Mobilome: prophages, transposons :: X within 'COG20_CATEGORY'
+* DNA primase, phage- or plasmid-associated :: COG3378 within 'COG20_FUNCTION'
+* Phage-related protein (PblB) :: COG4926 within 'COG20_FUNCTION'
+* Phage-related replication protein YjqB, UPF0714/DUF867 family (YjqB) (PDB:3A9L) :: COG4195 within 'COG20_FUNCTION'
+* Uncharacterized phage-associated protein, contains DUF4065 domain (GepA) :: COG3600 within 'COG20_FUNCTION'
+* phage terminase large subunit :: K06909 within 'KOfam'
+* Predicted phage phi-C31 gp36 major capsid-like protein (gp36) :: COG4653 within 'COG20_FUNCTION'
+* phage terminase small subunit :: K07474 within 'KOfam'
+* Phage anti-repressor protein Ant (PUBMED:27099293); Phage antirepressor protein YoqD, KilAC domain (KilAC) :: COG3561; COG3645 within 'COG20_FUNCTION'
+* Phage-related minor tail protein (YqbO); Phage-related protein :: COG5280; COG5412 within 'COG20_FUNCTION'
+* Abortive infection bacteriophage resistance protein (AbiF) :: COG4823 within 'COG20_FUNCTION'
+* Phage-related protein :: COG5412 within 'COG20_FUNCTION'
+* Phage shock protein PspC (stress-responsive transcriptional regulator) (PspC) :: COG1983 within 'COG20_FUNCTION'
+* Phage-related protein YomH (YomH) (PDB:2X8K) :: COG4722 within 'COG20_FUNCTION'
+* Holliday junction resolvase RusA (prophage-encoded endonuclease) (RusA) (PDB:1Q8R) :: COG4570 within 'COG20_FUNCTION'
+* Prophage antirepressor; Phage antirepressor protein YoqD, KilAC domain (KilAC) :: COG3617; COG3645 within 'COG20_FUNCTION'
+* phage shock protein E :: K03972 within 'KOfam'
+* Cell wall/membrane/envelope biogenesis; Mobilome: prophages, transposons; Mobilome: prophages, transposons; Mobilome: prophages, transposons :: M; X; X; X within 'COG20_CATEGORY'
+* Phage terminase large subunit (XtmB) (PDB:4IDH) :: COG1783 within 'COG20_FUNCTION'
+* DNA polymerase bacteriophage-type [EC:2.7.7.7] :: K02334 within 'KOfam'
+* Mobilome: prophages, transposons; Mobilome: prophages, transposons :: X; X within 'COG20_CATEGORY'
+* putative DNA-invertase from lambdoid prophage Rac :: K14060 within 'KOfam'
+* phage shock protein C :: K03973 within 'KOfam'
+
+Items additional data compatible output ......: search_results.txt
+Full report ..................................: phage-reuslts.txt
+```
+
+This will result in an output file that will look like this:
+
+|**gene_callers_id**|**source**|**accession**|**function**|**search_term**|**contigs**|
+|:--|:--|:--|:--|:--|:--|
+|560|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig1_split_00030|
+|563|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig1_split_00030|
+|756|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig1_split_00041|
+|757|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig1_split_00041|
+|779|COG20_FUNCTION|COG1983|Phage shock protein PspC (stress-responsive transcriptional regulator) (PspC)|Phage|Day17a_QCcontig1_split_00042|
+|1550|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig4_split_00008|
+|1555|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig4_split_00009|
+|1556|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig4_split_00009|
+|1557|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig4_split_00009|
+|1604|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig4_split_00011|
+|1605|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig4_split_00011|
+|2580|COG20_FUNCTION|COG4653|Predicted phage phi-C31 gp36 major capsid-like protein (gp36)|Phage|Day17a_QCcontig9_split_00011|
+|2580|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig9_split_00011|
+|2733|COG20_FUNCTION|COG4824|Phage-related holin (Lysis protein)|Phage|Day17a_QCcontig13_split_00002|
+|2733|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig13_split_00002|
+|2767|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig14_split_00001|
+|2825|COG20_FUNCTION|COG1511|Uncharacterized membrane protein YhgE, phage infection protein (PIP) family (YhgE)|Phage|Day17a_QCcontig15_split_00003|
+|2965|COG20_FUNCTION|COG4823|Abortive infection bacteriophage resistance protein (AbiF)|Phage|Day17a_QCcontig16_split_00006|
+|3029|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig16_split_00009|
+|3170|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig17_split_00002|
+|13008|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig276_split_00001|
+|13009|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig277_split_00001|
+|13022|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig279_split_00001|
+|13029|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig280_split_00001|
+|13106|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig283_split_00001|
+|13107|COG20_FUNCTION|COG3378|DNA primase, phage- or plasmid-associated|Phage|Day17a_QCcontig283_split_00001|
+|13107|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig283_split_00001|
+|13116|COG20_FUNCTION|COG3728|Phage terminase, small subunit (XtmA) (PDB:4ZC3)|Phage|Day17a_QCcontig283_split_00001|
+|13116|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig283_split_00001|
+|13135|COG20_FUNCTION|COG2369|Uncharacterized protein, contains phage Mu head morphogenesis gpF-like domain|Phage|Day17a_QCcontig285_split_00001|
+|13135|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig285_split_00001|
+|13141|COG20_FUNCTION|COG2369|Uncharacterized protein, contains phage Mu head morphogenesis gpF-like domain|Phage|Day17a_QCcontig286_split_00001|
+|13141|COG20_CATEGORY|X|Mobilome: prophages, transposons|Phage|Day17a_QCcontig286_split_00001|
+|15448|KOfam|K06909|phage terminase large subunit|Phage|Day17a_QCcontig476_split_00003|
+|13143|KOfam|K06909|phage terminase large subunit|Phage|Day17a_QCcontig286_split_00001|
+|15293|KOfam|K06909|phage terminase large subunit|Phage|Day17a_QCcontig470_split_00001|
+|15450|KOfam|K06909|phage terminase large subunit|Phage|Day17a_QCcontig476_split_00003|
+|8686|KOfam|K03973|phage shock protein C|Phage|Day17a_QCcontig100_split_00001|
+|9711|KOfam|K03973|phage shock protein C|Phage|Day17a_QCcontig125_split_00007|
+|14379|KOfam|K03972|phage shock protein E|Phage|Day17a_QCcontig379_split_00001|
+|27227|KOfam|K18624|macrophage erythroblast attacher|Phage|Day17a_QCcontig2462_split_00001|
+|31918|KOfam|K06904|Escherichia/Staphylococcus phage prohead protease|Phage|Day17a_QCcontig4102_split_00001|
+|31919|KOfam|K06904|Escherichia/Staphylococcus phage prohead protease|Phage|Day17a_QCcontig4102_split_00001|
+|2561|KOfam|K02334|DNA polymerase bacteriophage-type [EC:2.7.7.7]|Phage|Day17a_QCcontig9_split_00011|
+|1803|KOfam|K02334|DNA polymerase bacteriophage-type [EC:2.7.7.7]|Phage|Day17a_QCcontig4_split_00021|
+|3955|KOfam|K02334|DNA polymerase bacteriophage-type [EC:2.7.7.7]|Phage|Day17a_QCcontig26_split_00010|
+|7105|KOfam|K03969|phage shock protein A|Phage|Day17a_QCcontig74_split_00005|
+|4518|KOfam|K07474|phage terminase small subunit|Phage|Day17a_QCcontig33_split_00009|
+|4315|KOfam|K14060|putative DNA-invertase from lambdoid prophage Rac|Phage|Day17a_QCcontig30_split_00002|
+|4299|KOfam|K14060|putative DNA-invertase from lambdoid prophage Rac|Phage|Day17a_QCcontig30_split_00001|
+|3770|KOfam|K14060|putative DNA-invertase from lambdoid prophage Rac|Phage|Day17a_QCcontig25_split_00001|
+|4519|KOfam|K06909|phage terminase large subunit|Phage|Day17a_QCcontig33_split_00009|
+
+It is also possible to include sequences of genes into this output:
+
+{{ codestart }}
+anvi-search-functions -c %(contigs-db)s \
+                      --search-terms Phage \
+                      --full-report phage-results.txt \
+                      --include-sequences \
+                      --verbose
 {{ codestop }}

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -799,7 +799,7 @@ class LocusSplitter:
             if self.delimiter in self.num_genes:
                 self.run.info('Genes to report', '%d genes before the matching gene, and %d that follow' % (self.num_genes_list[0], self.num_genes_list[1]))
             else:
-                self.run.info('Genes to report', 'Matching gene, and %d genes after it' % (self.num_genes_list[0]))
+                self.run.info('Genes to report', 'Matching gene, and %d genes after it' % (self.num_genes_list[1]))
 
         utils.check_sample_id(self.output_file_prefix)
 

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -735,7 +735,7 @@ class LocusSplitter:
         self.is_in_flank_mode = bool(A('flank_mode'))
 
         if self.annotation_sources:
-            self.annotation_sources = self.annotation_sources.split(self.delimiter)
+            self.annotation_sources = [source.strip() for source in self.annotation_sources.split(self.delimiter)]
 
         if A('list_hmm_sources'):
             dbops.ContigsDatabase(self.input_contigs_db_path).list_available_hmm_sources()
@@ -773,7 +773,7 @@ class LocusSplitter:
                                   "needs exactly 2." % num_genes)
 
         if self.search_term:
-            self.search_term = self.search_term.split(self.delimiter)
+            self.search_term = [term.strip() for term in self.search_term.split(self.delimiter)]
 
         utils.is_contigs_db(self.input_contigs_db_path)
 

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -734,9 +734,6 @@ class LocusSplitter:
         self.include_fasta_output = True
         self.is_in_flank_mode = bool(A('flank_mode'))
 
-        if self.annotation_sources:
-            self.annotation_sources = [source.strip() for source in self.annotation_sources.split(self.delimiter)]
-
         if A('list_hmm_sources'):
             dbops.ContigsDatabase(self.input_contigs_db_path).list_available_hmm_sources()
             sys.exit()
@@ -773,11 +770,12 @@ class LocusSplitter:
                                   "needs exactly 2." % num_genes)
 
         if self.search_term:
-            self.search_term = [term.strip() for term in self.search_term.split(self.delimiter)]
+            self.search_term = list(set([term.strip() for term in self.search_term.split(self.delimiter)]))
 
-        utils.is_contigs_db(self.input_contigs_db_path)
+        if self.annotation_sources:
+            self.annotation_sources = list(set([source.strip() for source in self.annotation_sources.split(self.delimiter)]))
 
-        if len(self.hmm_sources):
+        if self.hmm_sources:
             self.hmm_sources = set([s.strip() for s in self.hmm_sources.split(self.delimiter)])
 
         # If user is in default mode, they MUST provide --num-genes

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -722,6 +722,8 @@ class LocusSplitter:
         self.input_contigs_db_path = A('contigs_db')
         self.num_genes = A('num_genes')
         self.search_term = A('search_term')
+        self.case_sensitive = A('case_sensitive')
+        self.exact_match = A('exact_match')
         self.gene_caller_ids = A('gene_caller_ids')
         self.delimiter = A('delimiter')
         self.output_dir = A('output_dir') or os.path.abspath(os.path.curdir)
@@ -850,7 +852,7 @@ class LocusSplitter:
                                                                       if not self.annotation_sources
                                                                       else self.annotation_sources)))
 
-                foo, search_report = contigs_db.search_for_gene_functions([term], requested_sources=self.annotation_sources, verbose=True)
+                foo, search_report = contigs_db.search_for_gene_functions([term], requested_sources=self.annotation_sources, verbose=True, case_sensitive=self.case_sensitive, exact_match=self.exact_match)
                 # gene id's of genes with the searched function
                 genes_that_hit = [i[0] for i in search_report]
                 gene_caller_ids_of_interest.extend(genes_that_hit)

--- a/bin/anvi-export-locus
+++ b/bin/anvi-export-locus
@@ -65,33 +65,36 @@ if __name__ == '__main__':
     parser = ArgumentParser(description=__description__)
 
     # Essential input
-    groupA = parser.add_argument_group('Essential INPUT')
+    groupA = parser.add_argument_group('INPUT DATABASE')
     groupA.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+
     # Query options for anchor gene
-    groupB =  parser.add_argument_group('Query options for locating locus', "search according to either hmm or functional annotations")
-    groupB.add_argument('-s', '--search-term', help='search term.') # there is a 'search-terms' argument in __init__py, come up with new name?
-    groupB.add_argument(*anvio.A('gene-caller-ids'), **anvio.K('gene-caller-ids'))
-    groupB.add_argument(*anvio.A('delimiter'), **anvio.K('delimiter'))
-    # Output options
-    groupC = parser.add_argument_group('THE OUTPUT', "Where should the output go. It will be one FASTA file with all matches \
-                                       or one FASTA per match (see --separate-fasta)")
-    groupC.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir'))
-    groupC.add_argument(*anvio.A('output-file-prefix'), **anvio.K('output-file-prefix', {'required': True}))
-    # Additional
-    groupD = parser.add_argument_group('ADDITIONAL STUFF', "Flags and parameters you can set according to your need")
-    groupD.add_argument(*anvio.A('flank-mode'), **anvio.K('flank-mode'))
-    groupD.add_argument(*anvio.A('num-genes'), **anvio.K('num-genes'))
-    # FIXME --separate-fasta is not an argument accepted by LocusSplitter, yet was put in this file for some
-    # reason. Maybe you know.
-    # groupD.add_argument('--separate-fasta', default = False, action='store_true', help='Split each match to a separate FASTA file.')
-    groupD.add_argument('--use-hmm', default = False, action='store_true', help='Use HMM hits instead of functional annotations. \
+    groupB =  parser.add_argument_group('ANCHOR GENE IDENTIFICATION OPTION #1', "Search based on gene function annotations or HMMs")
+    groupB.add_argument('-s', '--search-term', help='Search term to be found in function annotation sources.')
+    groupB.add_argument(*anvio.A('case-sensitive'), **anvio.K('case-sensitive'))
+    groupB.add_argument(*anvio.A('exact-match'), **anvio.K('exact-match'))
+    groupB.add_argument(*anvio.A('hmm-sources'), **anvio.K('hmm-sources'))
+    groupB.add_argument(*anvio.A('annotation-sources'), **anvio.K('annotation-sources'))
+    groupB.add_argument('--use-hmm', default = False, action='store_true', help='Use HMM hits instead of functional annotations. \
                             In other words, --search-term will be queried against HMM source annotations, NOT functional annotations. \
                             If you choose this option, you must also say which HMM source to use.')
-    groupD.add_argument(*anvio.A('hmm-sources'), **anvio.K('hmm-sources'))
-    groupD.add_argument(*anvio.A('list-hmm-sources'), **anvio.K('list-hmm-sources'))
-    groupD.add_argument(*anvio.A('annotation-sources'), **anvio.K('annotation-sources'))
-    groupD.add_argument(*anvio.A('remove-partial-hits'), **anvio.K('remove-partial-hits'))
-    groupD.add_argument(*anvio.A('never-reverse-complement'), **anvio.K('never-reverse-complement'))
+
+    groupC =  parser.add_argument_group('ANCHOR GENE IDENTIFICATION OPTION #2', "Search based on gene caller id(s)")
+    groupC.add_argument(*anvio.A('gene-caller-ids'), **anvio.K('gene-caller-ids'))
+
+    # Output options
+    groupD = parser.add_argument_group('THE OUTPUT', "Where should the output go. It will be one FASTA file with all matches \
+                                       or one FASTA per match (see --separate-fasta)")
+    groupD.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir'))
+    groupD.add_argument(*anvio.A('output-file-prefix'), **anvio.K('output-file-prefix', {'required': True}))
+
+    # Additional
+    groupE = parser.add_argument_group('ADDITIONAL STUFF', "Flags and parameters you can set according to your need")
+    groupE.add_argument(*anvio.A('flank-mode'), **anvio.K('flank-mode'))
+    groupE.add_argument(*anvio.A('num-genes'), **anvio.K('num-genes'))
+    groupE.add_argument(*anvio.A('remove-partial-hits'), **anvio.K('remove-partial-hits'))
+    groupE.add_argument(*anvio.A('delimiter'), **anvio.K('delimiter'))
+    groupE.add_argument(*anvio.A('never-reverse-complement'), **anvio.K('never-reverse-complement'))
 
     args = parser.get_args(parser)
 

--- a/bin/anvi-search-functions
+++ b/bin/anvi-search-functions
@@ -39,6 +39,8 @@ class SearchResultReporter(object):
         self.basic_report_path = A('output_file') or 'search_results.txt'
         self.full_report_path = A('full_report')
         self.include_sequences = A('include_sequences')
+        self.case_sensitive = A('case_sensitive')
+        self.exact_match = A('exact_match')
         self.verbose = A('verbose')
         self.args = args
         self.search_mode = None
@@ -54,7 +56,6 @@ class SearchResultReporter(object):
 
         # straighten things out
         self.search_terms = [s.strip() for s in A('search_terms').split(A('delimiter'))]
-        self.annotation_sources = [a.strip() for a in A('annotation_sources').split(A('delimiter'))] if A('annotation_sources') else None
 
         self.db = self.get_database()
 
@@ -93,7 +94,7 @@ class SearchResultReporter(object):
 
 
     def get_search_results(self):
-        self.matching_item_names_dict, self.verbose_output = self.db.search_for_gene_functions(self.search_terms, requested_sources=self.annotation_sources, verbose = self.verbose)
+        self.matching_item_names_dict, self.verbose_output = self.db.search_for_gene_functions(self.search_terms, requested_sources=self.annotation_sources, verbose=self.verbose, case_sensitive=self.case_sensitive, exact_match=self.exact_match)
 
         self.all_item_names = set([])
 
@@ -112,7 +113,7 @@ class SearchResultReporter(object):
                     results_dict[item_name][search_term + '_hits'] = search_term
 
         utils.store_dict_as_TAB_delimited_file(results_dict, self.basic_report_path, headers = [self.search_mode] + [s + '_hits' for s in self.search_terms])
-        run.info('Items additional data compatible output', self.basic_report_path)
+        run.info('Items additional data compatible output', self.basic_report_path, nl_before=1)
 
 
     def write_full_report(self):
@@ -169,6 +170,8 @@ if __name__ == '__main__':
 
     groupB = parser.add_argument_group('SEARCH FOR', 'Relevant terms')
     groupB.add_argument(*anvio.A('search-terms'), **anvio.K('search-terms', {'required': True}))
+    groupB.add_argument(*anvio.A('case-sensitive'), **anvio.K('case-sensitive'))
+    groupB.add_argument(*anvio.A('exact-match'), **anvio.K('exact-match'))
     groupB.add_argument(*anvio.A('delimiter'), **anvio.K('delimiter'))
     groupB.add_argument(*anvio.A('annotation-sources'), **anvio.K('annotation-sources'))
     groupB.add_argument(*anvio.A('list-annotation-sources'), **anvio.K('list-annotation-sources'))


### PR DESCRIPTION
This PR adds new functionality to gene function search capabilities in anvi'o, and fixes a bunch of bugs that prevented to limit searches to specific function annotation sources.

These changes, which include the addition of `--case-sensitive` and `--exact-match`, improve `anvi-export-locus` immediately, and address the feature request #2319.

The PR also includes an update to the online documentation for `anvi-search-functions`.