### PR TITLE
Better calculation of mean coverage Q2Q3

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2720,6 +2720,19 @@ D = {
                      "is because anvi'o computes gene coverages by going back to actual coverage values of each gene to "
                      "average them, instead of using contig average coverage values, for extreme accuracy."}
                 ),
+    'calculate-Q2Q3-carefully': (
+            ['--calculate-Q2Q3-carefully'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "By default, anvi'o summarizes collections by cutting corners. One of those corners is to take values "
+                     "for mean coverage Q2Q3 for each contig, and normalize that value by the size of the contig, and "
+                     "average those values to have a single value for the bin. While this strategy works quite well for "
+                     "regular mean coverage, the calculation of mean coverage Q2Q3 requires the ENTIRETY of the raw "
+                     "coverage values for each contig to be first concatenated so they can be sorted to calculate the "
+                     "most accurate Q2Q3 value for a given bin. This flag ensures anvi'o calculates mean coverage Q2Q3 "
+                     "values in that careful way at the expense of things taking much longer (but it really is worth it "
+                     "for your final summary of everything)."}
+                ),
     'reformat-contig-names': (
             ['--reformat-contig-names'],
             {'default': False,

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2731,7 +2731,8 @@ D = {
                      "coverage values for each contig to be first concatenated so they can be sorted to calculate the "
                      "most accurate Q2Q3 value for a given bin. This flag ensures anvi'o calculates mean coverage Q2Q3 "
                      "values in that careful way at the expense of things taking much longer (but it really is worth it "
-                     "for your final summary of everything)."}
+                     "for your final summary of everything). Please see https://github.com/merenlab/anvio/pull/2366 for "
+                     "details."}
                 ),
     'reformat-contig-names': (
             ['--reformat-contig-names'],

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3846,7 +3846,7 @@ class ProfileSuperclass(object):
             return split_coverages_dict
 
 
-    def init_collection_profile(self, collection_name):
+    def init_collection_profile(self, collection_name, calculate_Q2Q3_carefully=False):
         profile_db = ProfileDatabase(self.profile_db_path, quiet=True)
 
         # we only have a self.collections instance if the profile super has been inherited by summary super class.
@@ -3867,6 +3867,14 @@ class ProfileSuperclass(object):
 
         samples_template = dict([(s, []) for s in self.p_meta['samples']])
 
+        if calculate_Q2Q3_carefully:
+            self.run.warning("The anvi'o sumarizer class is instructed (hopefully by you) to calculate Q2Q3 mean "
+                             "coverages carefully. This means, depending on the size of your dataset and the number "
+                             "of contigs in your bins this step can take much much longer than usual, since anvi'o "
+                             "will have to do a lot of sorting of very large arrays. But then you will get the best "
+                             "mean coverage values for your populations (so brace yourself).",
+                             header="💀 THINGS WILL TAKE LONGER 💀")
+
         self.progress.new(f"Collection profile for '{collection_name}'")
         for table_name in table_names:
             # if SNVs are not profiled, skip the `variability` table
@@ -3877,32 +3885,42 @@ class ProfileSuperclass(object):
             table_data, _ = profile_db.db.get_view_data(f'{table_name}_splits')
 
             for bin_id in collection:
-                # populate averages per bin
-                averages = copy.deepcopy(samples_template)
-
-                # These weights are used to properly account for differences in split lengths.
-                # Consider table_name == 'mean_coverage', for a bin with 2 splits. Without
-                # weighting, if one split is length 100 with coverage 100 and the other is length
-                # 900 wth coverage 500, the mean_coverage for this bin is (100 + 500)/2 = 300. But
-                # more accurately, mean_coverage of this bin is 100*[100/1000] + 500*[900/1000] =
-                # 460
-                weights = []
-
-                for split_name in collection[bin_id]:
-                    if split_name not in table_data:
-                        continue
-
-                    weights.append(self.splits_basic_info[split_name]['length'])
-
+                if calculate_Q2Q3_carefully and table_name == 'mean_coverage_Q2Q3':
+                    self.collection_profile[bin_id][table_name] = {}
+                    # we need to do something specific here.
                     for sample_name in samples_template:
-                        averages[sample_name].append(table_data[split_name][sample_name])
+                        nucleotide_level_coverage_values = numpy.array([])
+                        for split_name in collection[bin_id]:
+                            nucleotide_level_coverage_values = numpy.append(nucleotide_level_coverage_values, self.split_coverage_values.get(split_name)[sample_name])
+                        stats = utils.CoverageStats(nucleotide_level_coverage_values)
+                        self.collection_profile[bin_id][table_name][sample_name] = stats.mean_Q2Q3
+                else:
+                    # populate averages per bin
+                    averages = copy.deepcopy(samples_template)
 
-                # finalize averages per bin:
-                for sample_name in samples_template:
-                    # weights is automatically normalized in numpy.average such that sum(weights) == 1
-                    averages[sample_name] = numpy.average([a or 0 for a in averages[sample_name]], weights=weights)
+                    # These weights are used to properly account for differences in split lengths.
+                    # Consider table_name == 'mean_coverage', for a bin with 2 splits. Without
+                    # weighting, if one split is length 100 with coverage 100 and the other is length
+                    # 900 wth coverage 500, the mean_coverage for this bin is (100 + 500)/2 = 300. But
+                    # more accurately, mean_coverage of this bin is 100*[100/1000] + 500*[900/1000] =
+                    # 460
+                    weights = []
 
-                self.collection_profile[bin_id][table_name] = averages
+                    for split_name in collection[bin_id]:
+                        if split_name not in table_data:
+                            continue
+
+                        weights.append(self.splits_basic_info[split_name]['length'])
+
+                        for sample_name in samples_template:
+                            averages[sample_name].append(table_data[split_name][sample_name])
+
+                    # finalize averages per bin:
+                    for sample_name in samples_template:
+                        # weights is automatically normalized in numpy.average such that sum(weights) == 1
+                        averages[sample_name] = numpy.average([a or 0 for a in averages[sample_name]], weights=weights)
+
+                    self.collection_profile[bin_id][table_name] = averages
 
         # generating precent recruitment of each bin plus __splits_not_binned__ in each sample:
         coverage_table_data, _ = profile_db.db.get_view_data('mean_coverage_splits')

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -93,6 +93,7 @@ class ArgsTemplateForSummarizerClass:
         self.debug = None
         self.quick_summary = False
         self.init_gene_coverages = False
+        self.calculate_Q2Q3_carefully = False
         self.skip_check_collection_name = False
         self.skip_init_functions = False
         self.cog_data_dir = None
@@ -133,6 +134,7 @@ class SummarizerSuperClass(object):
         self.skip_check_collection_name = A('skip_check_collection_name')
         self.skip_init_functions = A('skip_init_functions')
         self.init_gene_coverages = A('init_gene_coverages')
+        self.calculate_Q2Q3_carefully = A('calculate_Q2Q3_carefully')
         self.output_directory = A('output_dir')
         self.quick = A('quick_summary')
         self.debug = A('debug')
@@ -717,7 +719,7 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
 
     def init(self):
         # init profile data for colletion.
-        self.collection_dict, self.bins_info_dict = self.init_collection_profile(self.collection_name)
+        self.collection_dict, self.bins_info_dict = self.init_collection_profile(self.collection_name, calculate_Q2Q3_carefully=self.calculate_Q2Q3_carefully)
 
         # let bin names known to all
         self.bin_ids = list(self.collection_profile.keys())

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -437,7 +437,7 @@ class CoverageStats:
         if coverage.size < 4:
             self.mean_Q2Q3 = self.mean
         else:
-            sorted_c = sorted(coverage)
+            sorted_c = np.sort(coverage)
             Q = int(coverage.size * 0.25)
             Q2Q3 = sorted_c[Q:-Q]
             self.mean_Q2Q3 = np.mean(Q2Q3)

--- a/bin/anvi-summarize
+++ b/bin/anvi-summarize
@@ -95,6 +95,7 @@ if __name__ == '__main__':
     groupB.add_argument(*anvio.A('genomes-storage'), **anvio.K('genomes-storage', {'required': False}))
 
     groupC.add_argument(*anvio.A('init-gene-coverages'), **anvio.K('init-gene-coverages'))
+    groupC.add_argument(*anvio.A('calculate-Q2Q3-carefully'), **anvio.K('calculate-Q2Q3-carefully'))
     groupC.add_argument(*anvio.A('reformat-contig-names'), **anvio.K('reformat-contig-names'))
     groupC.add_argument('--report-aa-seqs-for-gene-calls', default=False, action='store_true', help="You can use this flag if\
                                   you would like amino acid AND dna sequences for your gene calls in the genes output\


### PR DESCRIPTION
A while ago Julian Torres-Morales and Jessica Mark Welch brought to our attention the fact that the way `anvi-summarize` cuts corners for performance reasons while aggregating values from different anvi'o views for a given bin in a collection ruins the way `mean_coverage_Q2Q3` values are calculated.

At the essence the problem lies the fact that in its quick-and-dirty approach, anvi'o takes every single `mean_coverage_Q2Q3` value for every single split in a bin, assigns weights to each value based on the split length, and then averages out the final values to come up with a single value for the entire bin. This works beautifully for `mean_coverage`, but not for `mean_coverage_Q2Q3`, since the latter in fact requires all nucleotide level coverage values for each split to be aggregated in a single array to calculate the mean coverage Q2Q3 from scratch.

This PR implements a solution through a new flag for `anvi-summarize`, `--calculate-Q2Q3-carefully`, when declared, anvi'o does not cut any corners at the expense of longer compute time in exchange of increased accuracy.

We thank Julian and Jessica for their patience! :)