### PR TITLE
Multithreading anvi-script-find-misassemblies

### DIFF
--- a/anvio/docs/programs/anvi-script-find-misassemblies.md
+++ b/anvio/docs/programs/anvi-script-find-misassemblies.md
@@ -56,3 +56,9 @@ Another default behavior of the script is to skip the first and last 100bp of a 
 {{ codestart }}
 anvi-script-find-misassemblies -b sample01.bam -o result --min-dist-to-end 0
 {{ codestop }}
+
+You can also speed up the process by using multiple threads with the flag `-T`:
+
+{{ codestart }}
+anvi-script-find-misassemblies -b sample01.bam -o result -T 8
+{{ codestart }}

--- a/sandbox/anvi-script-find-misassemblies
+++ b/sandbox/anvi-script-find-misassemblies
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8
+# -*- coding: utf-8 -*-
 
 import sys
 import anvio
@@ -7,6 +7,7 @@ import argparse
 
 import anvio.bamops as bamops
 import anvio.terminal as terminal
+import multiprocess as multiprocessing
 
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
@@ -23,9 +24,57 @@ __description__ = ("This script report errors in long read assembly using read-r
                    "The input file should be a BAM file of long reads mapped to an assembly made from "
                    "these reads.")
 
-def main():
+def process_contig(args, available_index_queue, output_queue, contigs_size):
+    bam = bamops.BAMFileObject(args.bam_file, 'rb')
 
+    while True:
+        try:
+            idx = available_index_queue.get(True)  # blocking call
+            contig = list(contigs_size.keys())[idx]
+            length = contigs_size[contig]
 
+            coverage = [0] * length
+            clipping = {}
+
+            # got through each read, compute coverage and idc (insertion, deletion, (hard - soft)clipping).
+            for read in bam.fetch(contig):
+                if read.flag == 4:
+                    continue
+
+                current_pos = read.reference_start
+                cigar_tup = read.cigartuples
+                # counting the numb of tup because position index is different for
+                # hard/soft clipping if they are at the begining or at the end of cigar string
+                num_tup = 0
+                for tup in cigar_tup:
+                    num_tup += 1
+                    # if mapping, compute cov, increase current position
+                    if tup[0] == 0:
+                        for pos in range(current_pos, current_pos + tup[1]):
+                            coverage[pos] += 1
+                        current_pos += tup[1]
+                    # if deletion, increase current position
+                    elif tup[0] == 2:
+                        current_pos += tup[1]
+                    # if clipping (soft-hard: tup[0] = 4 or 5), then +1 clipping
+                    elif tup[0] in [4, 5]:
+                        if num_tup == 1:
+                            if current_pos != 0:
+                                clipping[current_pos] = clipping.get(current_pos, 0) + 1
+                        elif current_pos != length:
+                            clipping[current_pos - 1] = clipping.get(current_pos - 1, 0) + 1
+
+            output_queue.put((contig, length, coverage, clipping))
+
+            # Clean up memory
+            del coverage[:]
+            del clipping
+            gc.collect()
+
+        except Exception as e:
+            output_queue.put(e)
+
+def main(args):
     if not args.just_do_it:
         raise ConfigError("This script ONLY makes sense if you are using a BAM file that was made from "
                           "mapping long read onto an assembly made with the SAME long reads. "
@@ -35,81 +84,81 @@ def main():
     run = terminal.Run()
     progress = terminal.Progress()
 
-    bam = bamops.BAMFileObject(args.bam_file, 'rb')
     min_dist_to_end = args.min_dist_to_end
     min_clipping_ratio = args.clipping_ratio
+
     run.info('BAM file', args.bam_file)
     run.info('Length of contig\'s end to ignore', args.min_dist_to_end)
+    run.info('Number of threads', args.num_threads)
 
-    progress.new("Computing coverage beep boop")
+    manager = multiprocessing.Manager()
+    available_index_queue = manager.Queue()
+    output_queue = manager.Queue()
 
-    def add_clipping_cov(data, pos):
-        if pos not in data[contig]['clipping']:
-            data[contig]['clipping'][pos] = 1
-        else:
-            data[contig]['clipping'][pos] += 1
-
-    # the main dictionary to store coverage information
-    cov_dict = {}
-
-    # read counter
-    read_count = 0
-    total_reads = bam.mapped
-
-    contigs_list = bam.references
-    contigs_length = bam.lengths
-    # make a dict of contig:length
+    # make a dict of contigs and their size
     contigs_size = {}
-    for i, contig in enumerate(contigs_list):
-        contigs_size[contig] = contigs_length[i]
+    bam = bamops.BAMFileObject(args.bam_file, 'rb')
+    for i, contig in enumerate(bam.references):
+        contigs_size[contig] = bam.lengths[i]
+        available_index_queue.put(i)
+    bam.close()
 
-    # got through each read, compute coverage and idc (insertion, deletion, (hard - soft)clipping).
-    for read in bam:
-        read_count += 1
+    num_contigs = len(contigs_size)
+    num_threads = min(num_contigs, args.num_threads)
+    if num_threads != args.num_threads:
+        run.info_single(f"You have {terminal.pluralize('contig', num_contigs)} which is less "
+                        f"than the {args.num_threads} threads that you requested. Anvi'o will only use "
+                        f"{terminal.pluralize('thread', num_contigs)}")
 
-        if read.flag == 4:
-            continue
+    progress.new(f"Computing coverage with {terminal.pluralize('thread', num_threads)} beep boop", progress_total_items = num_contigs)
+    progress.update('initializing threads ...')
 
-        if read_count % 500 == 0:
-            progress.update('%d / %d' % (read_count, total_reads))
+    processes = []
+    for i in range(num_threads):
+        p = multiprocessing.Process(
+            target=process_contig,
+            args=(args, available_index_queue, output_queue, contigs_size)
+        )
+        processes.append(p)
+        p.start()
 
-        contig = read.reference_name
-        contig_end = contigs_size[contig]
-        if contig not in cov_dict:
-            cov_dict[contig] = {'cov': {x:0 for x in range(contig_end)},
-                            'clipping': {},
-                            'length' : contig_end}
-        current_pos = read.reference_start
-        cigar_tup = read.cigartuples
-        # counting the numb of tup because position index is different for
-        # hard/soft clipping if they are at the begining or at the end of cigar string
-        num_tup = 0
-        for tup in cigar_tup:
-            num_tup += 1
-            # if mapping, compute cov, increase current position
-            if tup[0] == 0:
-                for pos in range(current_pos, current_pos + tup[1], 1):
-                    cov_dict[contig]['cov'][pos] += 1
-                current_pos += tup[1]
-            # if deletion, increase current position
-            if tup[0] == 2:
-                current_pos += tup[1]
-            # if clipping (soft-hard: tup[0] = 4 or 5), then +1 clipping
-            elif tup[0] in [4, 5]:
-                if num_tup == 1:
-                    # if start contig, skip
-                    if current_pos != 0:
-                        add_clipping_cov(cov_dict, current_pos)
-                elif current_pos != contig_end:
-                    add_clipping_cov(cov_dict, current_pos - 1)
+    cov_dict = {}
+    received = 0
+
+    while received < num_contigs:
+        try:
+            result = output_queue.get()
+            if isinstance(result, Exception):
+                for p in processes:
+                    p.terminate()
+                raise result
+            contig, length, cov, clip = result
+            cov_dict[contig] = {
+                'length': length,
+                'cov': dict(enumerate(cov)),
+                'clipping': clip
+            }
+            received += 1
+            progress.update(f"computing contigs {received}/{num_contigs}")
+            progress.increment(increment_to = received)
+        except KeyboardInterrupt:
+            run.info_single("Received SIGINT, terminating processes...")
+            for p in processes:
+                p.terminate()
+            break
+
+    for p in processes:
+        p.terminate()
+
     progress.end()
 
-    clippling_ouput = args.output_prefix + '-clipping.txt'
-    run.info('Output file', clippling_ouput)
-    with open(clippling_ouput, 'w') as file:
+    # writting the outputs
+    clipping_ouput = args.output_prefix + '-clipping.txt'
+    run.info('Output file', clipping_ouput)
+    with open(clipping_ouput, 'w') as file:
         file.write("contig\tlength\tpos\trelative_pos\tcov\tclipping\tclipping_ratio\n")
         for contig, data in cov_dict.items():
-            contig_length = cov_dict[contig]['length']
+            contig_length = data['length']
             for pos in data['clipping']:
                 cov = cov_dict[contig]['cov'][pos]
                 clipping = cov_dict[contig]['clipping'][pos]
@@ -123,7 +172,7 @@ def main():
     with open(zero_ouput, 'w') as file:
         file.write("contig\tlength\trange\trange_size\n")
         for contig, data, in cov_dict.items():
-            contig_length = cov_dict[contig]['length']
+            contig_length = data['length']
             in_window = False
             window_start = ''
             window_end = ''
@@ -196,8 +245,12 @@ if __name__ == '__main__':
         '--clipping-ratio',
         default=0.8,
         type=float,
-        help = ("Minimum ratio of 'total-coverage / coverage-of-clipped-reads' that will be reported "
+        help = ("Minimum ratio of 'coverage-of-clipped-reads / total-coverage' that will be reported "
                 "in the output file. Default is 0.8")
+    )
+    group1.add_argument(
+        *anvio.A('num-threads'),
+        **anvio.K('num-threads'),
     )
     group1.add_argument(
         *anvio.A('just-do-it'),
@@ -207,7 +260,7 @@ if __name__ == '__main__':
     args = parser.get_args(parser)
 
     try:
-        main()
+        main(args)
     except ConfigError as e:
         print(e)
         sys.exit(-1)

--- a/sandbox/anvi-script-find-misassemblies
+++ b/sandbox/anvi-script-find-misassemblies
@@ -66,11 +66,6 @@ def process_contig(args, available_index_queue, output_queue, contigs_size):
 
             output_queue.put((contig, length, coverage, clipping))
 
-            # Clean up memory
-            del coverage[:]
-            del clipping
-            gc.collect()
-
         except Exception as e:
             output_queue.put(e)
 


### PR DESCRIPTION
I tested it on a test case (single contig = single threads) and one real world dataset (metaMDBG assembly of Zymo mock community) and it is working with no difference in the output, except for the conitg order but we can live with that. 

Currently testing on ALL samples from ["Assemblies of long-read metagenomes suffer from diverse errors"](https://doi.org/10.1101/2025.04.22.649783).

Will merge when I confirm that ALL outputs are identical to the previous version of the script. 

Note: I don't have a special case for when the number of threads is one. I can see that in the rest of the codebase, we treat single thread processes differently. Notably the progress bar is quite different. But are there any other reasons I should be aware or is that fine for this code?

The PR include an update to the documentation as well.