### PR TITLE
A global argument to keep all functional annotations per gene (fixes #2375)

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -74,6 +74,9 @@ DEBUG_AUTO_FILL_ANVIO_DBS = '--debug-auto-fill-anvio-dbs' in sys.argv
 USER_KNOWS_IT_IS_NOT_A_GOOD_IDEA = '--I-know-this-is-not-a-good-idea' in sys.argv
 DOCS_PATH = os.path.join(os.path.dirname(__file__), 'docs')
 TMP_DIR = None
+# global args that we can set internally as needed
+RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE = False  # set to True if you want all functional annotations from a given annotation source
+                                                        # instead of the best hit per gene
 
 # if the user wants to use a non-default tmp directory, we set it here
 if '--tmp-dir' in sys.argv:

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -602,6 +602,9 @@ class ContigsSuperclass(object):
         If self.split_names_of_interest has a value, the dictionary only includes gene calls from those splits.
 
         Afterwards, it sets self.gene_function_calls_initiated to True.
+
+        Note: the global argument RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE affects the behavior of this function. If False, we get 
+        the best hit per gene (lowest e-value) for a given annotation source. If True, we get all hits.
         """
         if not self.contigs_db_path:
             return
@@ -643,13 +646,21 @@ class ContigsSuperclass(object):
             if gene_callers_id not in self.gene_function_calls_dict:
                 self.gene_function_calls_dict[gene_callers_id] = dict([(s, None) for s in self.gene_function_call_sources])
 
-            if self.gene_function_calls_dict[gene_callers_id][source] and e_value:
-                if self.gene_function_calls_dict[gene_callers_id][source][2] < e_value:
-                    # 'what we have:', self.gene_function_calls_dict[gene_callers_id][source]
-                    # 'rejected    :', ('%s :: %s' % (function if function else 'unknown', accession), e_value)
-                    continue
-
             entry = (accession, '%s' % (function if function else 'unknown'), e_value)
+
+            if self.gene_function_calls_dict[gene_callers_id][source]:
+                if anvio.RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE:
+                    previous_entry_acc, previous_entry_func, previous_entry_evalue = self.gene_function_calls_dict[gene_callers_id][source]
+                    combined_acc = f"{previous_entry_acc}!!!{accession}"
+                    combined_func = f"{previous_entry_func}!!!{entry[1]}"
+                    combined_evalue = f"{previous_entry_evalue}!!!{e_value}"
+                    entry = (combined_acc, combined_func, combined_evalue)
+                else:
+                    if e_value and self.gene_function_calls_dict[gene_callers_id][source][2] < e_value:
+                        # 'what we have:', self.gene_function_calls_dict[gene_callers_id][source]
+                        # 'rejected    :', ('%s :: %s' % (function if function else 'unknown', accession), e_value)
+                        continue
+
             self.gene_function_calls_dict[gene_callers_id][source] = entry
 
         contigs_db.disconnect()

--- a/bin/anvi-summarize
+++ b/bin/anvi-summarize
@@ -62,6 +62,9 @@ def main(args):
         if not args.contigs_db:
             raise ConfigError("You must provide a contigs database when you summarize anvi'o profiles. True story.")
 
+        # set this global arg so that all functional annotations are reflected in the summary output
+        anvio.RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE = True
+
         summary = summarizer.ProfileSummarizer(args)
     else:
         raise ConfigError("Well. '%s' is neither an anvi'o pan database, nor an anvi'o profile database. There is nothing this "


### PR DESCRIPTION
This PR fixes #2375 with the addition of a global argument called `RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE`. When this argument is set to True (which currently only happens when running `anvi-summarize` on a profile database), the `dbops.py` function `init_functions` can return multiple functional annotations (from a given annotation source) per gene separated by the `!!!` delimiter.

For instance, BEFORE this fix, `anvi-summarize` output was showing only one KOfam for gene 612 in the Infant Gut Dataset:
```
612	Day17a_QCcontig1	652697	654527	f	K00105
```
But now it is showing both KOfams:
```
612	Day17a_QCcontig1	652697	654527	f	K00111!!!K00105
```

A couple of caveats:

1. I didn't make this global argument into a flag; that is, a user cannot add `--return-all-functions-from-source-for-each-gene` to their command line in order to set this argument to True. I didn't see the need for this, since it's used in just one case so far. But perhaps in the future, if we need it elsewhere, we could change this to enable users to set the flag as well.
2. e-values are also combined with the `!!!` delimiter when this flag is used in `init_functions` to set the contents of the `self.gene_function_calls_dict`. This means that any downstream code expecting the e-value to be a float will break. So far, it is not a big deal because we only use it in `anvi-summarize` (which works fine), but if we start using this flag elsewhere, it could matter.



