### PR TITLE
Create MODELLER/db directory before writing database files

### DIFF
--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -1357,6 +1357,10 @@ class PDBDatabase(object):
         """Update the search database used by MODELLER so it shares the same proteins as this database"""
 
         modeller_database_dir = J(os.path.dirname(anvio.__file__), 'data/misc/MODELLER/db')
+        
+        # CREATE THE DIRECTORY IF IT DOESN'T EXIST
+        os.makedirs(modeller_database_dir, exist_ok=True)
+        
         pir_db = J(modeller_database_dir, 'pdb_95.pir')
         bin_db = J(modeller_database_dir, 'pdb_95.bin')
         dmnd_db = J(modeller_database_dir, 'pdb_95.dmnd')


### PR DESCRIPTION
**Description**:
The anvi-setup-pdb-database command fails when the MODELLER/db/ directory doesn't exist, showing a misleading "not authorized" error message. Bug:

**Error:** File/Path Error: It seems you are not authorized to create an output file at '.../MODELLER/db/pdb_95.pir'
**Location**: structureops.py, in PDBDatabase.update_modeller_database()
**Root cause**: The db/ subdirectory is never created before attempting to write files to it

**Fix**:
Add directory creation in PDBDatabase.update_modeller_database() method before file operations:

```
def update_modeller_database(self):
    """Update the search database used by MODELLER so it shares the same proteins as this database"""

    modeller_database_dir = J(os.path.dirname(anvio.__file__), 'data/misc/MODELLER/db')
    
    # CREATE THE DIRECTORY IF IT DOESN'T EXIST
    os.makedirs(modeller_database_dir, exist_ok=True)
```