### PR TITLE
New Version Info Handling

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -3,11 +3,7 @@
 
 """Lots of under-the-rug, operational garbage in here. Run. Run away."""
 
-anvio_version = '8-dev'
-anvio_codename = 'marie' # after Marie Tharp -- see the release notes for details: https://github.com/merenlab/anvio/releases/tag/v8
-
-major_python_version_required = 3
-minor_python_version_required = 10
+from anvio.version import anvio_version, anvio_codename, major_python_version_required, minor_python_version_required, get_versions
 
 import sys
 import platform
@@ -3752,27 +3748,18 @@ def K(param_id, params_dict={}):
 
 # The rest of this file is composed of code that responds to '-v' or '--version' calls from clients,
 # and provides access to the database version numbers for all anvi'o modules.
-
-import anvio.tables as t
-from anvio.terminal import Run
-
-
-run = Run()
-
-
-def set_version():
-    return anvio_version, \
-           anvio_codename, \
-           t.contigs_db_version, \
-           t.pan_db_version, \
-           t.profile_db_version, \
-           t.genes_db_version, \
-           t.auxiliary_data_version, \
-           t.genomes_storage_vesion, \
-           t.structure_db_version, \
-           t.metabolic_modules_db_version, \
-           t.trnaseq_db_version
-
+(__version__,
+ __codename__,
+ __contigs__version__,
+ __profile__version__, \
+ __genes__version__, \
+ __pan__version__, \
+ __auxiliary_data_version__, \
+ __structure__version__, \
+ __genomes_storage_version__ , \
+ __trnaseq__version__, \
+ __workflow_config_version__,
+ __kegg_modules_version__) = get_versions()
 
 def get_version_tuples():
     return [("Anvi'o version", "%s (v%s)" % (__codename__, __version__)),
@@ -3788,30 +3775,20 @@ def get_version_tuples():
 
 
 def print_version():
+    from anvio.terminal import Run
+    run = Run()
     run.info("Anvi'o", "%s (v%s)" % (__codename__, __version__), mc='green')
     run.info("Python", platform.python_version(), mc='cyan', nl_after=1)
     run.info("Profile database", __profile__version__)
     run.info("Contigs database", __contigs__version__)
     run.info("Pan database", __pan__version__)
     run.info("Genome data storage", __genomes_storage_version__)
-    run.info("Auxiliary data storage", __auxiliary_data_version__)
     run.info("Structure database", __structure__version__)
     run.info("Metabolic modules database", __kegg_modules_version__)
-    run.info("tRNA-seq database", __trnaseq__version__, nl_after=1)
-
-
-__version__, \
-__codename__, \
-__contigs__version__, \
-__pan__version__, \
-__profile__version__, \
-__genes__version__, \
-__auxiliary_data_version__, \
-__genomes_storage_version__ , \
-__structure__version__, \
-__kegg_modules_version__, \
-__trnaseq__version__ = set_version()
-
+    run.info("tRNA-seq database", __trnaseq__version__)
+    run.info("Genes database", __genes__version__)
+    run.info("Auxiliary data storage", __auxiliary_data_version__)
+    run.info("Workflow configurations", __workflow_config_version__, nl_after=1)
 
 if '-v' in sys.argv or '--version' in sys.argv:
     print_version()

--- a/anvio/dbinfo.py
+++ b/anvio/dbinfo.py
@@ -20,7 +20,7 @@ import anvio
 from anvio.db import DB
 from anvio.errors import ConfigError
 from anvio.terminal import Run, Progress
-from anvio.tables import versions_for_db_types
+from anvio.version import versions_for_db_types
 
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/kegg.py
+++ b/anvio/kegg.py
@@ -21,16 +21,17 @@ from typing import Dict, List, Tuple, Union
 
 import anvio
 import anvio.db as db
+import anvio.tables as t
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-import anvio.tables as t
 import anvio.ccollections as ccollections
 
 from anvio.errors import ConfigError
 from anvio.drivers.hmmer import HMMer
 from anvio.drivers.muscle import Muscle
 from anvio.parsers import parser_modules
+from anvio.version import versions_for_db_types
 from anvio.tables.genefunctions import TableForGeneFunctions
 from anvio.dbops import ContigsSuperclass, ContigsDatabase, ProfileSuperclass, ProfileDatabase, PanSuperclass
 from anvio.genomedescriptions import MetagenomeDescriptions, GenomeDescriptions
@@ -821,7 +822,7 @@ class KeggSetup(KeggContext):
         db_conn.disconnect()
 
         # if modules.db is out of date, give warning
-        target_version = int(anvio.tables.versions_for_db_types['modules'])
+        target_version = int(versions_for_db_types['modules'])
         if current_db_version != target_version:
             self.run.warning(f"Just so you know, the KEGG archive that was just set up contains an outdated MODULES.db (version: "
                              f"{current_db_version}). You may want to run `anvi-migrate` on this database before you do anything else. "
@@ -8369,7 +8370,7 @@ class ModulesDatabase(KeggContext):
             self.db.set_meta_value('total_brite_entries', None)
         self.db.set_meta_value('creation_date', time.time())
         self.db.set_meta_value('hash', self.get_db_content_hash())
-        self.db.set_meta_value('version', t.metabolic_modules_db_version)
+        self.db.set_meta_value('version', anvio.__kegg_modules_version__)
 
         self.db.disconnect()
 

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -12,29 +12,10 @@ __license__ = "GPL 3.0"
 __maintainer__ = "A. Murat Eren"
 __email__ = "a.murat.eren@gmail.com"
 
-
-contigs_db_version = "24"
-profile_db_version = "40"
-genes_db_version = "6"
-pan_db_version = "21"
-auxiliary_data_version = "2"
-structure_db_version = "2"
-genomes_storage_vesion = "7"
-trnaseq_db_version = "2"
-workflow_config_version = "3"
-metabolic_modules_db_version = "4"
-
-versions_for_db_types = {'contigs': contigs_db_version,
-                         'profile': profile_db_version,
-                         'genes': genes_db_version,
-                         'structure': structure_db_version,
-                         'pan': pan_db_version,
-                         'genomestorage': genomes_storage_vesion,
-                         'auxiliary data for coverages': auxiliary_data_version,
-                         'trnaseq': trnaseq_db_version,
-                         'config': workflow_config_version,
-                         'modules': metabolic_modules_db_version}
-
+####################################################################################################
+# EXTREMELY IMPORTANT NOTE: If you need to change the version number of any anvi'o database
+# due to changes in the table structure, you need to visit the file `anvio/versions.py `
+####################################################################################################
 
 ####################################################################################################
 #

--- a/anvio/tables/collections.py
+++ b/anvio/tables/collections.py
@@ -232,7 +232,7 @@ class TablesForCollections(Table):
                                   "which case things will likely work.")
             else:
                 utils.is_profile_db_and_contigs_db_compatible(self.db_path, contigs_db_path)
-                contigs_db = db.DB(contigs_db_path, t.contigs_db_version)
+                contigs_db = db.DB(contigs_db_path, anvio.__contigs__version__)
                 all_items = contigs_db.get_single_column_from_table(t.splits_info_table_name, 'split')
                 contigs_db.disconnect()
         else:

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -40,8 +40,9 @@ import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
 
 from anvio.dbinfo import DBInfo as dbi
-from anvio.errors import ConfigError, FilesNPathsError
 from anvio.sequence import Composition
+from anvio.version import versions_for_db_types
+from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import Run, Progress, SuppressAllOutput, get_date, TimeCode, pluralize
 
 # psutil is causing lots of problems for lots of people :/
@@ -4246,11 +4247,11 @@ def get_db_variant(db_path):
 def get_required_version_for_db(db_path):
     db_type = get_db_type(db_path)
 
-    if db_type not in t.versions_for_db_types:
+    if db_type not in versions_for_db_types:
         raise ConfigError("Anvi'o was trying to get the version of the -alleged- anvi'o database '%s', but it failed "
                            "because it turns out it doesn't know anything about this '%s' type." % (db_path, db_type))
 
-    return t.versions_for_db_types[db_type]
+    return versions_for_db_types[db_type]
 
 
 def get_all_sample_names_from_the_database(db_path):

--- a/anvio/version.py
+++ b/anvio/version.py
@@ -1,0 +1,61 @@
+"""
+Version information for anvi'o and its database artifacts.
+
+This module centralizes all version information to avoid circular imports
+during package installation and to provide a single source of truth for
+version-related data.
+"""
+
+# Core anvi'o version information
+anvio_version = '8-dev'
+anvio_codename = 'marie'  # after Marie Tharp -- see the release notes for details: https:ithub.com/merenlab/anvio/releases/tag/v8
+
+# Mandatory Python version
+major_python_version_required = 3
+minor_python_version_required = 10
+
+# Version numbers for anvi'o artifacts -- if you need to change any
+# of these numbers, you better have a well-tested migration script
+# ready to go along with that change!
+contigs_db_version = "24"
+profile_db_version = "40"
+genes_db_version = "6"
+pan_db_version = "21"
+auxiliary_data_version = "2"
+structure_db_version = "2"
+genomes_storage_version = "7"
+trnaseq_db_version = "2"
+workflow_config_version = "3"
+metabolic_modules_db_version = "4"
+
+versions_for_db_types = {'contigs': contigs_db_version,
+                         'profile': profile_db_version,
+                         'genes': genes_db_version,
+                         'structure': structure_db_version,
+                         'pan': pan_db_version,
+                         'genomestorage': genomes_storage_version,
+                         'auxiliary data for coverages': auxiliary_data_version,
+                         'trnaseq': trnaseq_db_version,
+                         'config': workflow_config_version,
+                         'modules': metabolic_modules_db_version}
+
+def get_versions():
+    """
+    Return version tuple for all anvi'o components.
+
+    This function mirrors the original set_version() function from __init__.py
+    but ensures database versions are loaded first.
+    """
+
+    return (anvio_version,
+            anvio_codename,
+            contigs_db_version,
+            profile_db_version,
+            genes_db_version,
+            pan_db_version,
+            auxiliary_data_version,
+            structure_db_version,
+            genomes_storage_version,
+            trnaseq_db_version,
+            workflow_config_version,
+            metabolic_modules_db_version)

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -15,6 +15,7 @@ import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import ConfigError
+from anvio.version import versions_for_db_types
 
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
@@ -30,7 +31,7 @@ run = terminal.Run()
 progress = terminal.Progress()
 r = errors.remove_spaces
 
-workflow_config_version = anvio.tables.versions_for_db_types['config']
+workflow_config_version = versions_for_db_types['config']
 
 class WorkflowSuperClass:
     def __init__(self):

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -9,13 +9,13 @@ import shutil
 
 import anvio
 import anvio.db as db
-import anvio.tables as t
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
-from anvio.errors import ConfigError, FilesNPathsError
 from anvio.migrations import migration_scripts
+from anvio.versions import versions_for_db_types
+from anvio.errors import ConfigError, FilesNPathsError
 
 
 __description__ = "Migrates any anvi'o artifact, whether it is a database or a config file, to a newer version. Pure magic."
@@ -177,8 +177,8 @@ class Migrater(object):
 
 
     def get_target_version(self):
-        if self.artifact_type in t.versions_for_db_types:
-            version = int(t.versions_for_db_types[self.artifact_type])
+        if self.artifact_type in versions_for_db_types:
+            version = int(versions_for_db_types[self.artifact_type])
         else:
             raise ConfigError(f"Anvi'o does not have any version information about the type '{self.artifact_type}'.")
 

--- a/bin/anvi-migrate
+++ b/bin/anvi-migrate
@@ -14,7 +14,7 @@ import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
 from anvio.migrations import migration_scripts
-from anvio.versions import versions_for_db_types
+from anvio.version import versions_for_db_types
 from anvio.errors import ConfigError, FilesNPathsError
 
 


### PR DESCRIPTION
Today I decided to work on modernizing anvi'o Python package.

So far we have been working with `setup.py` and `requirements.txt`, and it is time to switch to a modern `pyproject.toml` solution.

While working on that, I realized that there is no way to quickly learn about the anvi'o version before installing all dependencies. Because we keep our version information in `anvio/__init__.py`, but this file starts importing things like `numpy`, a dependency that only is installed after everyting is in place. So how can we learn about the package version if we don't want to write it in multiple places? We needed a simple Python in the codebase that solely responsible to keep track of versions of things.

So this PR introduces `anvio/version.py`, which consolidates information from `anvio/__init__.py` as well as `anvio/tables/__init__.py` to keep track of the version of the anvi'o package, key anvi'o artifacts, as well as Python version requirements.

Now this is out of the way, I can go back to the `pyproject.toml` thingy with a peace of mind.

I tested it by running this component test:

```
anvi-self-test --suite metagenomics-full
```

There may be a few tiny bugs to fix here and there, but those fixes will be absolutely straightforward so I will go ahead and merge this.