### PR TITLE
Add missing ruff hook and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.10
+    hooks:
+      - id: ruff-check
+        args: ["--fix"]
+
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.1
     hooks:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+[lint]
+# https://docs.astral.sh/ruff/rules/
+select = [
+    # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/
+    "UP009",
+]


### PR DESCRIPTION
Enables UP009 as it doesn't affect the ownership info for the remaining files.

https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/

The goal is to introduce a modern lint setup.

Relates to:
- #2574
- https://github.com/merenlab/anvio/pull/2574#issuecomment-4319584431