### PR TITLE
Revamp anvi-run-workflow for 'contigs'

### DIFF
--- a/anvio/docs/workflows/ecophylo.md
+++ b/anvio/docs/workflows/ecophylo.md
@@ -373,7 +373,7 @@ To visualize the output of [profile-mode](#profile-mode-insights-into-the-ecolog
 ```bash
 PROTEIN="" # Replace with name of protein from hmm_list.txt
 anvi-interactive -p METAGENOMICS_WORKFLOW/06_MERGED/"${PROTEIN}"/PROFILE.db \
-                 -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}"-contigs.db \
+                 -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}".db \
                  --manual
 ```
 
@@ -441,12 +441,12 @@ grep -v -f SUBSET_TREE/bad_branches_headers.txt SUBSET_TREE/collection-DEFAULT.t
 
 anvi-import-collection SUBSET_TREE/my_bins.txt -C curated \
                                                -p METAGENOMICS_WORKFLOW/06_MERGED/"${PROTEIN}"/PROFILE.db \
-                                               -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}"-contigs.db
+                                               -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}".db
                         
 anvi-split -C curated \
            --bin-id EVERYTHING_curated \
            -p METAGENOMICS_WORKFLOW/06_MERGED/"${PROTEIN}"/PROFILE.db \
-           -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}"-contigs.db \
+           -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}".db \
            --output-dir SUBSET_TREE/"${PROTEIN}"_curated
 ```
 
@@ -575,7 +575,7 @@ To visualize the results of the different ecophylo runs, just change the paths t
 
 ```bash
 PROTEIN="" # Replace with name of protein from hmm_list.txt
-anvi-interactive -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}"-contigs.db -p METAGENOMICS_WORKFLOW/06_MERGED/"${PROTEIN}"/PROFILE.db
+anvi-interactive -c METAGENOMICS_WORKFLOW/03_CONTIGS/"${PROTEIN}".db -p METAGENOMICS_WORKFLOW/06_MERGED/"${PROTEIN}"/PROFILE.db
 ```
 
 However, if you are interested in comparing the outputs of different parameters on the same protein, make a new %(workflow-config)s file, otherwise ecophylo will try and fail to overwrite your original run.
@@ -852,6 +852,6 @@ anvi-run-workflow -w ecophylo -c config_RP_L16.json
 anvi-run-workflow -w ecophylo -c config_RP_S11.json
 
 # Visualize
-anvi-interactive -c 03_CONTIGS/Ribosomal_L16-contigs.db -p 06_MERGED/Ribosomal_L16/PROFILE.db
-anvi-interactive -c 03_CONTIGS/Ribosomal_S11-contigs.db -p 06_MERGED/Ribosomal_S11/PROFILE.db
+anvi-interactive -c 03_CONTIGS/Ribosomal_L16.db -p 06_MERGED/Ribosomal_L16/PROFILE.db
+anvi-interactive -c 03_CONTIGS/Ribosomal_S11.db -p 06_MERGED/Ribosomal_S11/PROFILE.db
 ```

--- a/anvio/docs/workflows/metagenomics.md
+++ b/anvio/docs/workflows/metagenomics.md
@@ -176,7 +176,7 @@ Once everything finishes running (on our cluster it only takes 6 minutes as thes
 
 ```
 anvi-interactive -p 06_MERGED/G02/PROFILE.db \
-                 -c 03_CONTIGS/G02-contigs.db
+                 -c 03_CONTIGS/G02.db
 ```
 
 And it should look like this:
@@ -198,7 +198,7 @@ Which means, while you can use the program %(anvi-interactive)s to interactively
 
 ```bash
 anvi-interactive -p 05_ANVIO_PROFILE/G01/sample_01/PROFILE.db \
-                 -c 03_CONTIGS/G01-contigs.db
+                 -c 03_CONTIGS/G01.db
 ```
 
 [![single_profile_idba_ud](../../images/workflows/metagenomics/single_profile_idba_ud.png)]( ../../images/workflows/metagenomics/single_profile_idba_ud.png){:.center-img .width-50}
@@ -590,7 +590,7 @@ This is done through 'references mode', but as you see in the relevant section, 
 │   ├── anvi_run_ncbi_cogs-EXAMPLE.done
 │   ├── anvi_run_scg_taxonomy-EXAMPLE.done
 │   ├── EXAMPLE-annotate_contigs_database.done
-│   └── EXAMPLE-contigs.db
+│   └── EXAMPLE.db
 ├── config.json
 ├── contigs.fa
 ├── fasta.txt

--- a/anvio/migrations/config/v4_to_v5.py
+++ b/anvio/migrations/config/v4_to_v5.py
@@ -55,7 +55,12 @@ def migrate(config_path):
     run.info_single(f"The config file version is now {next_version}. This upgrade removes the `gunzip_fasta` "
                     f"rule from your config (if it was there). The contigs workflow no longer needs to decompress "
                     f"gzipped FASTA files before processing them, since all downstream tools (anvi-script-reformat-fasta, "
-                    f"anvi-gen-contigs-database, bowtie2-build, minimap2) natively support gzipped input.",
+                    f"anvi-gen-contigs-database, bowtie2-build, minimap2) natively support gzipped input. In addition, "
+                    f"the contigs workflow had additional changes that will make your *existing* `anvi-run-workflow` outputs "
+                    f"not recognized with the new version of the workflow :/ BUT we have made available a migration script "
+                    f"at https://github.com/merenlab/anvio/pull/2553 to help you with this backwards compatibility issue. "
+                    f"Please check out the link for more details, and reach out to us on anvi'o Discord if you have any "
+                    f"questions regarding how to complete the migration process for your data.",
                     nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/config/v4_to_v5.py
+++ b/anvio/migrations/config/v4_to_v5.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import sys
+import json
+import argparse
+
+import anvio
+import anvio.workflows as w
+import anvio.terminal as terminal
+import anvio.filesnpaths as filesnpaths
+
+from anvio.errors import ConfigError
+
+current_version, next_version = [x[1:] for x in __name__.split('_to_')]
+
+run = terminal.Run()
+progress = terminal.Progress()
+
+def migrate(config_path):
+    if config_path is None:
+        raise ConfigError("No config path is given :/")
+
+    # do we have write access?
+    filesnpaths.is_output_file_writable(config_path)
+
+    # learn the workflow name and the version
+    workflow_name, version = w.get_workflow_name_and_version_from_config(config_path, dont_raise=True)
+
+    # is this the right version?
+    if version != current_version:
+        raise ConfigError(f"This config file is not v{current_version} (hence, this script cannot really do anything).")
+
+    progress.new("Migrating the config file")
+    progress.update("...")
+
+    # You must skip version check, otherwise anvi'o complains that the config is out of date. DUH,
+    # that's why we are migrating.
+    anvio.QUIET = True
+    args = argparse.Namespace(workflow=workflow_name, config_file=config_path, skip_version_check=True)
+    workflow_object = w.get_workflow_module_dict()[workflow_name](args)
+    config = workflow_object.config
+    anvio.QUIET = False
+
+    if 'gunzip_fasta' in config:
+        del config['gunzip_fasta']
+
+    # set it to the new version
+    config['config_version'] = next_version
+
+    with open(config_path, 'w') as output:
+        output.write(json.dumps(config, indent=4))
+
+    progress.end()
+    run.info_single(f"The config file version is now {next_version}. This upgrade removes the `gunzip_fasta` "
+                    f"rule from your config (if it was there). The contigs workflow no longer needs to decompress "
+                    f"gzipped FASTA files before processing them, since all downstream tools (anvi-script-reformat-fasta, "
+                    f"anvi-gen-contigs-database, bowtie2-build, minimap2) natively support gzipped input.",
+                    nl_after=1, nl_before=1, mc='green')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=f"The migration script to migrate an anvi'o workflow config from "
+            f"v{current_version} to v{next_version}")
+    parser.add_argument('config', metavar = 'CONFIG', help = 'A v{current_version} config JSON.')
+    parser.add_argument(*anvio.A("workflow"), **anvio.K("workflow"))
+    args, unknown = parser.parse_known_args()
+
+    try:
+        migrate(args.config)
+    except ConfigError as e:
+        print(e)
+        sys.exit(-1)

--- a/anvio/tests/run_workflow_tests_for_ecophylo.sh
+++ b/anvio/tests/run_workflow_tests_for_ecophylo.sh
@@ -82,7 +82,7 @@ anvi-run-workflow -w ecophylo -c default-config.json
 INFO "Running ecophylo workflow interactive (profile-mode)"
 HMM=`awk 'NR==2{print $2 "_" $1}' hmm_list.txt`
 echo $HMM
-anvi-interactive -c ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/03_CONTIGS/${HMM}-contigs.db \
+anvi-interactive -c ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/03_CONTIGS/${HMM}.db \
                  -p ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/06_MERGED/${HMM}/PROFILE.db \
                  $dry_run_controller
 
@@ -131,7 +131,7 @@ anvi-run-workflow -w ecophylo -c merge-by-group-config.json
 
 INFO "Running ecophylo workflow interactive (merge by group - profile mode)"
 GROUP=`awk 'NR==2{print $4}' hmm_list_group.txt`
-anvi-interactive -c ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/03_CONTIGS/${GROUP}-contigs.db \
+anvi-interactive -c ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/03_CONTIGS/${GROUP}.db \
                  -p ECOPHYLO_WORKFLOW/METAGENOMICS_WORKFLOW/06_MERGED/${GROUP}/PROFILE.db \
                  $dry_run_controller
 

--- a/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-idba_ud.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-idba_ud"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-megahit.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-megahit"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaflye.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaflye.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-metaflye"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-metaspades.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-metaspades"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-mixed-assembly.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-mixed-assembly.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-mixed-assembly"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-one-sample.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode-one-sample.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-references-mode-one-sample"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
+++ b/anvio/tests/sandbox/workflows/metagenomics/config-references-mode.json
@@ -273,9 +273,6 @@
     "anvi_get_sequences_for_gene_calls": {
         "threads": ""
     },
-    "gunzip_fasta": {
-        "threads": ""
-    },
     "reformat_external_gene_calls_table": {
         "threads": ""
     },
@@ -345,6 +342,6 @@
         "LOGS_DIR": "00_LOGS-references-mode"
     },
     "max_threads": "",
-    "config_version": "4",
+    "config_version": "5",
     "workflow_name": "metagenomics"
 }

--- a/anvio/tests/sandbox/workflows/pangenomics/config.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/config.json
@@ -25,7 +25,7 @@
         "PAN_DIR": "03_PAN",
         "LOGS_DIR": "00_LOGS"
     },
-    "config_version": "3",
+    "config_version": "5",
     "anvi_gen_contigs_database": {
         "--project-name": "{group}"
     },

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny-using-hmms.json
@@ -36,7 +36,7 @@
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
     },
-    "config_version": "3",
+    "config_version": "5",
     "anvi_gen_contigs_database": {
         "--project-name": "{group}"
     },

--- a/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
+++ b/anvio/tests/sandbox/workflows/pangenomics/pan-config-with-phylogeny.json
@@ -35,7 +35,7 @@
         "PAN_DIR": "03_PAN_FIVE_PAN",
         "LOGS_DIR": "00_LOGS_FIVE_PAN"
     },
-    "config_version": "3",
+    "config_version": "5",
     "anvi_gen_contigs_database": {
         "--project-name": "{group}"
     },

--- a/anvio/tests/sandbox/workflows/phylogenomics/config.json
+++ b/anvio/tests/sandbox/workflows/phylogenomics/config.json
@@ -31,7 +31,7 @@
         "PHYLO_DIR": "01_PHYLOGENOMICS",
         "LOGS_DIR": "00_LOGS"
     },
-    "config_version": "3",
+    "config_version": "5",
     "anvi_gen_contigs_database": {
         "--project-name": "{group}"
     },

--- a/anvio/version.py
+++ b/anvio/version.py
@@ -25,7 +25,7 @@ auxiliary_data_version = "2"
 structure_db_version = "2"
 genomes_storage_version = "7"
 trnaseq_db_version = "2"
-workflow_config_version = "4"
+workflow_config_version = "5"
 metabolic_modules_db_version = "4"
 
 versions_for_db_types = {'contigs': contigs_db_version,

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -47,17 +47,6 @@ rule annotate_contigs_database:
     output: touch(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done")
 
 
-rule gunzip_fasta:
-    version: 1.0
-    log: dirs_dict["LOGS_DIR"] + "/{group}-gunzip_fasta.log"
-    input: lambda wildcards: M.get_raw_fasta(wildcards, remove_gz_suffix=False)
-    output: temp(os.path.join(M.dirs_dict['FASTA_DIR'], \
-                            '{group}' + '-temp.fa'))
-    threads: M.T('gunzip_fasta')
-    resources: nodes = M.T('gunzip_fasta')
-    shell: "gunzip < {input} > {output} 2>{log}"
-
-
 rule anvi_script_reformat_fasta_prefix_only:
     '''
         Reformating the headers of the contigs fasta files.

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -180,7 +180,7 @@ rule anvi_gen_contigs_database:
     # filtered.
     input: unpack(M.get_input_for_anvi_gen_contigs_database)
     output:
-        db = os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-contigs.db")
+        db = os.path.join(dirs_dict["CONTIGS_DIR"], "{group}.db")
     params:
         description = M.get_rule_param("anvi_gen_contigs_database", "--description"),
         skip_gene_calling = M.get_rule_param("anvi_gen_contigs_database", "--skip-gene-calling"),
@@ -448,7 +448,7 @@ rule anvi_script_run_eggnog_mapper:
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_script_run_eggnog_mapper.log"
     input:
         eggnog_output = rules.emapper.output,
-        contigs = dirs_dict["CONTIGS_DIR"] + "/{group}-contigs.db"
+        contigs = dirs_dict["CONTIGS_DIR"] + "/{group}.db"
     output:
         touch(dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_script_run_eggnog_mapper.done")
     params:
@@ -471,7 +471,7 @@ rule gen_external_genome_file:
     log: dirs_dict["LOGS_DIR"] + "" + "/gen_external_genome_file.log"
     input:
         annotation_done = expand(dirs_dict['CONTIGS_DIR'] + "/{sample}-annotate_contigs_database.done", sample=M.group_names),
-        contigs_db_paths = expand(dirs_dict["CONTIGS_DIR"] + "/{sample}-contigs.db", sample=M.group_names)
+        contigs_db_paths = expand(dirs_dict["CONTIGS_DIR"] + "/{sample}.db", sample=M.group_names)
     output: M.external_genomes_file
     threads: M.T("gen_external_genome_file")
     resources: nodes = M.T("gen_external_genome_file")

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -71,7 +71,7 @@ rule anvi_script_reformat_fasta_prefix_only:
     version: 1.0
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_script_reformat_fasta_prefix_only.log"
     input:
-        contigs = M.get_raw_fasta
+        contigs = M.get_input_fasta_path
     output:
         # write protecting the contigs fasta file using protected() because
         # runnig the assembly is probably the most time consuming step and

--- a/anvio/workflows/contigs/Snakefile
+++ b/anvio/workflows/contigs/Snakefile
@@ -32,7 +32,7 @@ localrules: annotate_contigs_database
 
 
 rule contigs_target_rule:
-    input: expand(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done", group=M.group_names)
+    input: expand(os.path.join(dirs_dict['CONTIGS_DIR'], "{group}-steps", "annotate_contigs_database.done"), group=M.group_names)
 
 
 rule annotate_contigs_database:
@@ -44,7 +44,7 @@ rule annotate_contigs_database:
     version: 1.0
     log: dirs_dict["LOGS_DIR"] + "/{group}-annotate_contigs_database.log"
     input: lambda wildcards: M.get_contigs_target_files()
-    output: touch(dirs_dict['CONTIGS_DIR'] + "/{group}-annotate_contigs_database.done")
+    output: touch(os.path.join(dirs_dict['CONTIGS_DIR'], "{group}-steps", "annotate_contigs_database.done"))
 
 
 rule anvi_script_reformat_fasta_prefix_only:
@@ -246,7 +246,7 @@ rule import_external_functions:
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-import_external_functions.log")
     input: unpack(M.get_input_for_import_external_functions)
     output:
-        functions_imported = touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-external-functions-imported.done")),
+        functions_imported = touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "external_functions_imported.done")),
     threads: M.T('import_external_functions')
     resources: nodes = M.T('import_external_functions')
     shell: "anvi-import-functions -c {input.contigs} -i {input.gene_functional_annotation} >> {log} 2>&1"
@@ -296,7 +296,7 @@ rule anvi_import_taxonomy_for_genes:
     # using a flag file because no file is created by this rule.
     # for more information see:
     # http://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#flag-files
-    output: touch(dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_anvi_import_taxonomy_for_genes.done")
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_anvi_import_taxonomy_for_genes.done"))
     params: parser = "centrifuge"
     threads: M.T('anvi_import_taxonomy_for_genes')
     resources: nodes = M.T('anvi_import_taxonomy_for_genes'),
@@ -313,7 +313,7 @@ rule anvi_run_hmms:
     input: ancient(M.get_contigs_db_path())
     # using a snakemake flag file as an output since no file is generated
     # by the rule.
-    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done")
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_hmms.done"))
     params:
         installed_hmm_profile = M.get_rule_param("anvi_run_hmms", "--installed-hmm-profile"),
         hmm_profile_dir = M.get_rule_param("anvi_run_hmms", "--hmm-profile-dir"),
@@ -335,7 +335,7 @@ rule anvi_run_pfams:
     version: 1.0
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-anvi_run_pfams.log")
     input: ancient(M.get_contigs_db_path())
-    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "anvi_run_pfams-{group}.done"))
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_pfams.done"))
     params:
         pfam_data_dir = M.get_rule_param('anvi_run_pfams', '--pfam-data-dir')
     threads: M.T('anvi_run_pfams')
@@ -347,7 +347,7 @@ rule anvi_run_kegg_kofams:
     version: 1.0
     log: os.path.join(dirs_dict["LOGS_DIR"], "{group}-anvi_run_kegg_kofams.log")
     input: ancient(M.get_contigs_db_path())
-    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "anvi_run_kegg_kofams-{group}.done"))
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_kegg_kofams.done"))
     params:
         kegg_data_dir = M.get_rule_param('anvi_run_kegg_kofams', '--kegg-data-dir'),
         hmmer_program = M.get_rule_param('anvi_run_kegg_kofams', '--hmmer-program'),
@@ -364,7 +364,7 @@ rule anvi_run_ncbi_cogs:
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_ncbi_cogs.log"
     input:
         contigs = ancient(M.get_contigs_db_path())
-    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_ncbi_cogs-{group}.done")
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_ncbi_cogs.done"))
     params:
         # anvi-run-ncbi-cogs params. See anvi-run-ncbi-cogs help menu for more info.
         cog_data_dir = M.get_rule_param('anvi_run_ncbi_cogs', '--cog-data-dir'),
@@ -384,9 +384,9 @@ rule anvi_run_scg_taxonomy:
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_scg_taxonomy.log"
     input:
         # make sure HMMs were done before running this rule
-        hmms_done = ancient(dirs_dict["CONTIGS_DIR"] + "/anvi_run_hmms-{group}.done"),
+        hmms_done = ancient(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_hmms.done")),
         contigs = ancient(M.get_contigs_db_path())
-    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_scg_taxonomy-{group}.done")
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_scg_taxonomy.done"))
     params:
         scg_taxonomy_data_dir = M.get_rule_param('anvi_run_scg_taxonomy', '--scgs-taxonomy-data-dir'),
     threads: M.T('anvi_run_scg_taxonomy')
@@ -401,7 +401,7 @@ rule anvi_run_trna_scan:
     log: dirs_dict["LOGS_DIR"] + "/{group}-anvi_run_trna_scan.log"
     input:
         contigs = ancient(M.get_contigs_db_path())
-    output: touch(dirs_dict["CONTIGS_DIR"] + "/anvi_run_trna_scan-{group}.done")
+    output: touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_trna_scan.done"))
     params:
         # FIXME not sure how to handle optional --trna-hits-file parameter
         #trna_scan_hits_file = M.get_rule_param('anvi_run_trna_scan', '--trna-hits-file'),
@@ -450,7 +450,7 @@ rule anvi_script_run_eggnog_mapper:
         eggnog_output = rules.emapper.output,
         contigs = dirs_dict["CONTIGS_DIR"] + "/{group}.db"
     output:
-        touch(dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_script_run_eggnog_mapper.done")
+        touch(os.path.join(dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_script_run_eggnog_mapper.done"))
     params:
         use_version = M.get_rule_param("anvi_script_run_eggnog_mapper", "--use-version")
     threads: M.T('anvi_script_run_eggnog_mapper')
@@ -470,7 +470,7 @@ rule gen_external_genome_file:
     version: 1.0
     log: dirs_dict["LOGS_DIR"] + "" + "/gen_external_genome_file.log"
     input:
-        annotation_done = expand(dirs_dict['CONTIGS_DIR'] + "/{sample}-annotate_contigs_database.done", sample=M.group_names),
+        annotation_done = expand(os.path.join(dirs_dict['CONTIGS_DIR'], "{sample}-steps", "annotate_contigs_database.done"), sample=M.group_names),
         contigs_db_paths = expand(dirs_dict["CONTIGS_DIR"] + "/{sample}.db", sample=M.group_names)
     output: M.external_genomes_file
     threads: M.T("gen_external_genome_file")

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -142,18 +142,18 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                   "config file. See documentation for more details.")
 
         if run_taxonomy_with_centrifuge:
-            optional_targets.append(self.dirs_dict["CONTIGS_DIR"] + "/{group}-anvi_anvi_import_taxonomy_for_genes.done")
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_anvi_import_taxonomy_for_genes.done"))
 
         run_anvi_run_hmms = self.get_param_value_from_config(["anvi_run_hmms", "run"]) == True
         if run_anvi_run_hmms:
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_hmms-{group}.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_hmms.done"))
 
         if self.get_param_value_from_config(["anvi_run_ncbi_cogs", "run"]) == True:
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_ncbi_cogs-{group}.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_ncbi_cogs.done"))
 
         run_anvi_run_kofams = self.get_param_value_from_config(["anvi_run_kegg_kofams", "run"]) == True
         if run_anvi_run_kofams:
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_kegg_kofams-{group}.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_kegg_kofams.done"))
 
         run_anvi_run_scg_taxonomy = self.get_param_value_from_config(["anvi_run_scg_taxonomy", "run"]) == True
         if run_anvi_run_scg_taxonomy:
@@ -161,25 +161,25 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                 self.run.warning('You chose to run anvi_run_scg_taxonomy, but you didn\'t choose to run '
                                  'anvi_run_hmms. Continue at your own risk. If your contigs databases '
                                  'don\'t have HMM hits stored already then anvi_run_scg_taxonomy will fail.')
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_scg_taxonomy-{group}.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_scg_taxonomy.done"))
 
         run_anvi_run_trna_scan = self.get_param_value_from_config(["anvi_run_trna_scan", "run"]) == True
         if run_anvi_run_trna_scan:
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_trna_scan-{group}.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_trna_scan.done"))
 
         if self.get_param_value_from_config(["anvi_script_run_eggnog_mapper", "run"]) == True:
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-anvi_script_run_eggnog_mapper.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_script_run_eggnog_mapper.done"))
 
         # import external functions if provided
         import_external_functions_flags = [os.path.join(self.dirs_dict["CONTIGS_DIR"],
-                                           group + "-external-functions-imported.done")\
+                                           group + "-steps", "external_functions_imported.done")\
                                            for group in self.contigs_information \
                                            if self.contigs_information[group].get('gene_functional_annotation')]
         if import_external_functions_flags:
             optional_targets.extend(import_external_functions_flags)
 
         if self.get_param_value_from_config(['anvi_run_pfams', 'run']):
-            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "anvi_run_pfams-{group}.done"))
+            optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_pfams.done"))
 
         return optional_targets
 

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -43,7 +43,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                            'anvi_gen_contigs_database', 'export_gene_calls_for_centrifuge', 'centrifuge',
                            'anvi_import_taxonomy_for_genes', 'anvi_run_scg_taxonomy', 'anvi_run_trna_scan', 'anvi_run_hmms', 'anvi_run_ncbi_cogs',
                            'annotate_contigs_database', 'anvi_get_sequences_for_gene_calls', 'emapper',
-                           'anvi_script_run_eggnog_mapper', 'gunzip_fasta', 'reformat_external_gene_calls_table',
+                           'anvi_script_run_eggnog_mapper', 'reformat_external_gene_calls_table',
                            'reformat_external_functions', 'import_external_functions', 'anvi_run_pfams', 'anvi_run_kegg_kofams'])
 
         self.general_params.extend(["fasta_txt"])
@@ -204,16 +204,16 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
     def get_raw_fasta(self, wildcards, remove_gz_suffix=True):
         '''
-            Define the path to the input fasta files.
+            Define the path to the input fasta files. Gzipped FASTA files are
+            returned as-is since all downstream tools (anvi-script-reformat-fasta,
+            anvi-gen-contigs-database, bowtie2-build, minimap2) natively support
+            gzipped input via fastalib.SequenceSource.
+
+            The `remove_gz_suffix` parameter is kept for API compatibility with
+            code that overrides this method (e.g., MetagenomicsWorkflow) but is
+            no longer acted upon.
         '''
-        contigs = self.fasta_information[wildcards.group]['path']
-        ends_with_gz = contigs.endswith('.gz')
-        if remove_gz_suffix and ends_with_gz:
-            # we need to gunzip the fasta file
-            # we will create a temporary uncompressed fasta file.
-            contigs = os.path.join(self.dirs_dict['FASTA_DIR'], \
-                                   wildcards.group + '-temp.fa')
-        return contigs
+        return self.fasta_information[wildcards.group]['path']
 
 
     def get_input_for_anvi_gen_contigs_database(self, wildcards):

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -199,7 +199,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
 
     def get_contigs_db_path(self):
-        return os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-contigs.db")
+        return os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}.db")
 
 
     def get_input_fasta_path(self, wildcards, remove_gz_suffix=True):
@@ -234,7 +234,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
     def get_input_for_import_external_functions(self, wildcards):
         d = {}
         d['gene_functional_annotation'] = self.get_external_gene_functions_file_name(wildcards)
-        d['contigs'] = os.path.join(self.dirs_dict["CONTIGS_DIR"], wildcards.group + "-contigs.db")
+        d['contigs'] = os.path.join(self.dirs_dict["CONTIGS_DIR"], wildcards.group + ".db")
         return d
 
 

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -202,17 +202,8 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         return os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-contigs.db")
 
 
-    def get_raw_fasta(self, wildcards, remove_gz_suffix=True):
-        '''
-            Define the path to the input fasta files. Gzipped FASTA files are
-            returned as-is since all downstream tools (anvi-script-reformat-fasta,
-            anvi-gen-contigs-database, bowtie2-build, minimap2) natively support
-            gzipped input via fastalib.SequenceSource.
-
-            The `remove_gz_suffix` parameter is kept for API compatibility with
-            code that overrides this method (e.g., MetagenomicsWorkflow) but is
-            no longer acted upon.
-        '''
+    def get_input_fasta_path(self, wildcards, remove_gz_suffix=True):
+        '''Returns the user-provided input FASTA path for a given group.'''
         return self.fasta_information[wildcards.group]['path']
 
 
@@ -293,7 +284,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
             Define the path to the input fasta files.
         '''
         # The raw fasta will be used if no formatting is needed
-        contigs = self.get_raw_fasta(wildcards)
+        contigs = self.get_input_fasta_path(wildcards)
 
         if self.get_param_value_from_config(['anvi_script_reformat_fasta','run']):
             # by default, reformat fasta is ran

--- a/anvio/workflows/ecophylo/rules/profile_mode.smk
+++ b/anvio/workflows/ecophylo/rules/profile_mode.smk
@@ -107,7 +107,7 @@ rule anvi_summarize:
     input:
         done = rules.add_default_collection.output.done
     params:
-        contigsDB = ancient(os.path.join(dirs_dict['HOME'], "METAGENOMICS_WORKFLOW", "03_CONTIGS", "{group}-contigs.db")),
+        contigsDB = ancient(os.path.join(dirs_dict['HOME'], "METAGENOMICS_WORKFLOW", "03_CONTIGS", "{group}.db")),
         profileDB = os.path.join(dirs_dict['HOME'], "METAGENOMICS_WORKFLOW", "06_MERGED", "{group}", "PROFILE.db"),
         output_dir = os.path.join(dirs_dict['HOME'], "METAGENOMICS_WORKFLOW", "07_SUMMARY", "{group}")
     output: touch(os.path.join(dirs_dict['HOME'], "METAGENOMICS_WORKFLOW", "07_SUMMARY", "{group}_summarize.done"))

--- a/anvio/workflows/metagenomics/Snakefile
+++ b/anvio/workflows/metagenomics/Snakefile
@@ -1001,7 +1001,7 @@ def configure_flag_files_for_anvi_merge_optional_inputs(wildcards, flag_file_nam
 
     if not run_flag:
         # keep legacy 'ancient' fallback (single path) so Snakemake doesn’t require flags
-        flag_files = ancient(dirs_dict["CONTIGS_DIR"] + f"/{wildcards.group}-contigs.db")
+        flag_files = ancient(dirs_dict["CONTIGS_DIR"] + f"/{wildcards.group}.db")
 
     return flag_files
 

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -293,7 +293,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
 
 
         contigs_annotated = [os.path.join(self.dirs_dict["CONTIGS_DIR"],\
-                             g + "-annotate_contigs_database.done") for g in self.group_names]
+                             g + "-steps", "annotate_contigs_database.done") for g in self.group_names]
         target_files.extend(contigs_annotated)
 
         if self.run_qc:

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -760,29 +760,21 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         if wildcards.group in self.references_for_removal:
             # if it's a reference for removal then we just want to use the
             # raw fasta file, and there is no need to reformat or assemble
-            contigs = self.get_raw_fasta(wildcards)
+            contigs = self.get_input_fasta_path(wildcards)
         elif self.get_param_value_from_config(['anvi_script_reformat_fasta','run']):
             contigs = self.dirs_dict["FASTA_DIR"] + "/{group}/{group}-contigs.fa".format(group=wildcards.group)
         else:
-            contigs = self.get_raw_fasta(wildcards)
+            contigs = self.get_input_fasta_path(wildcards)
         return contigs
 
 
-    def get_raw_fasta(self, wildcards, remove_gz_suffix=True):
-        """
-        Path to the input FASTA for reformat_fasta.
-
-        Priority:
-          1) If a precomputed raw FASTA exists (written by SR/LR assembler wrappers):
-             {FASTA_DIR}/{group}.raw.fa  -> use it.
-          2) References mode (or references slated for removal): delegate to base logic
-             that reads from self.fasta_information[...] (handles .gz via remove_gz_suffix).
-          3) Assembly mode (SR legacy path): use assembler output at
-             {FASTA_DIR}/{group}/final.contigs.fa
-        """
+    def get_input_fasta_path(self, wildcards, remove_gz_suffix=True):
+        '''Returns the input FASTA path for a given group. In references mode or
+        when removing references, delegates to the base class. In assembly mode,
+        returns the assembler output path.'''
         # References-mode / reference-removal path (uses fasta_information)
         if self.references_mode or wildcards.group in self.references_for_removal:
-            return super(MetagenomicsWorkflow, self).get_raw_fasta(
+            return super(MetagenomicsWorkflow, self).get_input_fasta_path(
                 wildcards, remove_gz_suffix=remove_gz_suffix)
 
         # Assembly-mode : assembler's canonical output location


### PR DESCRIPTION
This PR revamps the anvi'o snakemake workflow for contigs (the workflow that generates anvi'o contigs-db files from input FASTA files at scale).

This PR does two critical things:

1. It removes unnecessary decompression of FASTA files
2. Removes -contigs.db postfix from contigs-db files, and moves .done files into a separate directory to remove the clutter from `02_CONTIGS` directory in the default workflow output

Quick notes on the implications of these changes:

* The first change requires a version bump for the config.json files, and **the PR includes a migration script for `anvi-migrate`. So no problem there**.
* The second change, however, creates a **backwards compatibility issue** since the new directory structure and file naming patterns will make older directories look incomplete as far as snakemake workflows are concerned. This is not something we can fix with anvi'o code, but we can with a one-time additional migration script outside of anvi'o.  **The PR includes a Python script below that will make the existing `02_CONTIGS` directories compatible with the code. Please see the Migration section at the end of this document for this**.

The details for each item is below.

## Remove unnecessary gunzip step from contigs workflow for gzipped FASTA input

The purpose of this change is to take advantage of 97aec3ac266748253c1a6e54936c4d56267bce63, which made anvi'o great again with compressed FASTA files, and make sure our snakemake workflows are not trying to decompress FASTA files first.

Indeed, the contigs workflow has been decompressing gzipped FASTA files into temporary uncompressed files before passing them to downstream tools, even though those tools already support gzipped input natively.

Prior to this PR, when a .gz FASTA file was provided in a `fasta-txt` file, `get_raw_fasta()` in the contigs workflow redirected to a temp .fa path, which triggered the Snakemake rule called `gunzip_fasta`, through which every gzipped FASTA had to be fully decompressed to disk before any processing could begin. 

This effectively influenced two parts of the code:

  - When `anvi_script_reformat_fasta` was enabled the .gz file was unzipped before being passed to `anvi-script-reformat-fasta`
  - When `anvi_script_reformat_fasta` was disabled the .gz file was unzipped before being passed to `anvi-gen-contigs-database`

This PR changes that wrong attitude and,

  - Simplifies get_raw_fasta() and renames it to `get_input_fasta_path()` (since this is what it does now). The `remove_gz_suffix` parameter is still in there for API compatibility with `MetagenomicsWorkflow`, which overrides and calls this method, but the parameter has no impact anymore.
  - Removes the `gunzip_fasta` rule from `anvio/workflows/contigs/Snakefile `and from the rules list in `__init__.py`.
  - Bumps `workflow_config_version `from 4 to 5 in `anvio/version.py`, since existing config files with a `gunzip_fasta` section would otherwise fail validation.
  - Ads `anvio/migrations/config/v4_to_v5.py` to automatically remove the `gunzip_fasta` key from old config files when users run `anvi-migrate`.
  - Updates all test workflow config files so they have the right rule set and versoin numbers.

## Remove `-contigs` addition to contigs-db files

I always thought -contigs.db was an unnecessary addition to our contigs-db files in anvi'o workflows. They later propagate names we have to manually correct in pangenomes and everywhere else.

This PR includes changes with c1ae56885f10b7548895ee037f959ead6755f630 that remove `-contigs.db` postfix from contigs-db files. The biggest implications of this change is that the exiting workflow output directories will be incompatible with the new code if/once this PR is merged to `master` since snakemake will not be able to find the existing contigs-db as the code will no longer be looking for SAMPLE-contigs.db, but for SAMPLE.db.

**The migration script will take care of this.**

## Move `.done` files into a separate directory

Anvi'o snakemake workflows generate all these files to mark that certain steps are done:

```
  02_CONTIGS/
  ├── anvi_run_hmms-apple.done
  ├── anvi_run_hmms-banana.done
  ├── anvi_run_hmms-orange.done
  ├── anvi_run_kegg_kofams-apple.done
  ├── anvi_run_kegg_kofams-banana.done
  ├── anvi_run_kegg_kofams-orange.done
  ├── anvi_run_ncbi_cogs-apple.done
  ├── anvi_run_ncbi_cogs-banana.done
  ├── anvi_run_ncbi_cogs-orange.done
  ├── anvi_run_scg_taxonomy-apple.done
  ├── anvi_run_scg_taxonomy-banana.done
  ├── anvi_run_scg_taxonomy-orange.done
  ├── apple-annotate_contigs_database.done
  ├── apple-contigs.db
  ├── banana-annotate_contigs_database.done
  ├── banana-contigs.db
  ├── orange-annotate_contigs_database.done
  └── orange-contigs.db
```

Which is really annoying since the clutter is real.

The PR introduces changes to the code with fea805937d1573d9a61bdbfd325b2d7ce52d659e that results in a directory structure like this:

```
  02_CONTIGS/
  ├── apple.db
  ├── apple-steps
  │   ├── anvi_run_hmms.done
  │   ├── anvi_run_kegg_kofams.done
  │   ├── anvi_run_ncbi_cogs.done
  │   ├── anvi_run_scg_taxonomy.done
  │   └── annotate_contigs_database.done
  ├── banana.db
  ├── banana-steps
  │   ├── anvi_run_hmms.done
  │   ├── anvi_run_kegg_kofams.done
  │   ├── anvi_run_ncbi_cogs.done
  │   ├── anvi_run_scg_taxonomy.done
  │   └── annotate_contigs_database.done
  ├── orange.db
  └── orange-steps
      ├── anvi_run_hmms.done
      ├── anvi_run_kegg_kofams.done
      ├── anvi_run_ncbi_cogs.done
      ├── anvi_run_scg_taxonomy.done
      └── annotate_contigs_database.done
```

**The migration script will take care of this.**

## Migration

Here is a script written in Python that will make existing `02_CONTIGS` directories compatible with the new code so the anvi'o snakemake workflow for contigs will still recognize them as 'done':

*  [migrate_contigs_workflow_dir.py](https://github.com/user-attachments/files/25865635/migrate_contigs_workflow_dir.py)

After downloading this script, you can run it the following way:

```
python migrate_contigs_workflow_dir.py /PATH/TO/02_CONTIG
```

It will perform a dry run, and if everything looks OK, will do the moving of files.

---

Here is an older directory that looked like this:

```
tree 02_CONTIGS/
02_CONTIGS/
├── anvi_run_hmms-test.done
├── anvi_run_kegg_kofams-test.done
├── anvi_run_ncbi_cogs-test.done
├── anvi_run_scg_taxonomy-test.done
├── test-annotate_contigs_database.done
└── test-contigs.db
```

On which I run the migration script:

```
python migrate_contigs_workflow_dir.py 02_CONTIG
```

And this is how it looked after:

```
02_CONTIGS/
├── test-steps
│   ├── annotate_contigs_database.done
│   ├── anvi_run_hmms.done
│   ├── anvi_run_kegg_kofams.done
│   ├── anvi_run_ncbi_cogs.done
│   └── anvi_run_scg_taxonomy.done
└── test.db
```

Then, when I ran `anvi-run-workflow` again on this directory, it was able to recognize that everything is already in place:

```
anvi-run-workflow -w contigs -c test.json

(...)

Building DAG of jobs...
Nothing to be done (all requested files are present and up to date).
```

---

I think this is good to go, but who can ever know what the future holds eh?