### PR TITLE
Remove duplicate checkout step

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -31,7 +31,6 @@ jobs:
       run: |
         conda info
         conda list
-    - uses: actions/checkout@v6
     - name: "Install anvi'o from the codebase"
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
This was handled in dcd3111f4032dbdb1e1403b2405583a7cdc01273 and reverted in 5dc7d699b10b0f0671584d474cb2d023b85b7cd4. I believe the problem called for the revert was irrelevant to the checkout step but it got reverted because the changes were not separated into multiple commits.