### PR TITLE
Add support for --I-know-this-is-not-a-good-idea flag in pangenomics …

### DIFF
--- a/anvio/workflows/pangenomics/Snakefile
+++ b/anvio/workflows/pangenomics/Snakefile
@@ -58,7 +58,8 @@ rule anvi_pan_genome:
         skip_hierarchical_clustering = M.get_rule_param("anvi_pan_genome", "--skip-hierarchical-clustering"),
         enforce_hierarchical_clustering = M.get_rule_param("anvi_pan_genome", "--enforce-hierarchical-clustering"),
         distance = M.get_rule_param("anvi_pan_genome", "--distance"),
-        linkage = M.get_rule_param("anvi_pan_genome", "--linkage")
+        linkage = M.get_rule_param("anvi_pan_genome", "--linkage"),
+        i_know_this_is_not_a_good_idea = M.get_rule_param("anvi_pan_genome", "--I-know-this-is-not-a-good-idea")
     output: os.path.join(dirs_dict["PAN_DIR"], M.pan_project_name + "-PAN.db")
     shell:
         """
@@ -68,7 +69,7 @@ rule anvi_pan_genome:
             {params.min_occurrence} {params.min_percent_identity} \
             {params.description} {params.overwrite_output_destinations}\
             {params.skip_hierarchical_clustering} {params.enforce_hierarchical_clustering}\
-            {params.distance} {params.linkage} >> {log} 2>&1
+            {params.distance} {params.linkage} {params.i_know_this_is_not_a_good_idea} >> {log} 2>&1
         """
 
 

--- a/anvio/workflows/pangenomics/__init__.py
+++ b/anvio/workflows/pangenomics/__init__.py
@@ -65,7 +65,7 @@ class PangenomicsWorkflow(PhylogenomicsWorkflow, ContigsDBWorkflow, WorkflowSupe
                      "--minbit", "--mcl-inflation", "--min-occurrence",\
                      "--min-percent-identity", "--description",\
                      "--overwrite-output-destinations", "--skip-hierarchical-clustering",\
-                     "--enforce-hierarchical-clustering", "--distance", "--linkage"]
+                     "--enforce-hierarchical-clustering", "--distance", "--linkage", "--I-know-this-is-not-a-good-idea"]
         self.rule_acceptable_params_dict['anvi_pan_genome'] = pan_params
 
         storage_params = ["--gene-caller"]


### PR DESCRIPTION
## Add support for `--I-know-this-is-not-a-good-idea` flag in pangenomics workflow

### Summary
The pangenomics workflow currently fails when processing >100 genomes, requiring users to run the pangenome analysis step manually outside the workflow. This PR adds support for the `--I-know-this-is-not-a-good-idea` flag as a configurable parameter, enabling full workflow automation for large-scale comparative genomics studies.

### Problem
When running the pangenomics workflow with >100 genomes, the workflow stops with:
```
Config Error: Sorry for making you wait this long to tell you this, but you have a total of
              [N] genomes to process, and anvi'o may not be the best platform to do that...
              you can easily force anvi'o to start the analysis using the flag 
              `--I-know-this-is-not-a-good-idea`.
```

However, this flag is **not available** as a configurable parameter in the workflow's `config.json`, forcing users to:
1. Run the pangenome step manually with the flag
2. Resume the workflow afterward for phylogenomics and other downstream steps

This breaks workflow automation and reproducibility.

### Solution
This PR adds `--I-know-this-is-not-a-good-idea` as an optional parameter in the pangenomics workflow configuration.

**Changes made:**
- Added flag to the list of acceptable parameters in `anvio/workflows/pangenomics/__init__.py`
- Added parameter handling in the Snakefile's `params` section
- Added flag to the `anvi-pan-genome` shell command

### Usage
Users can now add this to their `config.json`:
```json
"anvi_pan_genome": {
    "threads": 20,
    "--mcl-inflation": "1.5",
    "--I-know-this-is-not-a-good-idea": true
}
```

The flag defaults to empty/false if not specified, maintaining the existing protective behavior for typical use cases.

### Use Case
Comparative genomics studies of closely related strains or species often involve 100-200+ genomes. While anvi'o correctly warns users about performance implications, researchers who understand these limitations should be able to use the automated workflow for their analyses without manual intervention.

### Testing
- ✅ Tested with 112 genomes in a Phaeobacter pangenomics study
- ✅ Parameter is now accepted in config validation
- ✅ Workflow runs successfully with the flag enabled
- ✅ Backward compatible (flag is optional)
- ✅ FWIW: it works painfully on a 64 cores/1TB RAM single node in less than 5 hours. On my way to try that with 300+ Vibri genomes. Yeah. I know. quadratic pain.

### Impact
This change:
- Enables full workflow automation for large genome sets
- Improves reproducibility (no manual steps required)
- Maintains protective warnings for typical use cases
- Is backward compatible (no breaking changes)

---

**Note:** I'm happy to make any adjustments if the anvi'o team has suggestions for improving this implementation!