### PR TITLE
`--no-hmmer-prefiltering` flag for `anvi-run-kegg-kofams` with large datasets

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -3205,6 +3205,18 @@ D = {
              'action': 'store_true',
              'help': "Use this flag to skip using BRITE hierarchies, which we don't recommend but let you do anyways."}
                 ),
+    'no-hmmer-prefiltering': (
+            ['--no-hmmer-prefiltering'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "By default, the initial set of hits we get back from HMMER are subject to its default e-value "
+                     "threshold of 10. However, if you are working with a very large dataset, this pre-filtering based "
+                     "on e-value might be too stringent and lead to missing some legitimate hits. If this is your case, "
+                     "you can use this flag to turn off the HMMER pre-filtering based on e-value. All hits we get from "
+                     "HMMER will still be subject to later bitscore-based filtering and the annotation heuristic to ensure "
+                     "we don't let in any garbage annotations (unless you use the `--keep-all-hits` or the `--skip-bitscore-heuristic` "
+                     "flags, respectively). See https://github.com/merenlab/anvio/issues/2446 for more details."}
+                ),
     'skip-binary-relations': (
             ['--skip-binary-relations'],
             {'default': False,

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -3212,10 +3212,11 @@ D = {
              'help': "By default, the initial set of hits we get back from HMMER are subject to its default e-value "
                      "threshold of 10. However, if you are working with a very large dataset, this pre-filtering based "
                      "on e-value might be too stringent and lead to missing some legitimate hits. If this is your case, "
-                     "you can use this flag to turn off the HMMER pre-filtering based on e-value. All hits we get from "
-                     "HMMER will still be subject to later bitscore-based filtering and the annotation heuristic to ensure "
-                     "we don't let in any garbage annotations (unless you use the `--keep-all-hits` or the `--skip-bitscore-heuristic` "
-                     "flags, respectively). See https://github.com/merenlab/anvio/issues/2446 for more details."}
+                     "you can use this flag to turn off the HMMER pre-filtering based on e-value (instead we will use `-T "
+                     "-20` and `-domT -20`). All hits we get from HMMER will still be subject to later bitscore-based "
+                     "filtering and the annotation heuristic to ensure we don't let in any garbage annotations (unless you "
+                     "use the `--keep-all-hits` or the `--skip-bitscore-heuristic` flags, respectively). See "
+                     "https://github.com/merenlab/anvio/issues/2446 for more details."}
                 ),
     'skip-binary-relations': (
             ['--skip-binary-relations'],

--- a/anvio/docs/programs/anvi-run-kegg-kofams.md
+++ b/anvio/docs/programs/anvi-run-kegg-kofams.md
@@ -50,6 +50,16 @@ anvi-run-kegg-kofams -c %(contigs-db)s \
                      --hmmer-program hmmscan
 {{ codestop }}
 
+## Prevent HMMER from pre-filtering hits with default e-value reporting thresholds
+The default e-value reporting thresholds that HMMER uses are quite high, but e-values are dependent on the size of the databases used. So, if you have a very large dataset, it is possible that we miss some annotations from hits with bit scores that would be good enough to pass the bit score thresholds, but never get reported by HMMER in the first place because their e-values are too high. To avoid this, use the following flag:
+
+{{ codestart }}
+anvi-run-kegg-kofams -c %(contigs-db)s \
+                     --no-hmmer-prefiltering
+{{ codestop }}
+
+In this case, we will set HMMER's reporting thresholds to be extremely low and bit score-based (`-T -20 and --domT -20`) so that we don't lose any hits with high bitscore yet high e-value. In most cases, this won't lead to many new annotations because the bitscore filtering we apply later will weed out most raw hits. But please exercise caution. Using this flag with `--keep-all-hits` is not recommended. 
+
 ## Keep all HMM hits
 Usually, this program parses out weak HMM hits and keeps only those that are above the score threshold for a given KO. If you would like to turn off this behavior and keep all hits (there will be _a lot_ of weak ones), you can follow the example below:
 

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -2948,6 +2948,7 @@ class RunKOfams(KeggContext):
         self.keep_all_hits = True if A('keep_all_hits') else False
         self.log_bitscores = True if A('log_bitscores') else False
         self.skip_bitscore_heuristic = True if A('skip_bitscore_heuristic') else False
+        self.no_hmmer_prefiltering = True if A('no_hmmer_prefiltering') else False
         self.bitscore_heuristic_e_value = A('heuristic_e_value')
         self.bitscore_heuristic_bitscore_fraction = A('heuristic_bitscore_fraction')
         self.skip_brite_hierarchies = A('skip_brite_hierarchies')

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -3467,9 +3467,13 @@ class RunKOfams(KeggContext):
                                                       simple_headers=True,
                                                       report_aa_sequences=True)
 
+        # turn off HMMER's default reporting thresholds if requested. We use an extremely low bitscore threshold instead.
+        noise_cutoff_terms = None
+        if self.no_hmmer_prefiltering:
+            noise_cutoff_terms = "-T -20 --domT -20"
         # run hmmscan
         hmmer = HMMer(target_files_dict, num_threads_to_use=self.num_threads, program_to_use=self.hmm_program)
-        hmm_hits_file = hmmer.run_hmmer('KOfam', 'AA', 'GENE', None, None, len(self.ko_dict), self.kofam_hmm_file_path, None, None)
+        hmm_hits_file = hmmer.run_hmmer('KOfam', 'AA', 'GENE', None, None, len(self.ko_dict), self.kofam_hmm_file_path, None, noise_cutoff_terms)
 
         has_stray_hits = False
         stray_hits_file = None

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -3479,7 +3479,7 @@ class RunKOfams(KeggContext):
         stray_hits_file = None
         if self.include_stray_kos:
             ohmmer = HMMer(target_files_dict, num_threads_to_use=self.num_threads, program_to_use=self.hmm_program)
-            stray_hits_file = ohmmer.run_hmmer('Stray KOs', 'AA', 'GENE', None, None, len(self.stray_ko_dict), self.stray_ko_hmm_file_path, None, None)
+            stray_hits_file = ohmmer.run_hmmer('Stray KOs', 'AA', 'GENE', None, None, len(self.stray_ko_dict), self.stray_ko_hmm_file_path, None, noise_cutoff_terms)
             has_stray_hits = True if stray_hits_file else False
 
         if not hmm_hits_file and not has_stray_hits:

--- a/bin/anvi-run-kegg-kofams
+++ b/bin/anvi-run-kegg-kofams
@@ -38,6 +38,7 @@ if __name__ == '__main__':
     groupO.add_argument(*anvio.A('keep-all-hits'), **anvio.K('keep-all-hits'))
     groupO.add_argument(*anvio.A('log-bitscores'), **anvio.K('log-bitscores'))
     groupO.add_argument(*anvio.A('skip-brite-hierarchies'), **anvio.K('skip-brite-hierarchies'))
+    groupO.add_argument(*anvio.A('no-hmmer-prefiltering'), **anvio.K('no-hmmer-prefiltering'))
     groupO.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
     groupH = parser.add_argument_group('BITSCORE RELAXATION HEURISTIC', "Sometimes, KEGG-provided bitscore thresholds "


### PR DESCRIPTION
This PR closes issue #2446. As described in that issue, very large datasets could be missing legitimate KOfam annotations simply because the default HMMER reporting thresholds (-E 10 and --domE 10) that rely on e-values (dependent on database size) would weed them out before we start processing the hits ourselves. The flag added here solves that problem by changing the reporting thresholds to `-T -20 --domT -20`). When using this flag with the standard bit score filtering of weak hits (ie, _not_ using `--keep-all-hits`), most of the additional reported hits will be weeded out anyway so that we don't keep garbage annotations.

It won't change the annotation set for most people/datasets, but for the big stuff, it could lead to some annotation recovery.