### PR TITLE
Fix deletion reporting in variability table

### DIFF
--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -447,7 +447,8 @@ class ProcessIndelCounts(object):
                     cov = (self.coverage[pos] + self.coverage[pos+1])/2
             else:
                 # The coverage is the average of the NT coverages that the deletion occurs over
-                cov = np.mean(self.coverage[pos:pos+indel['length']])
+                # plus the number of reads that have the deletion at that position
+                cov = np.mean(self.coverage[pos:pos+indel['length']]) + indel['count']
 
             # Filter the entry if need be
             if cov < self.min_coverage_for_variability:


### PR DESCRIPTION
This PR addresses the bug in #2390 where deletion events in regions of zero coverage were not being reported even when the same deletion appeared in all reads mapping (over) the DEL position.

@FlorianTrigodet realized that we should simply add the count of the deletion to the base coverage of the DEL position, as a sort of pseudo-coverage (reads are mapping across the position, just not directly including that particular base). So we made this minor change, and we are seeing the deletions in the variability table AND in the anvi-inspect page:

<img width="1523" alt="image" src="https://github.com/user-attachments/assets/b52f3f8d-5387-4a64-a9d6-640a0ed3e765" />

yay?