### PR TITLE
Mapping multiple orthologs graphics types

### DIFF
--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -1354,7 +1354,7 @@ class Mapper:
         # Set the color of Graphics elements for reactions containing select KOs. For other Graphics
         # elements, change the 'fgcolor' attribute to a nonsense value of '0' to ensure that the
         # elements with the prioritized color can be distinguished from other elements. Also, in
-        # overview maps, widen lines from the base map default of 1.0.
+        # overview and standard maps, widen lines from the base map default of 1.0.
         all_entries = pathway.get_entries(entry_type='ortholog')
         select_uuids = [entry.uuid for entry in select_entries]
         for entry in all_entries:
@@ -1362,9 +1362,11 @@ class Mapper:
                 for uuid in entry.children['graphics']:
                     graphics: kgml.Graphics = pathway.uuid_element_lookup[uuid]
                     if pathway.is_global_map:
+                        assert graphics.type == 'line'
                         graphics.fgcolor = color_hexcode
                         graphics.bgcolor = '#FFFFFF'
                     elif pathway.is_overview_map:
+                        assert graphics.type == 'line'
                         graphics.fgcolor = color_hexcode
                         graphics.bgcolor = '#FFFFFF'
                         graphics.width = 5.0
@@ -1375,6 +1377,7 @@ class Mapper:
                         elif graphics.type == 'line':
                             graphics.fgcolor = color_hexcode
                             graphics.bgcolor = '#FFFFFF'
+                            graphics.width = 5.0
                         else:
                             raise AssertionError(
                                 "Ortholog entries are assumed to have Graphics elements of type "
@@ -1391,18 +1394,18 @@ class Mapper:
         # recolor circles to reflect the colors of prioritized reactions involving the compounds.
         color_priority: Dict[str, Dict[str, Dict[Tuple[str, str], float]]] = {}
         if pathway.is_global_map:
-            color_priority = {'ortholog': {'line': {(color_hexcode, '#FFFFFF'): 1.0}}}
+            color_priority['ortholog'] = {'line': {(color_hexcode, '#FFFFFF'): 1.0}}
             recolor_unprioritized_entries = 'g'
             color_associated_compounds = 'high'
         elif pathway.is_overview_map:
-            color_priority = {'ortholog': {'line': {(color_hexcode, '#FFFFFF'): 1.0}}}
+            color_priority['ortholog'] = {'line': {(color_hexcode, '#FFFFFF'): 1.0}}
             recolor_unprioritized_entries = 'w'
             color_associated_compounds = 'high'
         else:
-            color_priority = {'ortholog': {
+            color_priority['ortholog'] = {
                 'rectangle': {('#000000', color_hexcode): 1.0},
                 'line': {(color_hexcode, '#FFFFFF'): 1.0}
-            }}
+            }
             recolor_unprioritized_entries = 'w'
             color_associated_compounds = None
         pathway.set_color_priority(
@@ -1458,43 +1461,62 @@ class Mapper:
         if not select_entries and not draw_map_lacking_kos:
             return False
 
-        # Set "secondary" colors of Graphics elements for reactions containing select KOs: white
-        # background color of lines or black foreground text of boxes. For other Graphics elements,
-        # change the 'fgcolor' attribute to a nonsense value to ensure that the elements with
-        # prioritized colors can be distinguished from other elements. Also, in overview maps, widen
-        # lines from the base map default of 1.0.
+        # Set "secondary" colors of ortholog Graphics elements for reactions containing select KOs:
+        # white background color of lines or black foreground text of rectangles. For other Graphics
+        # elements, change the 'fgcolor' attribute to a nonsense value to ensure that the elements
+        # with prioritized colors can be distinguished from other elements. Also, in overview and
+        # standard maps, widen lines from the base map default of 1.0.
         all_entries = pathway.get_entries(entry_type='ortholog')
         select_uuids = [entry.uuid for entry in select_entries]
-        prioritized_colors: List[Tuple[str, str]] = []
+        prioritized_colors: Dict[str, List[Tuple[str, str]]] = {}
         for entry in all_entries:
             if entry.uuid in select_uuids:
                 for uuid in entry.children['graphics']:
                     graphics: kgml.Graphics = pathway.uuid_element_lookup[uuid]
                     if pathway.is_global_map:
+                        assert graphics.type == 'line'
                         graphics.bgcolor = '#FFFFFF'
                     elif pathway.is_overview_map:
+                        assert graphics.type == 'line'
                         graphics.bgcolor = '#FFFFFF'
                         graphics.width = 5.0
                     else:
-                        graphics.fgcolor = '#000000'
-                    prioritized_colors.append((graphics.fgcolor, graphics.bgcolor))
+                        if graphics.type == 'rectangle':
+                            graphics.fgcolor = '#000000'
+                        elif graphics.type == 'line':
+                            graphics.bgcolor = '#FFFFFF'
+                            graphics.width = 5.0
+                        else:
+                            raise AssertionError(
+                                "Ortholog entries are assumed to have Graphics elements of type "
+                                "'rectangle' or 'line', not the encountered type, "
+                                f"'{graphics.type}'."
+                            )
+                    try:
+                        graphics_type_prioritized_colors = prioritized_colors[graphics.type]
+                    except:
+                        prioritized_colors[graphics.type] = graphics_type_prioritized_colors = []
+                    graphics_type_prioritized_colors.append((graphics.fgcolor, graphics.bgcolor))
             else:
                 for uuid in entry.children['graphics']:
                     graphics: kgml.Graphics = pathway.uuid_element_lookup[uuid]
                     graphics.fgcolor = '0'
 
-        # By default, global maps but not overview and standard maps have reactions with more than
-        # one color. Give higher priority to reaction entries that are encountered later (occur
-        # further down in the KGML file), and would thus be rendered above earlier reactions.
-        seen = set()
-        prioritized_colors = [
-            colors for colors in prioritized_colors if not (colors in seen or seen.add(colors))
-        ]
-        priorities = np.linspace(0, 1, len(prioritized_colors) + 1)[1: ]
-        ortholog_color_priority = {
-            colors: priority for colors, priority in zip(prioritized_colors, priorities)
-        }
-        color_priority = {'ortholog': ortholog_color_priority}
+        # By default, global maps but not overview and standard maps display reaction graphics in
+        # more than one color. Give higher priority to reaction entries that are encountered later
+        # (occur further down in the KGML file), and would thus be rendered above earlier reactions.
+        color_priority: Dict[str, Dict[str, Dict[Tuple[str, str], float]]] = {'ortholog': {}}
+        for graphics_type, graphics_type_prioritized_colors in prioritized_colors.items():
+            seen = set()
+            unique_prioritized_colors = [
+                colors for colors in graphics_type_prioritized_colors
+                if not (colors in seen or seen.add(colors))
+            ]
+            priorities = np.linspace(0, 1, len(unique_prioritized_colors) + 1)[1: ]
+            graphics_type_color_priority = {
+                colors: priority for colors, priority in zip(unique_prioritized_colors, priorities)
+            }
+            color_priority['ortholog'][graphics_type] = graphics_type_color_priority
 
         # Recolor "unprioritized" reactions to a background color. In global and overview maps,
         # recolor circles to reflect the colors of prioritized reactions involving the compounds.
@@ -1599,7 +1621,8 @@ class Mapper:
         if not entries and not draw_map_lacking_kos:
             return False
 
-        # Change the colors of the KO graphics. A reaction Entry can represent multiple KOs.
+        # Change the colors of the KO graphics. A reaction Entry can represent multiple KOs. Also,
+        # in overview and standard maps, widen lines from the base map default of 1.0.
         color_hexcodes = list(color_priority)
         for entry in entries:
             source_names = []
@@ -1620,25 +1643,36 @@ class Mapper:
             for uuid in entry.children['graphics']:
                 graphics: kgml.Graphics = pathway.uuid_element_lookup[uuid]
                 if pathway.is_global_map:
+                    assert graphics.type == 'line'
                     graphics.fgcolor = color_hexcode
                     graphics.bgcolor = '#FFFFFF'
                 elif pathway.is_overview_map:
+                    assert graphics.type == 'line'
                     graphics.fgcolor = color_hexcode
                     graphics.bgcolor = '#FFFFFF'
-                    # Widen colored lines in overview maps. The width of lines in the base map is
-                    # 1.0.
                     graphics.width = 5.0
                 else:
-                    graphics.fgcolor = '#000000'
-                    graphics.bgcolor = color_hexcode
+                    if graphics.type == 'rectangle':
+                        graphics.fgcolor = '#000000'
+                        graphics.bgcolor = color_hexcode
+                    elif graphics.type == 'line':
+                        graphics.fgcolor = color_hexcode
+                        graphics.bgcolor = '#FFFFFF'
+                        graphics.width = 5.0
+                    else:
+                        raise AssertionError(
+                            "Ortholog entries are assumed to have Graphics elements of type "
+                            f"'rectangle' or 'line', not the encountered type, '{graphics.type}'."
+                        )
 
         # Set the color priorities of entries for proper overlaying in the image. Recolor
         # "unprioritized" KO graphics to a background color. In global and overview maps, recolor
-        # circles to reflect the colors of prioritized lines and arrows.
-        ortholog_color_priority: Dict[Tuple[str, str], float] = {}
+        # circles to reflect the colors of prioritized reactions involving the compounds.
+        ortholog_color_priority: Dict[str, Dict[Tuple[str, str], float]] = {}
         if pathway.is_global_map:
+            ortholog_color_priority['line'] = line_color_priority = {}
             for color_hexcode, priority in color_priority.items():
-                ortholog_color_priority[(color_hexcode, '#FFFFFF')] = priority
+                line_color_priority[(color_hexcode, '#FFFFFF')] = priority
             pathway.set_color_priority(
                 {'ortholog': ortholog_color_priority},
                 recolor_unprioritized_entries='g',
@@ -1646,8 +1680,9 @@ class Mapper:
                 colormap=colormap
             )
         elif pathway.is_overview_map:
+            ortholog_color_priority['line'] = line_color_priority = {}
             for color_hexcode, priority in color_priority.items():
-                ortholog_color_priority[(color_hexcode, '#FFFFFF')] = priority
+                line_color_priority[(color_hexcode, '#FFFFFF')] = priority
             pathway.set_color_priority(
                 {'ortholog': ortholog_color_priority},
                 recolor_unprioritized_entries='w',
@@ -1655,8 +1690,11 @@ class Mapper:
                 colormap=colormap
             )
         else:
+            ortholog_color_priority['rectangle'] = rectangle_color_priority = {}
+            ortholog_color_priority['line'] = line_color_priority = {}
             for color_hexcode, priority in color_priority.items():
-                ortholog_color_priority[('#000000', color_hexcode)] = priority
+                rectangle_color_priority[('#000000', color_hexcode)] = priority
+                line_color_priority[(color_hexcode, '#FFFFFF')] = priority
             pathway.set_color_priority(
                 {'ortholog': ortholog_color_priority},
                 recolor_unprioritized_entries='w'

--- a/bin/anvi-draw-kegg-pathways
+++ b/bin/anvi-draw-kegg-pathways
@@ -386,11 +386,12 @@ if __name__ == '__main__':
         print(e)
         sys.exit(-1)
     except Exception as e:
-        print(
-            "Have you installed the necessary Python package requirements for "
-            "`anvi-draw-kegg-pathways`? This might be the cause of the error that was encountered, "
-            "reported below. Run the following command in your terminal and then try rerunning the "
-            "program:\npip install biopython ReportLab pymupdf frontend\n"
-        )
+        if type(e) != AssertionError:
+            print(
+                "\nHave you installed the necessary Python package requirements for "
+                "`anvi-draw-kegg-pathways`? This might be the cause of the error that was "
+                "encountered, reported below. Run the following command in your terminal and then "
+                "try rerunning the program:\npip install biopython ReportLab pymupdf frontend\n"
+            )
         traceback.print_exception(type(e), e, e.__traceback__)
         sys.exit(-1)

--- a/bin/anvi-draw-kegg-pathways
+++ b/bin/anvi-draw-kegg-pathways
@@ -367,8 +367,8 @@ if __name__ == '__main__':
     except ConfigError as e:
         e_str = re.sub(r'\s+', ' ', str(e))
         if (
-            "Unprioritized entries cannot be assigned the same combination of foreground and "
-            "background colors as prioritized entries of the same type."
+            "Unprioritized entry graphics cannot be assigned the same combination of foreground "
+            "and background colors as prioritized entries of the same entry and graphics types."
         ) in e_str:
             raise ConfigError(
                 "The colors of highlighted reactions and compounds cannot be set to reserved "

--- a/bin/anvi-draw-kegg-pathways
+++ b/bin/anvi-draw-kegg-pathways
@@ -309,13 +309,14 @@ def get_args() -> Namespace:
     groupCOLOR = parser.add_argument_group("COLOR", "Color scheme to use")
     groupCOLOR.add_argument(
         '--set-color', nargs='?', const=True, help=
-        "This argument can be used as a flag (without a value), to use a default color for "
+        "This argument can be used as a flag (without a value), to use a single default color for "
         "presence/absence data. Alternatively, it can be used with the value 'original' to use "
-        "original colors from the reference map. Lastly, this argument can take a color hexcode, "
-        "such as '#FFA500' for orange, to use instead of the default color. Use of this argument "
-        "with certain data types preempts the default way of displaying the data. For instance, "
-        "pangenomic KO data that would be dynamically colored by genome count is instead colored "
-        "by presence/absence."
+        "original colors from the reference map. Lastly, this argument can take a color hex code, "
+        "such as '#FFA500' for orange, to use instead of the default color. A COLOR HEX CODE "
+        "ARGUMENT MUST BE ENCLOSED IN QUOTES, AS # OTHERWISE CAUSES THE REST OF THE COMMAND TO BE "
+        "IGNORED AS A COMMENT. Use of this argument with certain data types preempts the default "
+        "way of displaying the data. For instance, pangenomic KO data that would be dynamically "
+        "colored by genome count is instead colored by presence/absence."
     )
     groupCOLOR.add_argument(
         '--colormap', nargs='+', help=


### PR DESCRIPTION
This pull request fixes KEGG mapping by `anvi-draw-kegg-pathways` in the case of encountering orthologs as both rectangle and line graphics on a map. I had overlooked maps in which ortholog entries for certain reactions are represented as lines, as is the case in a number of glycan biosynthesis and metabolism maps. This had not been a problem in highlighting ortholog rectangles on the maps alone, but in highlighting both graphics types, an error was encountered. Here is what a map now looks like for an _E. huxleyi_ transcriptome with both graphics types colored.

![kos_00510](https://github.com/user-attachments/assets/5c9b1518-2836-4ecb-9eed-84ac1ea2a2a9)
