### PR TITLE
Update GHA "uses" dependencies

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -14,8 +14,8 @@ jobs:
         python-version: ["3.10"]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@v6
+    - uses: conda-incubator/setup-miniconda@v4
       with:
         miniconda-version: 'latest'
         auto-update-conda: true
@@ -31,7 +31,7 @@ jobs:
       run: |
         conda info
         conda list
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: "Install anvi'o from the codebase"
       shell: bash -l {0}
       run: |
@@ -41,7 +41,7 @@ jobs:
       run: |
         interactive_dir=$(python -c "import site; print(site.getsitepackages()[0] + '/anvio/data/interactive')")
         echo "interactive_dir_path=$interactive_dir" >> $GITHUB_ENV
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 18
     - name: "Install npm dependencies for Anvi'o interactive interfaces"


### PR DESCRIPTION
* actions/checkout from v4 to v6
* conda-incubator/setup-miniconda from v3 to v4
* actions/setup-node from v4 to v6