### PR TITLE
Apply "unsafe" W291 fixes

### DIFF
--- a/anvio/data/misc/MODELLER/scripts/binarize_database.py
+++ b/anvio/data/misc/MODELLER/scripts/binarize_database.py
@@ -1,6 +1,6 @@
 """
 Positional arguments:
-1. INPUT - PIR database 
+1. INPUT - PIR database
 2. OUTPUT - BINARY database
 """
 import sys

--- a/anvio/drivers/MODELLER.py
+++ b/anvio/drivers/MODELLER.py
@@ -845,7 +845,7 @@ def check_MODELLER(executable=None):
 
     Checks the executable exists, that a license exists, and can produce the expected output of a
     modeller executable. Exists outside of the class MODELLER so it does not have to be checked
-    everytime the class is initialized. 
+    everytime the class is initialized.
 
     Parameters
     ==========

--- a/anvio/drivers/muscle.py
+++ b/anvio/drivers/muscle.py
@@ -50,7 +50,7 @@ class Muscle:
         PARAMETERS
         ==========
         sequences_list : List of tuples
-            each tuple should contain the sequence name as the first element, and the sequence itself 
+            each tuple should contain the sequence name as the first element, and the sequence itself
             as the second element
         debug : Boolean
             controls whether or not the temporary directory is removed after execution. Probably a good

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -702,8 +702,8 @@ class GenomeDescriptions(object):
 
 
     def search_for_gene_functions(self, search_terms, requested_sources=None, verbose=False, full_report=False, delimiter=',', case_sensitive=False, exact_match=False, genes_as_split_names=False):
-        """Search for gene functions matching the given terms in all contigs databases. Returns dictionaries 
-        in which the genome name has been added to the item matches and to the verbose (gene call) information 
+        """Search for gene functions matching the given terms in all contigs databases. Returns dictionaries
+        in which the genome name has been added to the item matches and to the verbose (gene call) information
         so that downstream reports can specify in which genome each match has been found.
         """
 

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -1340,8 +1340,8 @@ class Inversions:
 
 
     def parse_motif_output(self, meme_output_path, meme_log):
-        """ After searching for conserved motifs in the inverted repeats, we want to report 
-        the motif's group for each inversions. Then we can see in the report (txt summary and 
+        """ After searching for conserved motifs in the inverted repeats, we want to report
+        the motif's group for each inversions. Then we can see in the report (txt summary and
         html output) which inversions are linked together by site-specific invertase
         """
 

--- a/anvio/metabolicexchanges.py
+++ b/anvio/metabolicexchanges.py
@@ -1085,7 +1085,7 @@ class ExchangePredictorSingle(ExchangePredictorArgs):
 
                         def update_reported_pathway_evidence_for_chain(current_chain, comparison_chain):
                             """Updates variables like overall_max_prior with values from the current pathway map as the new 'best'
-                            evidence for an exchange. current_chain and comparison_chain store the length, overlap length, overlap proportion, and map id of 
+                            evidence for an exchange. current_chain and comparison_chain store the length, overlap length, overlap proportion, and map id of
                             the current 'best' reaction chain and the comparison chain, respectively."""
                             cur_max, cur_overlap, cur_prop, cur_map = current_chain
                             comp_max, comp_overlap, comp_prop, comp_map = comparison_chain

--- a/anvio/metabolism/algorithms.py
+++ b/anvio/metabolism/algorithms.py
@@ -898,7 +898,7 @@ class KeggEstimationAlgorithms:
     def add_module_coverage(self, mod, meta_dict_for_bin, profile_db=None, enzymes_of_interest_df=None):
         """This function updates the metabolism dictionary with coverage values for the given module.
 
-        For profile DB input, this function must be called after dbaccess.init_gene_coverage() so that the 
+        For profile DB input, this function must be called after dbaccess.init_gene_coverage() so that the
         relevant gene coverage values are initialized.
 
         NEW KEYS ADDED TO METABOLISM COMPLETENESS DICT

--- a/anvio/parsers/hmmscan.py
+++ b/anvio/parsers/hmmscan.py
@@ -52,21 +52,21 @@ class HMMERStandardOutput(object):
         | ...           ...         ...    ...     ...  ...    ...   ...           ...
         | 2896  Voltage_CLC  PF00654.19    320       1    !  210.9  29.1  1.700000e-66
         | 2897         YkuD  PF03734.13     30       1    !   48.2   0.2  8.400000e-17
-        | 
+        |
         |           i-evalue  hmm_start  hmm_stop hmm_bounds  ali_start  ali_stop  \
         | 0     6.600000e-22          1       237         [.          4       243
         | 1     1.700000e-07          1        95         [.          4        92
         | ...            ...        ...       ...        ...        ...       ...
         | 2896  7.800000e-64          3       352         ..         61       390
         | 2897  3.800000e-14          2       146         .]        327       459
-        | 
+        |
         |      ali_bounds  env_start  env_stop env_bounds  mean_post_prob  \
         | 0            ..          4       254         ..            0.74
         | 1            ..          4       148         ..            0.72
         | ...         ...        ...       ...        ...             ...
         | 2896         ..         59       392         ..            0.94
         | 2897         ..        326       459         ..            0.78
-        | 
+        |
         |       match_state_align              comparison_align             sequence_align
         | 0     vvtGggGFlGrrivkeLlrl...  +v+Gg+G++G++ v +L++ ...  LVLGGAGYIGSHAVDQLISK...
         | 1     vvtGggGFlGrrivkeLlrl...  ++ Gg+GFlG++i k L+++...  IIFGGSGFLGQQIAKILVQR...

--- a/anvio/sequencefeatures.py
+++ b/anvio/sequencefeatures.py
@@ -896,37 +896,37 @@ class Palindromes:
 
             >>> from anvio.sequencefeatures import Palindromes as P
             >>> from anvio.terminal import Run
-            >>> 
+            >>>
             >>> p = P(run=Run(verbose=False))
-            >>> 
+            >>>
             >>> s = 'ooxooooooooooooooooxoooxoxxoxxoxoooooooooxoxxoxooooooooo--ooo-o-xoxoooxoooooooooooooooooo'
-            >>> 
+            >>>
             >>> RESOLUTION = lambda: [s[start:end] for start, end in p.resolve_mismatch_map(s, max_num_mismatches=max_num_mismatches, min_mismatch_distance_to_first_base=min_mismatch_distance_to_first_base, min_palindrome_length=min_palindrome_length)]
-            >>> 
+            >>>
             >>> max_num_mismatches=1
             >>> min_mismatch_distance_to_first_base=1
             >>> min_palindrome_length=5
             >>> print(RESOLUTION())
             ['ooooooooooooooooxooo', 'oxooooooooo', 'oxooooooooo', 'oooxoooooooooooooooooo']
-            >>> 
+            >>>
             >>> max_num_mismatches=1
             >>> min_mismatch_distance_to_first_base=2
             >>> min_palindrome_length=5
             >>> print(RESOLUTION())
             ['ooooooooooooooooxooo', 'ooooooooo', 'ooooooooo', 'oooxoooooooooooooooooo']
-            >>> 
+            >>>
             >>> max_num_mismatches=1
             >>> min_mismatch_distance_to_first_base=5
             >>> min_palindrome_length=5
             >>> print(RESOLUTION())
             ['oooooooooooooooo', 'ooooooooo', 'ooooooooo', 'oooooooooooooooooo']
-            >>> 
+            >>>
             >>> max_num_mismatches=5
             >>> min_mismatch_distance_to_first_base=1
             >>> min_palindrome_length=5
             >>> print(RESOLUTION())
             ['ooxooooooooooooooooxoooxoxxo', 'oxoooooooooxoxxoxooooooooo', 'oxoooxoooooooooooooooooo']
-            >>> 
+            >>>
             >>> max_num_mismatches=5
             >>> min_mismatch_distance_to_first_base=2
             >>> min_palindrome_length=5

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -837,7 +837,7 @@ class FilterHmmHitsTable(object):
         Filter the hmm_hits table based on HMM model coverage, gene coverage, or open reading frame completeness.
 
         Returns:
-            CSV: Filtered domtblout file from hmmsearch. 
+            CSV: Filtered domtblout file from hmmsearch.
             str: The file path of the temporary file where the filtered DataFrame is saved.
         """
 

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -3876,7 +3876,7 @@ def to_jsonable(obj):
 
     Examples
     ========
-    >>> d = {...} # some dict of any size and level of nestedness 
+    >>> d = {...} # some dict of any size and level of nestedness
     >>> json.dumps(f, default=utils.to_jsonable)
     """
 
@@ -4998,7 +4998,7 @@ def split_by_delim_not_within_parens(d, delims, return_delims=False):
     d : str
         string to split
     delims : str or list of str
-        a single delimiter, or a list of delimiters, to split on. Note that if delims is the empty string (""), every 
+        a single delimiter, or a list of delimiters, to split on. Note that if delims is the empty string (""), every
         individual character in the string that is not within parentheses will be returned in the list of splits.
     return_delims : boolean
         if this is true then the list of delimiters found between each split is also returned


### PR DESCRIPTION
These fixes are not auto applied (missed in #2578) because they not considered "safe": https://docs.astral.sh/ruff/rules/trailing-whitespace/#fix-safety

We can auto apply unsafe fixes by `--unsafe-fixes` argument in hook config but I think the current approach is overall safer.

Relates to:
- #2578