### PR TITLE
Fixing batch processing of HMMer outputs being appended to main table

### DIFF
--- a/anvio/drivers/hmmer.py
+++ b/anvio/drivers/hmmer.py
@@ -450,7 +450,6 @@ class HMMer:
 
         detected_non_ascii = False
         lines_with_non_ascii = []
-        output_lines = []
 
         def process_batch(line_batch, base_line_number):
             nonlocal detected_non_ascii
@@ -476,16 +475,18 @@ class HMMer:
             for line_bytes in hmm_hits_file:
                 batch.append(line_bytes)
                 if len(batch) >= lines_per_chunk:
-                    output_lines.extend(process_batch(batch, base_line_number))
+                    filtered_lines = process_batch(batch, base_line_number)
+                    if filtered_lines:
+                        with buffer_write_lock:
+                            merged_file_buffer.write("\n".join(filtered_lines) + "\n")
                     base_line_number += len(batch)
                     batch = []
 
             if batch:
                 filtered_lines = process_batch(batch, base_line_number)
                 if filtered_lines:
-                    filtered_text = "\n".join(filtered_lines) + "\n"
                     with buffer_write_lock:
-                        merged_file_buffer.write(filtered_text)
+                        merged_file_buffer.write("\n".join(filtered_lines) + "\n")
 
         # Log warning if non-ASCII characters were detected
         if detected_non_ascii:


### PR DESCRIPTION
This pull request addresses the bug report #2468  identified by @mankeldy and reported by @ivagljiva.

This fixes errors introduced in #2423. The intent of pull request #2423 was to process up to 1,000,000 hits per thread. When a full ```batch``` was created (i.e. 1 million hits) then the variable ```output_files``` was generated. This was never processed, filtered or output in the final HMM hits output table. Subsequently, if a file contained e.g. 2.5 million hits, then the first two batches (of 1 million hits each) would not be output, and only the final 0.5 million would be.  This is a very silly error.

This update fixes that mistake - each batch, regardless of whether it is full (1 million) or not, is processed and written to the output file. This fix keeps the the intended time and memory savings of #2423, but actually works now.

To test it, I reannotated an anvio database as so:
```
anvi-run-kegg-kofams -c GCA_000690595.db -T 4 --just-do-it --kegg-data-dir resources/anvio_ref_dbs/kegg/ --include-stray-KOs --debug
```

and confirmed whether all the hits (normal and stray) were output in the final hmm..table:
```
(anvio-dev) $ grep -v -e "^#"  /tmp/tmpzng8q_ib/AA_gene_sequences.fa.*_table | wc -l
93478
(anvio-dev) $ wc -l /tmp/tmpzng8q_ib/hmm.table
93478 /tmp/tmpzng8q_ib/hmm.table
(anvio-dev) $ grep -v -e "^#" /tmp/tmptzqmr6w7/AA_gene_sequences.fa*_table | wc -l
3143
(anvio-dev) $ wc -l /tmp/tmptzqmr6w7/hmm.table
3143 /tmp/tmptzqmr6w7/hmm.table
```

I also changed the number of lines per chunk (to 100), which would previously cause only incomplete batches (<100 lines) to be output to the final hmm.table.

```
(anvio-dev) $ grep -v -e "^#" /tmp/tmpureyqili/AA_gene_sequences.fa.*_table | wc -l
93478
(anvio-dev) $ wc -l /tmp/tmpureyqili/hmm.table
93478 /tmp/tmpureyqili/hmm.table
(anvio-dev) $ grep -v -e "^#" /tmp/tmpbxdio9op/AA_gene_sequences.fa.*_table | wc -l
3143
(anvio-dev) $ wc -l /tmp/tmpbxdio9op/hmm.table
3143 /tmp/tmpbxdio9op/hmm.table
```


Many thanks to @ivagljiva and @mankeldy for finding this issue. A very annoying mistake and I apologise for introducing it in the first case.