### PR TITLE
Updating get-sequences-for-gene-calls for genes with multiple annotat…

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1269,6 +1269,14 @@ D = {
                      "the gene names that appear multiple times, and remove all but the one with the lowest e-value. Good "
                      "for whenever you really need to get only a single copy of single-copy core genes from a genome bin."}
                 ),
+    'return-all-function-hits-for-each-gene': (
+            ['--return-all-function-hits-for-each-gene'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Any given function annotation source may provide more than one annotation for a given gene. Using this flag "
+                     "will instruct anvi'o to report all hits, even if the default behavior is to report only the most "
+                     " statistically significant one."}
+                ),
     'unique-genes': (
             ['--unique-genes'],
             {'default': False,

--- a/bin/anvi-get-sequences-for-gene-calls
+++ b/bin/anvi-get-sequences-for-gene-calls
@@ -61,6 +61,8 @@ def export_from_contigs(args):
             raise ConfigError("Due to the lazy programming, --flank-length and --export-gff3 flags are incompatible :(")
         if args.annotation_source:
             func_kwargs['gene_annotation_source'] = args.annotation_source
+        if args.return_all_function_hits_for_each_gene:
+            anvio.RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE = True
 
         c.gen_GFF3_file_of_sequences_for_gene_caller_ids(**func_kwargs)
     else:
@@ -122,6 +124,7 @@ if __name__ == '__main__':
     groupB.add_argument(*anvio.A('export-gff3'), **anvio.K('export-gff3'))
     groupB.add_argument(*anvio.A('annotation-source'), **anvio.K('annotation-source'))
     groupB.add_argument(*anvio.A('list-annotation-sources'), **anvio.K('list-annotation-sources'))
+    groupB.add_argument(*anvio.A('return-all-function-hits-for-each-gene'), **anvio.K('return-all-function-hits-for-each-gene'))
 
     groupC = parser.add_argument_group('OPTION #2: GET SEQUENCES FROM A GENOMES STORAGE')
     groupC.add_argument(*anvio.A('genomes-storage'), **anvio.K('genomes-storage', {'required': False}))


### PR DESCRIPTION
When exploring function calls for some databases I recognised that the output of anvi-export-functions:
e.g. For gene_id 1401
```
1401    KOfam   K24866  precorrin-2 dehydrogenase [EC:1.3.1.76] 1.5e-71
1401    KOfam   K02302  uroporphyrin-III C-methyltransferase / precorrin-2 dehydrogenase / sirohydrochlorin ferrochelatase [EC:2.1.1.107 1.3.1.76 4.99.1.4]     1.4e-197
1401    KOfam   K02303  uroporphyrin-III C-methyltransferase [EC:2.1.1.107]     5.1e-120
```

didn't match up with what I saw from anvi-get-sequences-for-gene-calls.

```md
GCF_019670005_000000000001      .       CDS     1557585 1559012 .       -       .       ID=GCF_019670005___1401;Name=K02302;db_xref=KOfam:K02302;product=uroporphyrin-III C-methyltransferase / precorrin-2 dehydrogenase / sirohydrochlorin ferrochelatase [EC 2.1.1.107 1.3.1.76 4.99.1.4]
```

This behaviour was intended and would pick the function hit with the lowest e-value. I thought it might be valuable for anvio users (but mainly for me) to export multiple annotations for each gene call in their gffs (Yay...) so looked at how I could implement it. 

I found that the behaviour was dependent on the global attribute ```RETURN_ALL_FUNCTIONS_FROM_SOURCE_FOR_EACH_GENE``` and that by setting it to TRUE, I could achieve the desired outcome. I made this dependent by including an additional flag ```--return-all-hits```. 

The other code is for formatting multiple strings. The script will now look at all gene calls and if multiple features are present then the strings are formatted, comma-separated and populate the relevant fields. According to [GFF3 specification](https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md)(the GFF3 specification), comma-separation is okay for db_xref and product, but not really for Name. If merged, you may choose to retain the !!! separation for Name.

anvi-get-sequences-for-gene-calls can now be called as:
```bash
anvi-get-sequences-for-gene-calls --annotation-source KOfam --export-gff3 -c results/bacdive/bacteria_anvio/database/GCF_019670005.db -o GCF_019670005_new.gff3 --return-all-hits
```
