### PR TITLE
anvi-export-splits-taxonomy now export a table with all taxonomic levels

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1471,6 +1471,10 @@ class ContigsSuperclass(object):
         taxon_names_table = contigs_db.db.get_table_as_dict(t.taxon_names_table_name)
 
         output = open(output_file_path, 'w')
+        column_list = ['split_name'] + [k for k in taxon_names_table[list(taxon_names_table.keys())[0]].keys()]
+        header = "\t".join(column_list)
+        print(header)
+        output.write(f"{header}\n")
         for split_name in self.splits_basic_info:
             if split_name in splits_taxonomy_table:
                 taxon_id = splits_taxonomy_table[split_name]['taxon_id']

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1476,9 +1476,10 @@ class ContigsSuperclass(object):
                 taxon_id = splits_taxonomy_table[split_name]['taxon_id']
                 if taxon_id:
                     self.splits_taxonomy_dict[split_name] = taxon_names_table[taxon_id]
-                    output.write('{0}\t{1}\n'.format(split_name, '\t'.join(x for x in self.splits_taxonomy_dict[split_name].values())))
+                    taxonomy_string = "\t".join(str(x) for x in self.splits_taxonomy_dict[split_name].values())
+                    output.write(f"{split_name}\t{taxonomy_string}\n")
                 else:
-                    output.write('{0}\t\n'.format(split_name))
+                    output.write(f"{split_name}\t\n")
         output.close()
 
         contigs_db.disconnect()

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -1462,24 +1462,28 @@ class ContigsSuperclass(object):
         if not self.a_meta['gene_level_taxonomy_source']:
             raise ConfigError("There is no taxonomy source for genes in the contigs database :/")
 
-        if not len(self.splits_taxonomy_dict):
-            self.init_splits_taxonomy()
 
-        if not len(self.splits_taxonomy_dict):
-            raise ConfigError("The splits taxonomy is empty. There is nothing to report. Could it be "
-                               "possible the taxonomy caller you used did not assign any taxonomy to "
-                               "anything?")
+        self.progress.new('Initializing splits taxonomy')
+        self.progress.update('...')
 
-        self.run.info("Taxonomy", "Annotations for %d of %d total splits are recovered" % (len(self.splits_taxonomy_dict), len(self.splits_basic_info)))
+        contigs_db = ContigsDatabase(self.contigs_db_path)
+        splits_taxonomy_table = contigs_db.db.smart_get(t.splits_taxonomy_table_name, 'split', self.split_names_of_interest, string_the_key=True, error_if_no_data=False, progress=self.progress)
+        taxon_names_table = contigs_db.db.get_table_as_dict(t.taxon_names_table_name)
 
         output = open(output_file_path, 'w')
         for split_name in self.splits_basic_info:
-            if split_name in self.splits_taxonomy_dict:
-                output.write('{0}\t{1}\n'.format(split_name, self.splits_taxonomy_dict[split_name]))
-            else:
-                output.write('{0}\t\n'.format(split_name))
+            if split_name in splits_taxonomy_table:
+                taxon_id = splits_taxonomy_table[split_name]['taxon_id']
+                if taxon_id:
+                    self.splits_taxonomy_dict[split_name] = taxon_names_table[taxon_id]
+                    output.write('{0}\t{1}\n'.format(split_name, '\t'.join(x for x in self.splits_taxonomy_dict[split_name].values())))
+                else:
+                    output.write('{0}\t\n'.format(split_name))
         output.close()
 
+        contigs_db.disconnect()
+        self.progress.end()
+        self.run.info("Taxonomy", "Annotations for %d of %d total splits are recovered" % (len(splits_taxonomy_table), len(self.splits_basic_info)))
         self.run.info("Output", output_file_path)
 
 


### PR DESCRIPTION
I need to export the split level taxonomy after importing gene taxonomy from kaiju. I realized that `anvi-export-splits-taxonomy` was only reporting the genus information. And it was not even possible to ask for a different taxo level.

Funny, because the documentation for the output says that anvi'o gives all taxo levels: https://anvio.org/help/main/artifacts/splits-taxonomy-txt/

Anyway, here is my attempt to correct that. The user cannot choose the taxo level, but you get a tab-delim file with name of split and then multiple columns for the different taxonomic levels. No header in the output at the moment.

I would be very happy if someone could check that commit before I merge. 
DANKE.