### PR TITLE
Update anvi-gen-variability-profile.md

### DIFF
--- a/anvio/docs/programs/anvi-gen-variability-profile.md
+++ b/anvio/docs/programs/anvi-gen-variability-profile.md
@@ -26,6 +26,16 @@ anvi-gen-variability-profile -p %(profile-db)s \
                              -s %(structure-db)s 
 {{ codestop }}
 
+You can also output your %(variability-profile-txt) to a specific location, which can be useful when working with multiple `engine` parameters.
+
+{{ codestart }}
+anvi-gen-variability-profile -p %(profile-db)s \
+                             -c %(contigs-db)s \
+                             -C DEFAULT \
+                             -b EVERYTHING \
+                             --output-file /path/to/your/variability.txt
+{{ codestop }}
+
 ### Focusing on a subset of the input 
 
 Instead of focusing on everything (providing the collection `DEFAULT` and the bin `EVERYTHING`), there are three ways to focus on a subset of the input: 


### PR DESCRIPTION
Updated info for the --output-file, which is can be necessary when scripting or working with multiple engine parameters (otherwise, I imagine the file would get overwritten or anvio wouldn't like that it already exists. I ran a script without this and I have no idea where the file went, so hopefully someone doesn't make the same mistake :) )