### PR TITLE
Updated anvi-gen-contigs-database and anvi-run-ncbi-cogs pages

### DIFF
--- a/anvio/docs/programs/anvi-gen-contigs-database.md
+++ b/anvio/docs/programs/anvi-gen-contigs-database.md
@@ -40,6 +40,8 @@ anvi-gen-contigs-database -f scaffolds.fa \
                           -o North_Atlantic_MGX_004.db
 {{ codestop }}
 
+To shorten the runtime, you can also multithread `anvi-gen-contigs-database` with the `-T` flag followed by the desired number of threads, depending on your system.
+
 There are a myriad of programs you can run on a %(contigs-db)s once it is created to add more and more layers of information on it. Please see the artifact %(contigs-db)s to see a list of steps you can follow.
 
 ### Create a contigs database with external gene calls

--- a/anvio/docs/programs/anvi-run-ncbi-cogs.md
+++ b/anvio/docs/programs/anvi-run-ncbi-cogs.md
@@ -27,3 +27,10 @@ By default, this program uses `diamond` to search for hits to the database. You 
 anvi-run-ncbi-cogs -c %(contigs-db)s \
             --search-with blastp
 {{ codestop }}
+
+### Running with multiple threads
+{{ codestart }}
+anvi-run-ncbi-cogs -c %(contigs-db)s \
+            --cog-data-dir path/to/%(cogs-data)s \ 
+            -T 16
+{{ codestop }}


### PR DESCRIPTION
Added information about multithreading to the help pages for [anvi-gen-contigs-database](https://anvio.org/help/main/programs/anvi-gen-contigs-database/) and [anvi-run-ncbi-cogs](https://anvio.org/help/main/programs/anvi-run-ncbi-cogs/). Tried to keep it consistent with the formatting of similar pages.