### PR TITLE
Report all completion and redundancy estimate

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -3687,6 +3687,12 @@ D = {
                      "a comma-separated list. The default stats are 'detection' and "
                      "'mean_coverage_Q2Q3'. To see a list of available stats, use this flag "
                      "and provide an absolutely ridiculous string after it (we suggest 'cattywampus', but you do you)."}
+    ),
+    'report-all-estimates': (
+            ['--report-all-estimates'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Use this flag to report all C/R estimates, from all domains."}
     )
 }
 

--- a/bin/anvi-estimate-genome-completeness
+++ b/bin/anvi-estimate-genome-completeness
@@ -195,7 +195,7 @@ def print_for_a_single_contigs_db(contigs_db_path, profile_db_path=None, collect
     else:
         run.warning(None, header = 'Genome in "%s"' % os.path.basename(contigs_db_path), lc = 'green')
 
-    if not completeness.initialized_properly:
+    if not completeness.initialized_properly or args.report_all_estimates:
         print_improper(args, collection, completeness, run, progress)
     else:
         print_proper(args, collection, completeness, run, progress)
@@ -268,6 +268,7 @@ if __name__ == '__main__':
 
     groupD = parser.add_argument_group('PARAMETERS OF CONVENIENCE', "Because life is already very hard as it is.")
     groupD.add_argument(*anvio.A('list-collections'), **anvio.K('list-collections'))
+    groupD.add_argument(*anvio.A('report-all-estimates'), **anvio.K('report-all-estimates'))
     groupD.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
     groupD.add_argument(*anvio.A('concise'), **anvio.K('concise'))
     groupD.add_argument(*anvio.A('output-file'), **anvio.K('output-file'))


### PR DESCRIPTION
I added a flag to `anvi-estimate-genome-completeness` to report completion/redundancy estimate from all domains. The function was already in the code but not available when using the classic anvi'o SCG collections. 