### PR TITLE
Fix use of stray_ko_dict when including stray KOs in anvi-estimate-metabolism

### DIFF
--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -4211,7 +4211,7 @@ class KeggMetabolismEstimator(KeggContext, KeggEstimatorArgs):
             # (henceforth referred to as the KO dict, even though it doesn't only contain KOs for user data)
             self.setup_ko_dict(exclude_threshold=self.exclude_kos_no_threshold)
             if self.include_stray_kos:
-                self.setup_stray_ko_dict(add_entries_to_regular_ko_dict=True)
+                self.setup_stray_ko_dict(add_entries_to_regular_ko_dict=False)
             annotation_source_set = set(['KOfam'])
 
             # check for kegg modules db


### PR DESCRIPTION
Revert to seperating the stray_ko_dict as a separate entity. Fixes issues when using:

anvi-estimate-metabolism --include-stray-KOs

Which would lead to the following errors:
Traceback (most recent call last):
  File github/anvio/bin/anvi-estimate-metabolism, line 148, in <module>
    main(args)
  File github/anvio/anvio/terminal.py, line 915, in wrapper
    program_method(*args, **kwargs)
  File github/anvio/bin/anvi-estimate-metabolism, line 39, in main
    m.estimate_metabolism()
  File github/anvio/anvio/kegg.py, line 6014, in estimate_metabolism
    kegg_metabolism_superdict, kofam_hits_superdict = self.estimate_for_genome(kofam_hits_info)
  File github/anvio/anvio/kegg.py, line 5516, in estimate_for_genome
    self.append_kegg_metabolism_superdicts(genome_metabolism_superdict, genome_ko_superdict)
  File github/anvio/anvio/kegg.py, line 6557, in append_kegg_metabolism_superdicts
    output_dict = self.generate_output_dict_for_kofams(ko_superdict_for_list_of_splits, headers_to_include=header_list)
  File github/anvio/anvio/kegg.py, line 6416, in generate_output_dict_for_kofams
    metadata_dict = self.get_ko_metadata_dictionary(ko, dont_fail_if_not_found=True)
  File github/anvio/anvio/kegg.py, line 3456, in get_ko_metadata_dictionary
    elif self.include_stray_kos and self.stray_ko_dict and knum in self.stray_ko_dict:
AttributeError: 'KeggMetabolismEstimator' object has no attribute 'stray_ko_dict'. Did you mean: 'setup_ko_dict'?