### PR TITLE
new display subsection in main tab

### DIFF
--- a/anvio/data/interactive/images/display-chart.svg
+++ b/anvio/data/interactive/images/display-chart.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="40"
+   height="40"
+   viewBox="0 0 128 128"
+   fill="none"
+   version="1.1"
+   id="svg13"
+   sodipodi:docname="display-chart.svg"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#cccccc"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.4217391"
+     inkscape:cx="20.067114"
+     inkscape:cy="20.067114"
+     inkscape:window-width="1083"
+     inkscape:window-height="795"
+     inkscape:window-x="0"
+     inkscape:window-y="33"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg13" />
+  <path
+     d="M60.1497 30.8697V30.7033L59.9842 30.7205C52.6875 31.4791 45.755 34.2897 39.9901 38.8266C34.2252 43.3635 29.8637 49.4409 27.411 56.3548C24.9584 63.2687 24.5149 70.736 26.1319 77.8916C27.7489 85.0472 31.3604 91.5982 36.5477 96.7856C41.7351 101.973 48.2861 105.584 55.4417 107.201C62.5973 108.818 70.0646 108.375 76.9785 105.922C83.8924 103.47 89.9699 99.1081 94.5067 93.3432C99.0436 87.5783 101.854 80.6459 102.613 73.3492L102.63 73.1837H102.464H63.9997C62.9786 73.1837 61.9993 72.778 61.2773 72.056C60.5553 71.334 60.1497 70.3547 60.1497 69.3337V30.8697ZM67.8497 65.3337V65.4837H67.9997H106.666C107.687 65.4837 108.667 65.8893 109.389 66.6113C110.111 67.3333 110.516 68.3126 110.516 69.3337C110.516 81.6706 105.616 93.5023 96.8919 102.226C88.1684 110.949 76.3367 115.85 63.9997 115.85C51.6627 115.85 39.831 110.949 31.1074 102.226C22.3839 93.5023 17.483 81.6706 17.483 69.3337C17.483 56.9967 22.3839 45.165 31.1074 36.4414C39.831 27.7178 51.6627 22.817 63.9997 22.817C65.0208 22.817 66 23.2226 66.722 23.9446C67.444 24.6666 67.8497 25.6459 67.8497 26.667V65.3337Z"
+     fill="url(#paint0_linear_563_4114)"
+     id="path1"
+     style="fill:#848d9c;fill-opacity:1" />
+  <path
+     d="M72.9387 60.3942V36.0498H81.7276V60.3942H72.9387ZM72.9387 33.7276V24.9387H81.7276V33.7276H72.9387ZM86.272 60.3942V42.7164H95.0609V60.3942H86.272ZM86.272 31.6053H95.0609V40.3942H86.272V31.6053ZM99.6053 60.3942V49.3831H108.394V60.3942H99.6053ZM99.6053 38.272H108.394V47.0609H99.6053V38.272Z"
+     stroke="#848D9C"
+     stroke-width="0.1"
+     style="mix-blend-mode:plus-lighter;fill:#848d9c;fill-opacity:1;stroke:none"
+     id="path4" />
+  <defs
+     id="defs13">
+    <linearGradient
+       id="paint0_linear_563_4114"
+       x1="29"
+       y1="42.5"
+       x2="99"
+       y2="107.5"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0.0115155"
+         stop-color="#E06666"
+         id="stop4" />
+      <stop
+         offset="0.20531"
+         stop-color="#F6B26B"
+         id="stop5" />
+      <stop
+         offset="0.469956"
+         stop-color="#FFD966"
+         id="stop6" />
+      <stop
+         offset="0.744566"
+         stop-color="#93C47D"
+         id="stop7" />
+      <stop
+         offset="0.916144"
+         stop-color="#76A5AF"
+         id="stop8" />
+    </linearGradient>
+    <linearGradient
+       id="paint1_linear_563_4114"
+       x1="72.5"
+       y1="24.5"
+       x2="107.5"
+       y2="60"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#E06666"
+         id="stop9" />
+      <stop
+         offset="0.244792"
+         stop-color="#F6B26B"
+         id="stop10" />
+      <stop
+         offset="0.5"
+         stop-color="#FFD966"
+         id="stop11" />
+      <stop
+         offset="0.776042"
+         stop-color="#93C47D"
+         id="stop12" />
+      <stop
+         offset="1"
+         stop-color="#76A5AF"
+         id="stop13" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/anvio/data/interactive/index.html
+++ b/anvio/data/interactive/index.html
@@ -198,22 +198,50 @@
                 <div class="col-11 tab-content ml-1">
                     <div role="tabpanel" class="tab-pane fade show active" id="tree_settings">
                         <div id="tree-settings" class="form-horizontal">
-                            <span id="toggle-chevron-item" class="settings-header btn d-flex chart-icon-padding align-items-center" data-toggle="collapse" href="#item-collapse-main" role="button" aria-expanded="true" aria-controls="item-collapse-option" onclick="$('#toggle-chevron-item').children('i').toggleClass('bi-chevron-up bi-chevron-down');">
+                            <span id="toggle-chevron-display" class="settings-header btn d-flex chart-icon-padding align-items-center" data-toggle="collapse" href="#display-collapse-main" role="button" aria-expanded="true" aria-controls="display-collapse-main" onclick="$('#toggle-chevron-display').children('i').toggleClass('bi-chevron-up bi-chevron-down');">
+                                <img src="images/display-chart.svg" alt="Display Icon"/>
+                                Display
+                                <i class="text-secondary ml-1 d-flex pt-1 align-items-center bi bi-chevron-down"></i>
+                            </span>
+                            <div class="collapse multi-collapse show" id="display-collapse-main">
+                                <div class="ml-2" id="display-settings">
+                                    <div class="form-group form-margin">
+                                        <label class="settings-label" for="tree_type" data-help="drawing-type">Drawing Type</label>
+                                        <div class="col-10 menu-padding">
+                                            <select id="tree_type" class="form-control">
+                                                <option value="phylogram">Phylogram</option>
+                                                <option value="circlephylogram" selected>Circle Phylogram</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div id="tree_type_circlephylogram">
+                                        <div class="d-flex align-items-center mt-2 mb-2">
+                                            <span class="mr-2" data-help="draw-angle">Angle:</span>
+                                            <input type="text" value="0" size="3" id="angle-min" class="form-control input-xs mr-1" style="width: 50px;">
+                                            <span class="mr-1">to</span>
+                                            <input type="text" value="270" size="3" id="angle-max" class="form-control input-xs mr-3" style="width: 50px;">
+                                            <span class="mr-2" data-help="tree-radius">Radius:</span>
+                                            <input type="text" value="0" size="3" id="tree-radius" class="form-control input-xs" style="width: 50px;">
+                                        </div>
+                                    </div>
+                                    <div id="tree_type_phylogram" style="display: none;">
+                                        <div class="d-flex align-items-center mt-2 mb-2">
+                                            <span class="mr-2" data-help="tree-height">Height:</span>
+                                            <input type="text" value="0" size="3" id="tree_height" class="form-control input-xs mr-3" style="width: 50px;">
+                                            <span class="mr-2" data-help="tree-width">Width:</span>
+                                            <input type="text" value="0" size="3" id="tree_width" class="form-control input-xs" style="width: 50px;">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <span id="toggle-chevron-item" class="settings-header btn d-flex chart-icon-padding mt-5 align-items-center" data-toggle="collapse" href="#item-collapse-main" role="button" aria-expanded="true" aria-controls="item-collapse-option" onclick="$('#toggle-chevron-item').children('i').toggleClass('bi-chevron-up bi-chevron-down');">
                                 <img src="images/item-chart.svg" alt="Item Icon"/>
                                 Items
                                 <i class="text-secondary ml-1 d-flex pt-1 align-items-center bi bi-chevron-down"></i>
                             </span>
                             <div class="collapse multi-collapse show" id="item-collapse-main">
                                     <div class="ml-2" id="items-data-section">
-                                        <div class="form-group form-margin">
-                                                <label class="settings-label" for="tree_type" data-help="drawing-type">Drawing Type</label>
-                                                <div class="col-10 menu-padding">
-                                                    <select id="tree_type" class="form-control">
-                                                        <option value="phylogram">Phylogram</option>
-                                                        <option value="circlephylogram" selected>Circle Phylogram</option>
-                                                    </select>
-                                                </div>
-                                        </div>
                                         <div class="form-group form-margin">
                                                 <label class="settings-label" for="trees_container" data-help="order-by">Order</label>
                                                 <div class="col-10 menu-padding">
@@ -571,36 +599,7 @@
                             </div>
                             <div class="ml-3">
                                 <span class="settings-secondary-header">Dendrogram</span>
-                                <div id="tree_type_circlephylogram">
-                                    <div class="form-group form-margin circlephylogram_settings d-flex mt-3 align-items-center">
-                                            <label class="col-2 settings-label" for="angle-min" data-help="draw-angle">Angle:</label>
-                                            <div class="col-6 form-inline input-align">
-                                                <input type="text" value="0" size="4" id="angle-min" class="form-control input-xs col-3"> <span class="ml-1">to</span>
-                                                <input type="text" value="270" size="4" id="angle-max" class="form-control input-xs col-3">
-                                            </div>
-                                    </div>
-                                    <div class="form-group form-margin circlephylogram_settings d-flex align-items-center">
-                                            <label class="col-2 settings-label" for="tree-radius" data-help='tree-radius'>Radius:</label>
-                                            <div class="col-6 d-flex input-align">
-                                                <input type="text" value="0" size="4" id="tree-radius" class="form-control input-xs col-3">
-                                            </div>
-                                    </div>
-                                </div>
-                                <div id="tree_type_phylogram">
-                                    <div class="form-group form-margin phylogram_settings d-flex align-items-center" style="display: none;">
-                                            <label class="col-2 settings-label" for="tree_height" data-help="tree-height">Height:</label>
-                                            <div class="col-6 d-flex input-align">
-                                                <input type="text" value="0" size="4" id="tree_height" class="form-control input-xs col-3">
-                                            </div>
-                                    </div>
-                                    <div class="form-group form-margin phylogram_settings d-flex align-items-center" style="display: none;">
-                                            <label class="col-2 settings-label" for="tree_width" data-help="tree-width">Width:</label>
-                                            <div class="col-6 d-flex input-align">
-                                                <input type="text" value="0" size="4" id="tree_width" class="form-control input-xs col-3">
-                                            </div>
-                                    </div>
-                                </div>
-                                <div class="form-group form-margin d-flex align-items-center">
+                                <div class="form-group form-margin d-flex mt-3 align-items-center">
                                         <label class="col-3 settings-label" for="edge_length_normalization" data-help="edge-length-norm">Edge length norm.:</label>
                                         <div class="col-2 d-flex">
                                             <input type="checkbox" id="edge_length_normalization" name="checkbox" value="value">

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -2273,6 +2273,16 @@ function drawTree() {
                     $('#tree-radius').val(Math.max(VIEWER_HEIGHT, VIEWER_WIDTH));
                 }
 
+                if (settings['tree-height'] == 0)
+                {
+                    $('#tree_height').val(VIEWER_HEIGHT);
+                }
+
+                if (settings['tree-width'] == 0)
+                {
+                    $('#tree_width').val(VIEWER_WIDTH);
+                }
+
                 a_display_is_drawn = true;
 
                 waitingDialog.hide();


### PR DESCRIPTION
Been changing a couple of things in the interface lately and I though this one deserve a PR and maybe a discussion.
It bothered me for a while that the display type was in the 'Items' subsection of the Main tab. Does not make a lot of sense. 
Also, we often need/want to change basic settings for the display like the radius/angle of the circle phylogram, and the height/width of the phylogram, but they are buried in the options tab.

In this PR, I created a new subsection of the Main tab, called "Display":

<img width="558" height="350" alt="image" src="https://github.com/user-attachments/assets/52131212-ef85-4565-a772-fc65acbe2b81" />

I left the option for edge normalisation in the options tab as it is more more advanced tunning.

Note: it now automatically displays the values used by default. What I mean is that when switching to phylogram, the height and width was always '0' in the settings, making it unnecessarily difficult to guess what value would give you. NOT ANYMORE.

I also don't find that section particularly beautiful and I am also questioning if it should be close by default, so if anyone reads this PR, let me know how you feel and I'll see what I (lol, more likely Claude) can do.