### PR TITLE
Specify the target sequence database size to hmmer programmes to avoid inconsistent E-value calculation when multiprocessing

### DIFF
--- a/anvio/drivers/hmmer.py
+++ b/anvio/drivers/hmmer.py
@@ -63,8 +63,6 @@ class HMMer:
             tmp_dir = filesnpaths.get_temp_directory_path()
             self.tmp_dirs.append(tmp_dir)
             
-            print(type(target_files_dict[source]))
-            
             # create splitted fasta files inside tmp directory
             split_fastas, number_of_sequences = utils.split_fasta(target_files_dict[source],
                                                                parts=self.num_threads_to_use,
@@ -234,7 +232,6 @@ class HMMer:
             self.run.warning("You requested to use the program `%s`, but because you are working with %s sequences Anvi'o will use `nhmmscan` instead. "
                              "We hope that is alright." % (self.program_to_use, alphabet))
 
-        
         thread_num = 0
         for partial_input_file in self.target_files_dict[target]:
             log_file = partial_input_file + '_log'

--- a/anvio/drivers/hmmer.py
+++ b/anvio/drivers/hmmer.py
@@ -256,6 +256,7 @@ class HMMer:
                                 '--tblout', table_file,
                                 '--domtblout', domtable_file,
                                 '-Z', number_of_sequences,
+                                '--domZ', number_of_sequences,
                                 hmm, partial_input_file]
                 else:
                     cmd_line = ['nhmmscan' if alphabet in ['DNA', 'RNA'] else self.program_to_use,
@@ -263,6 +264,7 @@ class HMMer:
                                 '--cpu', cores_per_process,
                                 '--tblout', table_file,
                                 '-Z', number_of_sequences,
+                                '--domZ', number_of_sequences,
                                 hmm, partial_input_file]
             else: # if we didn't pass any noise cutoff terms, here we don't include them in the command line
                 if 'domtable' in desired_output:
@@ -272,6 +274,7 @@ class HMMer:
                                 '--tblout', table_file,
                                 '--domtblout', domtable_file,
                                 '-Z', number_of_sequences,
+                                '--domZ', number_of_sequences,
                                 hmm, partial_input_file]
                 else:
                     cmd_line = ['nhmmscan' if alphabet in ['DNA', 'RNA'] else self.program_to_use,
@@ -279,6 +282,7 @@ class HMMer:
                                 '--cpu', cores_per_process,
                                 '--tblout', table_file,
                                 '-Z', number_of_sequences,
+                                '--domZ', number_of_sequences,
                                 hmm, partial_input_file]
 
             t = multiprocessing.Process(target=self.hmmer_worker, args=(partial_input_file,

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -909,7 +909,7 @@ def transpose_tab_delimited_file(input_file_path, output_file_path, remove_after
     return output_file_path
 
 
-def split_fasta(input_file_path, parts=1, file_name_prefix=None, shuffle=False, output_dir=None):
+def split_fasta(input_file_path, parts=1, file_name_prefix=None, shuffle=False, output_dir=None, return_number_of_sequences=False):
     """Splits a given FASTA file into multiple parts.
 
     Please note that this function will not clean after itself. You need to take care of the
@@ -929,12 +929,15 @@ def split_fasta(input_file_path, parts=1, file_name_prefix=None, shuffle=False, 
     output_dir : str, path
         Output directory. By default, anvi'o will store things in a new directory under
         the system location for temporary files
+    return_number_of_sequences : bool
+        Whether to return the number of sequences in the original fasta file
 
     Returns
     =======
     output_file_paths : list
         Array with `parts` number of elements where each item is an output file path
-
+    length : int, optional
+        The number of sequences in the original fasta file. Only returnd if 'return_number_of_sequences' is True
     """
     if not file_name_prefix:
         file_name_prefix = os.path.basename(input_file_path)
@@ -999,7 +1002,11 @@ def split_fasta(input_file_path, parts=1, file_name_prefix=None, shuffle=False, 
 
     source.close()
 
-    return output_file_paths
+    if return_number_of_sequences:
+        return output_file_paths, length
+    
+    else:
+        return output_file_paths
 
 
 def get_random_colors_dict(keys):


### PR DESCRIPTION
## Pull Request Description:
This pull request addresses an issue (#2446) with E-value calculations in the HMMer/run_hmmer program when using multiple processes. The E-value is dependent on the size of the sequence database, leading to inconsistencies when the database is split into smaller chunks for parallel processing. This affects the outcome of the bitscore heuristic and can result in varying E-values for the same sequences.

## Problem Description and Solution:

When annotating genes using multiple processes, the sequence database is split into smaller chunks, causing the E-values calculated by hmmer to differ from those calculated when the entire database is queried at once. This inconsistency particularly affects hits near the E-value threshold.

To resolve this, the -Z and --domZ parameters were specified in the hmmer command. These parameters are determined from the unsplit sequence file before it is split, equivalent to running it with one process, and are then used within the hmmer.run_hmmer() calls as additional noise cutoff parameters.


## Testing:
```
$ anvi-run-kegg-kofams --debug -c GCF_029633915.db --kegg-data-dir resources/anvio_ref_dbs/kegg/ --include-stray-KOs -T 1 --just-do-it
$ grep 2145 /tmp/tmp0qsgw3oy/AA_gene_sequences.fa.0_table
2145                 -          K10681               -            4.3e-32  108.5  15.6   7.3e-24   81.5   4.9   2.6   2   1   1   3   3   3   2 -
2145                 -          K20971               -            2.7e-31  106.0   1.3   2.7e-31  106.0   1.3   2.0   2   0   0   2   2   2   1 -
2145                 -          K03548               -              0.012   12.1   0.9      0.02   11.4   0.1   1.7   2   0   0   2   2   2   0 -
2145                 -          K12323               -              0.012   10.4   1.1     0.019    9.7   1.1   1.2   1   0   0   1   1   1   0 -
2145                 -          K04757               -            1.4e-06   25.4   0.0     2e-06   24.9   0.0   1.2   1   0   0   1   1   1   1 -
2145                 -          K03776               -              4e-13   45.9   0.2   5.3e-13   45.5   0.2   1.1   1   0   0   1   1   1   1 -

$ anvi-run-kegg-kofams --debug -c GCF_029633915.db --kegg-data-dir resources/anvio_ref_dbs/kegg/ --include-stray-KOs -T 4 --just-do-it
$ grep 2145 /tmp/tmpptkmibay/AA_gene_sequences.fa.*_table
2145                 -          K10681               -            4.3e-32  108.5  15.6   7.3e-24   81.5   4.9   2.6   2   1   1   3   3   3   2 -
2145                 -          K20971               -            2.7e-31  106.0   1.3   2.7e-31  106.0   1.3   2.0   2   0   0   2   2   2   1 -
2145                 -          K03548               -              0.012   12.1   0.9      0.02   11.4   0.1   1.7   2   0   0   2   2   2   0 -
2145                 -          K12323               -              0.012   10.4   1.1     0.019    9.7   1.1   1.2   1   0   0   1   1   1   0 -
2145                 -          K04757               -            1.4e-06   25.4   0.0     2e-06   24.9   0.0   1.2   1   0   0   1   1   1   1 -
2145                 -          K03776               -              4e-13   45.9   0.2   5.3e-13   45.5   0.2   1.1   1   0   0   1   1   1   1 -
```