### PR TITLE
Don't override default ruff rules selection

### DIFF
--- a/anvio/agglomeration.py
+++ b/anvio/agglomeration.py
@@ -204,7 +204,7 @@ class Agglomerator:
 
             while remapping_stack:
                 remapping_item = remapping_stack.pop()
-                current_ref_name = remapping_item[0]
+                remapping_item[0]
                 current_aligned_ref = remapping_item[1]
                 # Record mismatches between query sequences and the agglomerated reference sequence,
                 # with the coordinate system being nucleotide positions in the agglomerated reference.
@@ -298,7 +298,6 @@ class Agglomerator:
                     # Sort mismatches by position.
                     query_mismatches_to_agglom_ref_in_alignment_frame.sort(key=lambda query_mismatch_item: query_mismatch_item[0])
                     prev_alignment_pos = -1
-                    prev_agglom_ref_nt = ''
                     for alignment_pos, agglom_ref_nt in query_mismatches_to_agglom_ref_in_alignment_frame:
                         if alignment_pos > prev_alignment_pos + 1:
                             cigartuples.append((7, alignment_pos - prev_alignment_pos - 1))
@@ -310,7 +309,6 @@ class Agglomerator:
                         else:
                             cigartuples.append((8, 1))
                         prev_alignment_pos = alignment_pos
-                        prev_agglom_ref_nt = agglom_ref_nt
                     if alignment_length > prev_alignment_pos + 1:
                         cigartuples.append((7, alignment_length - prev_alignment_pos - 1))
 

--- a/anvio/argparse.py
+++ b/anvio/argparse.py
@@ -287,7 +287,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
 
 
     def fill_in_contigs_db(self, db_hash=None):
-        if not 'contigs_db' in self.args:
+        if 'contigs_db' not in self.args:
             return
 
         if self.args.contigs_db:
@@ -309,7 +309,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
 
 
     def fill_in_genomes_storage_db(self, db_hash=None):
-        if not 'genomes_storage' in self.args:
+        if 'genomes_storage' not in self.args:
             return
 
         if self.args.genomes_storage:
@@ -335,7 +335,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
             return
 
         FindAnvioDBs.__init__(self, run=self.run, progress=self.progress) if not self.anvio_dbs_found else None
-        if not 'profile' in self.anvio_dbs:
+        if 'profile' not in self.anvio_dbs:
             self.__args_failed.append(('profile_db', 'No profile databases around :/'))
             return
 
@@ -380,7 +380,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
             return
 
         FindAnvioDBs.__init__(self, run=self.run, progress=self.progress) if not self.anvio_dbs_found else None
-        if not 'pan' in self.anvio_dbs:
+        if 'pan' not in self.anvio_dbs:
             return self.__args_failed.append(('pan_db', 'No pan databases around :/'))
 
         pan_dbs = self.anvio_dbs['pan']

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -1444,7 +1444,7 @@ class ReadsMappingToARange:
                         L.reverse = pileupread.alignment.is_reverse
                         L.sequence = pileupread.alignment.query
 
-                        if not L.read_unique_id in read_ids:
+                        if L.read_unique_id not in read_ids:
                             data.append(L)
                             read_ids.add(L.read_unique_id)
 

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -1174,7 +1174,6 @@ class BottleApplication(Bottle):
                 'aa_sequences_in_gene_cluster': {},
                 'previous_gene_cluster_name': None,
                 'next_gene_cluster_name': None,
-                'index': None,
                 'total': None
                 }
 

--- a/anvio/ccollections.py
+++ b/anvio/ccollections.py
@@ -223,7 +223,7 @@ class Collections:
         bins_info_dict = self.get_bins_info_dict(collection_name)
         collection_dict = self.get_collection_dict(collection_name)
 
-        invalid_bin_names = [b for b in bin_names_list if not b in collection_dict]
+        invalid_bin_names = [b for b in bin_names_list if b not in collection_dict]
         if invalid_bin_names:
             raise ConfigError("Some of the bin names you want to merge is not in the collection %s :/ Here "
                               "is a list of them: %s" % (collection_name, ', '.join(invalid_bin_names)))

--- a/anvio/cli/cluster_contigs.py
+++ b/anvio/cli/cluster_contigs.py
@@ -211,7 +211,7 @@ def cluster_contigs(args, unknown, subparsers, modules):
 
     merged_profile_db = dbops.ProfileDatabase(args.profile_db)
 
-    if(merged_profile_db.meta['merged'] != True):
+    if(not merged_profile_db.meta['merged']):
         raise ConfigError("'%s' does not seem to be a merged profile database :/" % args.profile_db)
 
     contigs_db = dbops.ContigsDatabase(args.contigs_db)

--- a/anvio/cli/compute_completeness.py
+++ b/anvio/cli/compute_completeness.py
@@ -24,7 +24,7 @@ __description__ = "A script to generate completeness info for a given list of _s
 
 def compute_completeness(args):
     run = terminal.Run()
-    progress = terminal.Progress()
+    terminal.Progress()
 
     utils.is_contigs_db(args.contigs_db)
 

--- a/anvio/cli/delete_state.py
+++ b/anvio/cli/delete_state.py
@@ -44,7 +44,7 @@ def main():
                               "You don't know which state name you want to get rid of? We heard that the '--list-states' "
                               "flag helps for that.")
 
-        if not args.state in states:
+        if args.state not in states:
             raise ConfigError("The state name '%s' does not seem to appear in this database. But we have %s instead: "
                                "%s." % ((args.state, 'this one' if len(states) == 1 else 'these ones', ', '.join(list(states.keys())))))
 

--- a/anvio/cli/export_state.py
+++ b/anvio/cli/export_state.py
@@ -49,7 +49,7 @@ def main():
                                "did you try '--list-states' flag? You can press `1` for yes, `2` for no, and `3` for "
                                "maybe.")
 
-        if not args.state in states:
+        if args.state not in states:
             raise ConfigError("The state name '%s' does not seem to appear in this database. But we have %s instead: "
                                "%s." % ((args.state, 'this one' if len(states) == 1 else 'these ones', ', '.join(list(states.keys())))))
 

--- a/anvio/cli/get_codon_frequencies.py
+++ b/anvio/cli/get_codon_frequencies.py
@@ -195,7 +195,7 @@ def parse_select_functions_table(args, from_function_sources):
     if args.function_sources is None:
         args.function_sources = []
         from_function_sources = []
-    if args.function_sources == True:
+    if args.function_sources:
         pass
     else:
         # Add the sources from the file to the list of all function sources to check for and load in

--- a/anvio/cli/get_codon_usage_bias.py
+++ b/anvio/cli/get_codon_usage_bias.py
@@ -247,7 +247,7 @@ def parse_select_functions_table(args, from_function_sources):
     if args.function_sources is None:
         args.function_sources = []
         from_function_sources = []
-    if args.function_sources == True:
+    if args.function_sources:
         pass
     else:
         # Add the sources from the file to the list of all function sources to check for and load in

--- a/anvio/cli/get_sequences_for_hmm_hits.py
+++ b/anvio/cli/get_sequences_for_hmm_hits.py
@@ -91,7 +91,7 @@ def run_program():
         defline_data_dict = hmmops.SequencesForHMMHits(None).defline_data_dict
         defline_format = hmmops.SequencesForHMMHits(None).defline_format
 
-        run.warning(f"Here are the variables you can use to provide a user-defined defline template: ")
+        run.warning("Here are the variables you can use to provide a user-defined defline template: ")
         for key in defline_data_dict.keys():
             run.info_single("{%s}" % key)
         run.info_single("Remember, by default, anvi'o will use the following template to format the deflines of "

--- a/anvio/cli/get_short_reads_from_bam.py
+++ b/anvio/cli/get_short_reads_from_bam.py
@@ -47,7 +47,6 @@ def get_args():
     parser.add_argument('input_bams', metavar = 'BAM FILE[S]', nargs='+',
                         help = 'BAM file(s) to access to recover short reads')
 
-    output_file_kwargs = {'help': 'File path(s) to store results. Multiple files should be separated by commas (no spaces).'}
 
     groupA = parser.add_argument_group('INPUT OPTION #1', "Work with good'ol anvi'o databases, collections, and bins, and get all the reads from "
                                             "one or more BAM files that match to the contigs matching to your selections.")

--- a/anvio/cli/get_split_coverages.py
+++ b/anvio/cli/get_split_coverages.py
@@ -62,7 +62,7 @@ def run_program():
     # this extra flag is necessary for avoiding args.gene_caller_id == 0 which could evaluate to False
     # when gene caller id is 0 :)
     has_valid_gene_caller_id_arg = False
-    if args.gene_caller_id != None:
+    if args.gene_caller_id is not None:
         has_valid_gene_caller_id_arg = utils.is_gene_caller_id(args.gene_caller_id)
         if not args.contigs_db:
             raise ConfigError("If you wish to work with a gene caller id, you also need to provide "

--- a/anvio/cli/import_items_order.py
+++ b/anvio/cli/import_items_order.py
@@ -37,7 +37,7 @@ def main():
 def run_program():
     args = get_args()
     run = terminal.Run()
-    progress = terminal.Progress()
+    terminal.Progress()
 
     A = lambda x: args.__dict__[x] if x in args.__dict__ else None
     input_file_path = A('input_order')

--- a/anvio/cli/matrix_to_newick.py
+++ b/anvio/cli/matrix_to_newick.py
@@ -38,7 +38,7 @@ def main():
         # a quick check of the data to see if there are any missing
         # values
         _, _, _, vectors = utils.get_vectors_from_TAB_delim_matrix(args.input_matrix, run=run)
-        num_missing_data = len([item for sublist in vectors for item in sublist if item == None])
+        num_missing_data = len([item for sublist in vectors for item in sublist if item is None])
         if num_missing_data:
             run.warning(f"Oy. Your file contains {PL('missing data item', num_missing_data)}. Anvi'o will do its "
                         f"best to accomodate for it, but you should take a careful look at your output tree (that, "

--- a/anvio/cli/merge_collections.py
+++ b/anvio/cli/merge_collections.py
@@ -55,7 +55,7 @@ def run_program():
 
     combined_dict = {}
     for contig_name in contig_names:
-        if not contig_name in contig_name_to_splits:
+        if contig_name not in contig_name_to_splits:
             raise ConfigError("Oh. You have the wrong stuff. Probably. Because, the contig '%s' does not match to any of "
                                "the contig names in your database. Here is a random contig name you have in it in "
                                "comparison: '%s'." % (contig_name, list(contig_name_to_splits.keys())[0]))

--- a/anvio/cli/migrate.py
+++ b/anvio/cli/migrate.py
@@ -242,7 +242,7 @@ class Migrater(object):
         for i in range(self.artifact_version, self.target_version):
             script_name = "v%s_to_v%s" % (i, i + 1)
 
-            if not self.artifact_type in migration_scripts or not script_name in migration_scripts[self.artifact_type]:
+            if self.artifact_type not in migration_scripts or script_name not in migration_scripts[self.artifact_type]:
                 raise ConfigError("Anvi'o can not find a migrate script required for this operation. (Artifact Type: %s, Script name: %s) " % (self.artifact_type, script_name))
 
             tasks.append(script_name)

--- a/anvio/cli/predict_CPR_genomes.py
+++ b/anvio/cli/predict_CPR_genomes.py
@@ -76,7 +76,7 @@ def run_program():
     if not len(completeness.sources):
         raise ConfigError("HMM's were not run for this contigs database :/")
 
-    if not 'Campbell_et_al' in completeness.sources:
+    if 'Campbell_et_al' not in completeness.sources:
         raise ConfigError("This classifier uses Campbell et al. single-copy gene collections, and it is not among the available HMM sources in your "
                            "contigs database :/ Bad news.")
 

--- a/anvio/cli/reformat_bam.py
+++ b/anvio/cli/reformat_bam.py
@@ -45,7 +45,7 @@ def load_dict_from_tsv(path):
         for line in fh:
             if line.startswith("#"):
                 continue
-            if not '\t' in line:
+            if '\t' not in line:
                 raise Exception(f"ERROR: Invalid line in {path} (missing tab): {line}")
             new, old = line.strip().split("\t")
             utils.is_this_name_OK_for_database('contig name prefix', new)

--- a/anvio/cli/run_ncbi_cogs.py
+++ b/anvio/cli/run_ncbi_cogs.py
@@ -5,7 +5,6 @@ import sys
 from argparse import Namespace
 
 import anvio
-import anvio.terminal as terminal
 
 from anvio.cogs import COGs
 from anvio.terminal import time_program

--- a/anvio/cli/scan_trnas.py
+++ b/anvio/cli/scan_trnas.py
@@ -3,7 +3,6 @@
 import sys
 
 import anvio
-import anvio.terminal as terminal
 
 from anvio.tables.trnahits import TablesForTransferRNAs
 from anvio.errors import ConfigError, FilesNPathsError

--- a/anvio/cli/setup_kegg_data.py
+++ b/anvio/cli/setup_kegg_data.py
@@ -156,7 +156,7 @@ def get_args():
     groupE.add_argument(*anvio.A('reset'), **anvio.K('reset'))
     groupE.add_argument(*anvio.A('just-do-it'), **anvio.K('just-do-it'))
 
-    groupA = parser.add_argument_group('MODE-SPECIFIC PARAMS', "Each section (underneath the program details) "
+    parser.add_argument_group('MODE-SPECIFIC PARAMS', "Each section (underneath the program details) "
                                                                "below lists the parameters for one mode.")
 
 

--- a/anvio/cli/show_misc_data.py
+++ b/anvio/cli/show_misc_data.py
@@ -5,7 +5,6 @@ import sys
 from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.terminal as terminal
 
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import MiscDataTableFactory

--- a/anvio/cli/summarize.py
+++ b/anvio/cli/summarize.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Generate summary output from anvi'o datbases"""
 
-import os
 import sys
 
 import anvio

--- a/anvio/clustering.py
+++ b/anvio/clustering.py
@@ -107,7 +107,7 @@ def get_vectors_for_vectors_with_missing_data(vectors):
     Modified from the solution at https://stackoverflow.com/questions/31420912/python-hierarchical-clustering-with-missing-values
     """
 
-    vectors[vectors == None] = np.nan
+    vectors[vectors is None] = np.nan
 
     Npat = vectors.shape[0]
     dist = np.ndarray(shape=(Npat,Npat))

--- a/anvio/clusteringconfuguration.py
+++ b/anvio/clusteringconfuguration.py
@@ -267,7 +267,7 @@ class ClusteringConfiguration:
 
                 dbc = db.DB(database_path, None, ignore_version=True)
 
-                if not table in dbc.get_table_names():
+                if table not in dbc.get_table_names():
                     raise ConfigError('The table you requested (%s) does not seem to be in %s :/' % (table, database))
 
                 # here we know we are working with a database table that we have access to. however, in anvi'o database

--- a/anvio/codonusage.py
+++ b/anvio/codonusage.py
@@ -867,12 +867,12 @@ class SingleGenomeCodonUsage(object):
     #############################################
     def _establish_function_sources(self, from_function_sources):
         """Gets `function_sources` for methods that take the argument, `from_function_sources`."""
-        if from_function_sources == True:
+        if from_function_sources:
             function_sources = list(self.function_sources)
             if not function_sources:
                 raise ConfigError(
                     "All function sources were requested, but none exist for the object.")
-        elif from_function_sources != False:
+        elif from_function_sources:
             function_sources = list(from_function_sources)
         else:
             function_sources = None

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -1085,7 +1085,7 @@ class COGsSetup:
             open(self.COG_data_dir_version, 'w').write(COG_DATA_VERSION)
 
         for file_name in self.files:
-            if not 'url' in self.files[file_name]:
+            if 'url' not in self.files[file_name]:
                 continue
 
             file_path = os.path.join(self.raw_NCBI_files_dir, file_name)
@@ -1100,7 +1100,7 @@ class COGsSetup:
         for file_name in self.files:
             file_path = os.path.join(self.raw_NCBI_files_dir, file_name)
 
-            if not 'func' in self.files[file_name]:
+            if 'func' not in self.files[file_name]:
                 continue
 
             self.files[file_name]['func'](file_path, os.path.join(self.COG_data_dir, self.files[file_name]['formatted_file_name']))

--- a/anvio/completeness.py
+++ b/anvio/completeness.py
@@ -234,10 +234,10 @@ class Completeness:
         # for further filtering down below.
         if best_matching_domain in domains_in_hmm_hits:
             source = self.SCG_domain_predictor.SCG_domain_to_source[best_matching_domain]
-            best_mathcing_domain_completion, best_matching_domain_redundancy = hmm_hits[best_matching_domain][source]['percent_completion'], \
+            _best_mathcing_domain_completion, best_matching_domain_redundancy = hmm_hits[best_matching_domain][source]['percent_completion'], \
                                                                                hmm_hits[best_matching_domain][source]['percent_redundancy']
         else:
-            best_mathcing_domain_completion, best_matching_domain_redundancy = None, None
+            _best_mathcing_domain_completion, best_matching_domain_redundancy = None, None
 
         # figure shit out
         info_text = ''

--- a/anvio/data/misc/HMM/__init__.py
+++ b/anvio/data/misc/HMM/__init__.py
@@ -31,7 +31,7 @@ def display_miscellaneous_models(run=None):
         from anvio.terminal import Run
         run = Run()
 
-    misc_dir = os.path.abspath(os.path.dirname(__file__))
+    os.path.abspath(os.path.dirname(__file__))
 
     run.warning(None, header='Miscellaneous HMM models', lc='green')
     run.info_single("These models are not run by default, but shipped with anvi'o due to their "

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -808,7 +808,7 @@ class ContigsSuperclass(object):
                 hmm_hit = hmm_hits_table[e['hmm_hit_entry_id']]
                 hmm_source = e['source']
 
-                if not e['split'] in self.hmm_searches_dict:
+                if e['split'] not in self.hmm_searches_dict:
                     self.hmm_searches_dict[e['split']] = copy.deepcopy(sources_tmpl)
 
                 search_type = 'hmms_%s' % self.hmm_sources_info[e['source']]['search_type']
@@ -835,7 +835,7 @@ class ContigsSuperclass(object):
         _ = self.nt_positions_info
 
         if (not self.a_meta['genes_are_called']) or \
-           (not contig_name in self.nt_positions_info) or \
+           (contig_name not in self.nt_positions_info) or \
            (not len(self.nt_positions_info[contig_name])):
             return (0, 0, 0)
 
@@ -1416,7 +1416,7 @@ class ContigsSuperclass(object):
         _ = self.nt_positions_info
 
         if (not self.a_meta['genes_are_called']) or \
-           (not contig_name in self.nt_positions_info) or \
+           (contig_name not in self.nt_positions_info) or \
            (not len(self.nt_positions_info[contig_name])):
             # In these cases everything gets 0
             pass
@@ -3426,7 +3426,7 @@ class PanSuperclass(object):
                 # of the final gene clusters stored in the pan database due to various reasons. for
                 # instance, if the user set a min occurrence parameter, a singleton will not be found
                 # in the pan db yet it will return a functional hit.
-                if not gene_caller_id in self.gene_callers_id_to_gene_cluster[genome_name]:
+                if gene_caller_id not in self.gene_callers_id_to_gene_cluster[genome_name]:
                     gene_cluster_id = 'n/a'
                     found_mismatch = True
                 else:
@@ -4237,7 +4237,7 @@ class ProfileSuperclass(object):
 
 
     def get_variability_information_for_split(self, split_name, skip_outlier_SNVs=False, return_raw_results=False):
-        if not split_name in self.split_names:
+        if split_name not in self.split_names:
             raise ConfigError("get_variability_information_for_split: The split name '%s' does not seem to be "
                                "represented in this profile database. Are you sure you are looking for it "
                                "in the right database?" % split_name)
@@ -4270,7 +4270,7 @@ class ProfileSuperclass(object):
         return d
 
     def get_indels_information_for_split(self, split_name):
-        if not split_name in self.split_names:
+        if split_name not in self.split_names:
             raise ConfigError("get_indels_information_for_split: The split name '%s' does not seem to be "
                                "represented in this profile database. Are you sure you are looking for it "
                                "in the right database?" % split_name)
@@ -5611,7 +5611,7 @@ class AA_counts(ContigsSuperclass):
         if not len(collections_info_table):
             raise ConfigError("There are no collections stored in the profile database :/")
 
-        if not self.collection_name in collections_info_table:
+        if self.collection_name not in collections_info_table:
             valid_collections = ', '.join(list(collections_info_table.keys()))
             raise ConfigError("'%s' is not a valid collection name. But %s: '%s'." \
                                     % (self.collection_name,

--- a/anvio/drivers/MODELLER.py
+++ b/anvio/drivers/MODELLER.py
@@ -342,7 +342,7 @@ class MODELLER:
         self.out["best_model_path"] = new_best_file_path
 
         # append the best score to self.out
-        self.out["best_score"] = self.model_info.loc[self.model_info["picked_as_best"] == True, self.scoring_method]
+        self.out["best_score"] = self.model_info.loc[self.model_info["picked_as_best"], self.scoring_method]
 
 
     def abort(self):
@@ -359,7 +359,7 @@ class MODELLER:
         "gene_2_ModelAvg.pdb"
         """
 
-        if not "get_model.py" in self.scripts.keys():
+        if "get_model.py" not in self.scripts.keys():
             raise ConfigError("You are out of line calling tidyup without running get_model.py")
 
         # remove all copies of all scripts that were ran

--- a/anvio/drivers/sourmash.py
+++ b/anvio/drivers/sourmash.py
@@ -1,16 +1,12 @@
 """Interface to sourmash"""
 
 import os
-import numpy as np
-import pandas as pd
-import shutil
 
 import anvio
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
-from scipy.stats import entropy, skew, kurtosis
 
 from anvio.errors import ConfigError
 

--- a/anvio/drivers/vmatch.py
+++ b/anvio/drivers/vmatch.py
@@ -216,7 +216,7 @@ class Vmatch(object):
 
         pid = "Vmatch"
         self.progress.new(pid)
-        self.progress.update(f"Setting up search")
+        self.progress.update("Setting up search")
 
         with open(self.fasta_query_path) as query_file:
             for line_num, line in enumerate(query_file, 1):
@@ -304,7 +304,6 @@ class Vmatch(object):
         num_unparsed_chunks = 0
 
         query_file = open(self.fasta_query_path)
-        output_dfs = []
         if unprocessed_chunk_dict:
             self.progress.update_pid(pid)
             self.progress.update(f"Queuing queries 1-{pp_total_lines}/{pp_total_lines}")

--- a/anvio/genomesimilarity.py
+++ b/anvio/genomesimilarity.py
@@ -173,11 +173,11 @@ class Dereplicate:
                         "are now burdened with the responsibility of knowing what parameters you used to generate "
                         "these results.%s" % additional_msg)
 
-        if self.ani_dir and not self.program_name in ['pyANI', 'fastANI']:
+        if self.ani_dir and self.program_name not in ['pyANI', 'fastANI']:
             raise ConfigError("You provided a pre-existing directory of ANI results (--ani-dir), but also provided a program "
                               "name ('%s') that was not compatible with ANI." % self.program_name)
 
-        if self.mash_dir and not self.program_name in ['sourmash']:
+        if self.mash_dir and self.program_name not in ['sourmash']:
             raise ConfigError("You provided a pre-existing directory of mash results (--mash-dir), but also provided a program "
                               "name ('%s') that was not compatible with mash." % self.program_name)
 

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -448,7 +448,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
             self.progress.update('for "%s" ...' % layer)
             layer_type = utils.get_predicted_type_of_items_in_a_dict(self.items_additional_data_dict, layer)
 
-            if layer_type == None:
+            if layer_type is None:
                 skipped_additional_data_layers.append(layer)
                 continue
 
@@ -462,7 +462,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                     else:
                         item_layer_data_tuple.append(('', item))
                 else:
-                    if self.items_additional_data_dict[item][layer] == None:
+                    if self.items_additional_data_dict[item][layer] is None:
                         if layer_type != str:
                             items_for_which_we_put_zeros_for_missing_values.add(item)
                             item_layer_data_tuple.append((0.0, item))
@@ -1661,7 +1661,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
         # if the user specifies a view, set it as default:
         if self.view:
-            if not self.view in self.views:
+            if self.view not in self.views:
                 raise ConfigError("The requested view ('%s') is not available for this run. Please see "
                                          "available views by running this program with --show-views flag." % self.view)
 
@@ -1690,7 +1690,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                              "by using `anvi-script-generate-auxiliary-data-from-summary-cp` script."))
 
         if self.state_autoload:
-            if not self.state_autoload in self.states_table.states:
+            if self.state_autoload not in self.states_table.states:
                 raise ConfigError("The requested state ('%s') is not available for this run. Please see "
                                          "available states by running this program with --show-states flag." % self.state_autoload)
 
@@ -2010,7 +2010,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                 if layer_name in layer_names_considered:
                     continue
 
-                if layer_types[layer_name] == None:
+                if layer_types[layer_name] is None:
                     # all items in this layer has type None, there can't possibly
                     # be anything worth showing here.
                     layer_names_considered.add(layer_name)
@@ -2445,7 +2445,7 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
             remove_column = True
 
             # If there is a "!" it is of stacked-bar type
-            if not "!" in layer_name:
+            if "!" not in layer_name:
                 for sample_name in samples_in_layer_data:
                     # loops through samples until it finds evidence the column is string-type
                     if isinstance(additional_layer_dict[sample_name][layer_name], str):

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -920,7 +920,7 @@ class Inversions:
                     sum_freq[inversion_id][oligo_primer] = {'reference': None,
                                                             'non_reference': {}}
 
-                if reference == False:
+                if not reference:
                     if oligo not in sum_freq[inversion_id][oligo_primer]:
                         sum_freq[inversion_id][oligo_primer]['non_reference'][oligo] = frequency
                     else:
@@ -990,7 +990,7 @@ class Inversions:
                         if oligo_primer not in self.summary['inversions'][inversion_id]['activity'][sample]:
                             continue
                         ref_id = all_oligo['reference']
-                        previous_width = self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][ref_id]['width'];
+                        previous_width = self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer][ref_id]['width']
                         for i, x in all_oligo['non_reference']:
                             i_start = previous_width
                             if i not in self.summary['inversions'][inversion_id]['activity'][sample][oligo_primer]:

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -10,7 +10,6 @@ import shutil
 import functools
 import numpy as np
 import pandas as pd
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 
@@ -983,12 +982,12 @@ class Mapper:
             return drawn
 
         # Determine the individual maps to draw.
-        if draw_individual_files == True:
+        if draw_individual_files:
             if groups_txt is None:
                 draw_files_categories = list(project_name_contigs_db)
             else:
                 draw_files_categories = list(group_sources)
-        elif draw_individual_files == False:
+        elif not draw_individual_files:
             draw_files_categories = []
         else:
             draw_files_categories = draw_individual_files
@@ -999,12 +998,12 @@ class Mapper:
         ]
 
         # Determine the map grids to draw.
-        if draw_grid == True:
+        if draw_grid:
             if groups_txt is None:
                 draw_grid_categories = list(project_name_contigs_db)
             else:
                 draw_grid_categories = list(group_sources)
-        elif draw_grid == False:
+        elif not draw_grid:
             draw_grid_categories = []
         else:
             draw_grid_categories = draw_grid
@@ -1128,7 +1127,7 @@ class Mapper:
                 self.run = run
                 self.progress.end()
 
-        if draw_grid == False:
+        if not draw_grid:
             # Our work here is done.
             if groups_txt is None:
                 category_message = "contigs databases"
@@ -1883,12 +1882,12 @@ class Mapper:
             return drawn
 
         # Determine the individual maps to draw.
-        if draw_individual_files == True:
+        if draw_individual_files:
             if groups_txt is None:
                 draw_files_categories = all_genome_names
             else:
                 draw_files_categories = list(group_sources)
-        elif draw_individual_files == False:
+        elif not draw_individual_files:
             draw_files_categories = []
         else:
             draw_files_categories = draw_individual_files
@@ -1899,12 +1898,12 @@ class Mapper:
         ]
 
         # Determine the map grids to draw.
-        if draw_grid == True:
+        if draw_grid:
             if groups_txt is None:
                 draw_grid_categories = all_genome_names
             else:
                 draw_grid_categories = list(group_sources)
-        elif draw_grid == False:
+        elif not draw_grid:
             draw_grid_categories = []
         else:
             draw_grid_categories = draw_grid
@@ -2049,7 +2048,7 @@ class Mapper:
                 self.progress.end()
             drawn['individual'][category] = drawn_category
 
-        if draw_grid == False:
+        if not draw_grid:
             # Our work here is done.
             if groups_txt is None:
                 category_message = "genomes"
@@ -2788,7 +2787,6 @@ class Mapper:
 
         group_source_count: Dict[str, int] = {}
         source_group: Dict[str, str] = {}
-        ko_groups: Dict[str, List[str]] = {}
         if group_sources:
             get_categories = _get_qualifying_groups
 
@@ -3138,11 +3136,10 @@ class Mapper:
         """
         # KOs correspond to arrows rather than boxes in global and overview maps.
         is_global_map = False
-        is_overview_map = False
         if re.match(GLOBAL_MAP_ID_PATTERN, pathway_number):
             is_global_map = True
         elif re.match(OVERVIEW_MAP_ID_PATTERN, pathway_number):
-            is_overview_map = True
+            pass
 
         # A 1x resolution global 'KO' image is used as the base of the drawing, whereas a 2x
         # overview or standard 'map' image is used as the base. The global 'KO' image grays out
@@ -3269,7 +3266,6 @@ class Mapper:
         """
         rectangle_count = 0
         for compound_entry in pathway.get_entries(entry_type='compound'):
-            compound_rectangle_uuids: List[str] = []
             for uuid in compound_entry.children['graphics']:
                 graphics: kgml.Graphics = pathway.uuid_element_lookup[uuid]
                 if graphics.type == 'rectangle':
@@ -3371,11 +3367,11 @@ class ColorbarDrawer:
                 length_in_data_coords = 1 / len(colors)
                 origin_in_points = ax.transData.transform((0, 0))
                 if self.orientation == 'vertical':
-                    size_value = height_in_points = (
+                    size_value = (
                         ax.transData.transform((0, length_in_data_coords)) - origin_in_points
                     )[1]
                 elif self.orientation == 'horizontal':
-                    size_value = width_in_points = (
+                    size_value = (
                         ax.transData.transform((length_in_data_coords, 0)) - origin_in_points
                     )[0]
                 else:

--- a/anvio/kgml.py
+++ b/anvio/kgml.py
@@ -1623,7 +1623,6 @@ class XMLOps:
                         indented_output += f' {attr}="{v}"'
                     else:
                         indented_output += f'\n{" " * attr_indentation}{attr}="{v}"'
-                prev_attr = attr
         else:
             indented_output = f'{" " * tag_indentation}<{tag}'
             raise AssertionError(
@@ -1962,7 +1961,6 @@ class Drawer:
                 if kwargs.get('fontsize') is None:
                     kwargs['fontsize'] = 9
             else:
-                map_dir = self.kegg_context.png_2x_map_dir
                 map_filepath = os.path.join(
                     self.kegg_context.png_2x_map_dir, f'map{pathway.number}.png'
                 )

--- a/anvio/kgmlnetworkops.py
+++ b/anvio/kgmlnetworkops.py
@@ -1,10 +1,9 @@
 import os
-import sys
 import pandas as pd
 
 from copy import deepcopy
 from argparse import Namespace
-from typing import Any, Literal, Union
+from typing import Any, Union
 from dataclasses import dataclass, field
 
 import anvio.metabolism.context as kcontext
@@ -13,8 +12,7 @@ import anvio.terminal as terminal
 import anvio.reactionnetwork as rn
 
 from anvio.dbops import ContigsDatabase
-from anvio.argparse import ArgumentParser
-from anvio.errors import ConfigError, FilesNPathsError
+from anvio.errors import ConfigError
 
 @dataclass
 class Chain:
@@ -1906,7 +1904,7 @@ class GapAnalyzer:
                     # The gappy chain is partly cyclic. The branch index records the position in the
                     # chain of the particular occurrence of the reaction that enters or exits the
                     # cycle.
-                    gappy_kgml_compound_id = gappy_chain.kgml_compound_entries[branch_index].id
+                    gappy_chain.kgml_compound_entries[branch_index].id
                     segments: list[tuple[int]] = []
                     for ungappy_chain, overlap in zip(
                         gap_chain_relations.ungappy_chains, gap_chain_relations.overlaps
@@ -3121,7 +3119,7 @@ class GapFiller:
             json_full_gene['ko_top_hits'] = json_ko_top_hits
             ko_df = self.top_gene_kos_df[self.top_gene_kos_df['gene_callers_id'] == gcid]
             for ko_row in ko_df.itertuples():
-                json_ko_top_hits['ko_id'] = ko_id = ko_row.accession
+                json_ko_top_hits['ko_id'] = ko_row.accession
                 json_ko_top_hits['ko_name'] = ko_row.function
                 json_ko_top_hits['e_value'] = ko_row.e_value
 
@@ -3330,7 +3328,6 @@ class GapFiller:
             json_gap_kos_via_cog_top_hits.append(json_gap_ko_via_cog_top_hits)
             json_gap_ko_via_cog_top_hits['ko_id'] = ko_id
             json_gap_ko_via_cog_top_hits['ko_name'] = ko_name
-            json_associated_cog_hits: list[dict] = []
             json_gap_ko_via_cog_top_hits['cog_ids'] = hits_df['accession'].tolist()
 
         return json_candidate_genes

--- a/anvio/mcgclassifier.py
+++ b/anvio/mcgclassifier.py
@@ -152,7 +152,7 @@ class MetagenomeCentricGeneClassifier:
             if self.gen_figures:
                 plot_dir = self.output_file_prefix + '-nucleotide-coverage-distribution-plots'
                 os.makedirs(plot_dir, exist_ok=self.overwrite_output_destinations)
-        except FileExistsError as e:
+        except FileExistsError:
             raise FilesNPathsError("%s already exists, if you would like to overwrite it, then use -W (see help menu)." % plot_dir)
 
         # checking alpha
@@ -240,7 +240,7 @@ class MetagenomeCentricGeneClassifier:
                 samples_information['presence'][sample] = False
             if samples_information['presence'][sample]:
                 positive_samples.append(sample)
-            elif samples_information['presence'][sample] == False:
+            elif not samples_information['presence'][sample]:
                 negative_samples.append(sample)
 
             samples_information['detection'][sample] = detection[sample]
@@ -372,7 +372,7 @@ class MetagenomeCentricGeneClassifier:
                 self.progress.update('%d of %d genes...' % (counter, num_genes))
 
             # samples in which the gene is present
-            _samples = self.gene_presence_absence_in_samples.loc[gene_id,self.gene_presence_absence_in_samples.loc[gene_id,]==True].index
+            _samples = self.gene_presence_absence_in_samples.loc[gene_id,self.gene_presence_absence_in_samples.loc[gene_id,]].index
             # mean and std of non-outlier nt in each sample
             x = list(self.samples_coverage_stats_dicts.loc[_samples,'non_outlier_mean_coverage'].values)
             if "non_outlier_coverage_std" in self.samples_coverage_stats_dicts:
@@ -484,9 +484,9 @@ class MetagenomeCentricGeneClassifier:
         self.gene_class_df = pd.DataFrame(index=gene_ids)
         for gene_id in gene_ids:
             # determine the number of occurences in positive samples
-            self.gene_class_df.loc[gene_id, 'occurence_in_positive_samples'] = len([s for s in self.positive_samples if self.gene_presence_absence_in_samples.loc[gene_id,s] == True])
+            self.gene_class_df.loc[gene_id, 'occurence_in_positive_samples'] = len([s for s in self.positive_samples if self.gene_presence_absence_in_samples.loc[gene_id,s]])
             # determine the number of occurences in negative samples
-            self.gene_class_df.loc[gene_id, 'occurence_in_negative_samples'] = len([s for s in self.negative_samples if self.gene_presence_absence_in_samples.loc[gene_id,s] == True])
+            self.gene_class_df.loc[gene_id, 'occurence_in_negative_samples'] = len([s for s in self.negative_samples if self.gene_presence_absence_in_samples.loc[gene_id,s]])
             # set the occurence_in_positive_and_negative_samples
             self.gene_class_df.loc[gene_id, 'occurence_in_positive_and_negative_samples'] = self.gene_class_df.loc[gene_id, 'occurence_in_positive_samples'] + self.gene_class_df.loc[gene_id, 'occurence_in_negative_samples']
 

--- a/anvio/mcgops.py
+++ b/anvio/mcgops.py
@@ -43,7 +43,7 @@ class MCGPlots:
         self.samples_nuc_coverage_dict = {}
         self.gene_id = gene_id
 
-        self.samples = set(mcg.gene_presence_absence_in_samples.loc[gene_id, mcg.gene_presence_absence_in_samples.loc[gene_id,]==True].index)
+        self.samples = set(mcg.gene_presence_absence_in_samples.loc[gene_id, mcg.gene_presence_absence_in_samples.loc[gene_id,]].index)
         # taking only the positive samples in which the gene is present
         self.samples = self.samples.intersection(mcg.positive_samples)
         if not self.samples:

--- a/anvio/metabolicexchanges.py
+++ b/anvio/metabolicexchanges.py
@@ -6,18 +6,15 @@ import sys
 import multiprocessing
 from copy import deepcopy
 from argparse import Namespace
-from collections import defaultdict
 
 import anvio
-import anvio.kgml as kgml
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.kgmlnetworkops as nw
 import anvio.reactionnetwork as rn
 import anvio.filesnpaths as filesnpaths
 
-from anvio.dbops import ContigsDatabase
-from anvio.errors import ConfigError, FilesNPathsError
+from anvio.errors import ConfigError
 from anvio.genomedescriptions import GenomeDescriptions
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
@@ -1252,8 +1249,8 @@ class ExchangePredictorSingle(ExchangePredictorArgs):
             consumer_names = ",".join([self.genomes_to_compare[consumer]['name'] for consumer in genomes_consume])
             all_genome_names = ",".join([self.genomes_to_compare[x]['name'] for x in genomes_produce.union(genomes_consume) if x])
             if producer or consumer:
-                producer_name = self.genomes_to_compare[producer]['name'] if producer else None
-                consumer_name = self.genomes_to_compare[consumer]['name'] if consumer else None
+                self.genomes_to_compare[producer]['name'] if producer else None
+                self.genomes_to_compare[consumer]['name'] if consumer else None
                 if producer == consumer or (not producer) or (not consumer): # unique to one genome
                     unique_compounds[compound_id] = {'compound_name': compound_name,
                                                     'genomes': all_genome_names,

--- a/anvio/migrations/__init__.py
+++ b/anvio/migrations/__init__.py
@@ -15,7 +15,7 @@ for script_full_path in Path(base_path).glob('*/v*_to_v*.py'):
     script_name = script_filename[:-3]
     db_type = os.path.basename(script_path)
 
-    if not db_type in migration_scripts:
+    if db_type not in migration_scripts:
         migration_scripts[db_type] = {}
 
     spec = importlib.util.spec_from_file_location(script_name, script_full_path)

--- a/anvio/migrations/modules/v2_to_v3.py
+++ b/anvio/migrations/modules/v2_to_v3.py
@@ -2,7 +2,6 @@
 
 import sys
 import argparse
-import re
 
 import anvio.db as db
 import anvio.utils as utils

--- a/anvio/migrations/pan/v14_to_v15.py
+++ b/anvio/migrations/pan/v14_to_v15.py
@@ -4,7 +4,6 @@ import sys
 import argparse
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
 
 from anvio.errors import ConfigError

--- a/anvio/parsers/agnostos.py
+++ b/anvio/parsers/agnostos.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 
-import os
 import pandas as pd
 
 import anvio
 import anvio.terminal as terminal
-import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
 
-from anvio.errors import ConfigError
 from anvio.parsers.base import Parser
 
 

--- a/anvio/parsers/centrifuge.py
+++ b/anvio/parsers/centrifuge.py
@@ -85,7 +85,7 @@ class Centrifuge(Parser):
             gene_callers_id = hit['gene_callers_id']
             taxon_id = hit['taxon_id']
 
-            if not taxon_id in report:
+            if taxon_id not in report:
                 continue
 
             taxon = report[taxon_id]['t_species']

--- a/anvio/parsers/hmmer.py
+++ b/anvio/parsers/hmmer.py
@@ -231,7 +231,6 @@ class HMMERStandardOutput(object):
 
     def read_lines_until(self, condition, include_last=False, store=True):
         lines = []
-        return_value = lines if store else True
 
         for line in self.query_lines[self.line_no:]:
             self.line_no += 1

--- a/anvio/parsers/hmmscan.py
+++ b/anvio/parsers/hmmscan.py
@@ -230,7 +230,6 @@ class HMMERStandardOutput(object):
 
     def read_lines_until(self, condition, include_last=False, store=True):
         lines = []
-        return_value = lines if store else True
 
         for line in self.query_lines[self.line_no:]:
             self.line_no += 1

--- a/anvio/pfam.py
+++ b/anvio/pfam.py
@@ -115,7 +115,7 @@ class PfamSetup(object):
             try:
                 with gzip.open(input_file,'rt') as f:
                     content = f.read()
-            except gzip.BadGzipFile as err:
+            except gzip.BadGzipFile:
                 raise Exception ("BadGzipFile", input_file)
         else:
             content = read_remote_file(self.database_url + '/Pfam.version.gz')
@@ -307,7 +307,7 @@ class Pfam(object):
         if '.' in accession:
             accession = accession.split('.')[0]
 
-        if not accession in self.function_catalog:
+        if accession not in self.function_catalog:
             if ok_if_missing_from_catalog:
                 return "Unknown function with PFAM accession %s" % accession
             else:
@@ -601,8 +601,8 @@ class HMMProfile(object):
             emission = emission_line.split()
 
             # These are not used currently but maybe someday will be
-            insertion = insertion_line.split()
-            state = state_line.split()
+            insertion_line.split()
+            state_line.split()
 
             assign_type = lambda x, t: t(x) if x != '-' else '-'
             profile['MATCH_STATES']['MATCH_STATE'].append(int(emission.pop(0)))

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -1910,7 +1910,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
     def generate_output_destination(self, postfix, directory=False):
         return_path = os.path.join(self.output_directory, postfix)
 
-        if directory == True:
+        if directory:
             if os.path.exists(return_path):
                 shutil.rmtree(return_path)
             os.makedirs(return_path)

--- a/anvio/programs.py
+++ b/anvio/programs.py
@@ -132,7 +132,7 @@ def parse_help_output(output):
 
         section, desc, _params = get_param_set(output)
 
-        if section == None:
+        if section is None:
             break
 
         if _params == '':
@@ -1237,7 +1237,7 @@ class ProgramsNetwork(AnvioPrograms):
         for program in self.programs.values():
             for artifact in program.meta_info['provides']['value'] + program.meta_info['requires']['value']:
                 artifacts_seen[artifact.id] += 1
-                if not artifact.id in artifact_names_seen:
+                if artifact.id not in artifact_names_seen:
                     all_artifacts.append(artifact)
                     artifact_names_seen.add(artifact.id)
 

--- a/anvio/reactionnetwork.py
+++ b/anvio/reactionnetwork.py
@@ -4083,7 +4083,7 @@ class GenomicNetwork(ReactionNetwork):
             if remove_missing_objective_metabolites:
                 self.remove_missing_objective_metabolites(objective_dict)
             json_reactions.append(objective_dict)
-        elif objective != None:
+        elif objective is not None:
             raise ConfigError(
                 f"Anvi'o does not recognize an objective with the name, '{objective}'."
             )
@@ -5280,7 +5280,7 @@ class PangenomicNetwork(ReactionNetwork):
             if remove_missing_objective_metabolites:
                 self.remove_missing_objective_metabolites(objective_dict)
             json_reactions.append(objective_dict)
-        elif objective != None:
+        elif objective is not None:
             raise ConfigError(
                 f"Anvi'o does not recognize an objective with the name, '{objective}'."
             )
@@ -6645,7 +6645,7 @@ class Constructor:
         cdb = ContigsDatabase(contigs_db, run=self.run)
         cdb_db: DB = cdb.db
         sources: List[str] = cdb.meta['gene_function_sources']
-        if not sources or not 'KOfam' in sources:
+        if not sources or 'KOfam' not in sources:
             raise ConfigError(
                 "The contigs database indicates that genes were never annotated with KOs. This is "
                 "especially strange since to load a reaction network means that a network had to "
@@ -7223,7 +7223,7 @@ class Constructor:
                     network.kegg_modelseed_aliases[kegg_reaction_id] = [reaction_id]
                 modelseed_kegg_aliases.append(kegg_reaction_id)
                 for ko in kos:
-                    if not reaction_id in ko.reaction_ids:
+                    if reaction_id not in ko.reaction_ids:
                         # This is the first time encountering the reaction as a reference of the KO.
                         ko.reaction_ids.append(reaction_id)
                     try:
@@ -7250,7 +7250,7 @@ class Constructor:
                     network.ec_number_modelseed_aliases[ec_number] = [reaction_id]
                 modelseed_ec_number_aliases.append(ec_number)
                 for ko in kos:
-                    if not reaction_id in ko.reaction_ids:
+                    if reaction_id not in ko.reaction_ids:
                         # This is the first time encountering the reaction as a reference of the KO.
                         ko.reaction_ids.append(reaction_id)
                     try:
@@ -7755,7 +7755,7 @@ class Constructor:
         cdb = ContigsDatabase(contigs_db)
         cdb_db: DB = cdb.db
         sources: List[str] = cdb.meta['gene_function_sources']
-        if not sources or not 'KOfam' in sources:
+        if not sources or 'KOfam' not in sources:
             raise ConfigError(
                 "The contigs database indicates that genes were never annotated with KOs, which is "
                 "required to build a reaction network. This can be solved by running "
@@ -8789,10 +8789,10 @@ class Constructor:
                 network.modelseed_ec_number_aliases[modelseed_reaction_id] = []
 
             if DEBUG:
-                assert not modelseed_reaction_id in ko.kegg_reaction_aliases
+                assert modelseed_reaction_id not in ko.kegg_reaction_aliases
             ko.kegg_reaction_aliases[modelseed_reaction_id] = kegg_reaction_ids
             if DEBUG:
-                assert not modelseed_reaction_id in ko.ec_number_aliases
+                assert modelseed_reaction_id not in ko.ec_number_aliases
             ko.ec_number_aliases[modelseed_reaction_id] = []
 
         # Add ModelSEED reactions aliasing newly encountered EC numbers to the network.

--- a/anvio/sequencefeatures.py
+++ b/anvio/sequencefeatures.py
@@ -479,7 +479,7 @@ class Palindromes:
 
         A = lambda x: args.__dict__[x] if x in args.__dict__ else None
         self.palindrome_search_algorithm = A('palindrome_search_algorithm')
-        self.min_palindrome_length = 10 if A('min_palindrome_length') == None else A('min_palindrome_length')
+        self.min_palindrome_length = 10 if A('min_palindrome_length') is None else A('min_palindrome_length')
         self.max_num_mismatches = A('max_num_mismatches') or 0
         self.min_distance = A('min_distance') or 0
         self.min_mismatch_distance_to_first_base = A('min_mismatch_distance_to_first_base') or 1

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -225,7 +225,7 @@ class StructureDatabase(object):
     def get_pdb_content(self, corresponding_gene_call):
         """Returns the file content (as a string) of a pdb for a given gene"""
 
-        if not corresponding_gene_call in self.genes_with_structure:
+        if corresponding_gene_call not in self.genes_with_structure:
             raise ConfigError('The gene caller id {} was not found in the structure database :('.format(corresponding_gene_call))
 
         return self.db.get_single_column_from_table(

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -140,7 +140,7 @@ class SummarizerSuperClass(object):
         self.cog_data_dir = A('cog_data_dir')
         self.report_aa_seqs_for_gene_calls = A('report_aa_seqs_for_gene_calls')
         self.report_DNA_sequences = A('report_DNA_sequences')
-        self.delete_output_directory_if_exists = False if A('delete_output_directory_if_exists') == None else A('delete_output_directory_if_exists')
+        self.delete_output_directory_if_exists = False if A('delete_output_directory_if_exists') is None else A('delete_output_directory_if_exists')
         self.just_do_it = A('just_do_it')
         self.reformat_contig_names = A('reformat_contig_names')
 
@@ -792,7 +792,7 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
         # I am not sure whether this is the best place to do this,
         T = lambda x: 'True' if x else 'False'
 
-        J = lambda x: x in self.p_meta and self.p_meta[x] != None
+        J = lambda x: x in self.p_meta and self.p_meta[x] is not None
 
         self.summary['basics_pretty'] = {'profile': [
                                                      ('Created on', self.p_meta['creation_date']),
@@ -1130,7 +1130,6 @@ class ContigSummarizer(SummarizerSuperClass):
         # import things that are only relevant for this context where we will
         # use the power of direct access to contigs-db tables to avoid long wait times
         # when we just need simple summaries of the contigs-db contents.
-        import anvio.db as db
         import anvio.tables as t
 
         # open contigs-db directly

--- a/anvio/synteny.py
+++ b/anvio/synteny.py
@@ -283,7 +283,7 @@ class NGram(object):
                 ngram = self.order_window(annotated_window_dict['gene_clusters'])
 
             # flip annotation if the ngram was flipped
-            if ngram[1] == True:
+            if ngram[1]:
                 annotated_window_dict_ordered = {}
                 for annotation_source, annotation in annotated_window_dict.items():
                     annotated_window_flipped = annotation[::-1]

--- a/anvio/tables/collections.py
+++ b/anvio/tables/collections.py
@@ -95,9 +95,9 @@ class TablesForCollections(Table):
 
         if bins_info_dict:
             if set(collection_dict.keys()) - set(bins_info_dict.keys()):
-                raise ConfigError(f"Bins in the collection dict do not match to the ones in the bins info dict. "
-                                  f"They do not have to be identical, but for each bin id, there must be a unique "
-                                  f"entry in the bins informaiton dict. There is something wrong with your input :/")
+                raise ConfigError("Bins in the collection dict do not match to the ones in the bins info dict. "
+                                  "They do not have to be identical, but for each bin id, there must be a unique "
+                                  "entry in the bins informaiton dict. There is something wrong with your input :/")
 
         if drop_collection:
             # remove any pre-existing information for 'collection_name'

--- a/anvio/taxonomyops/__init__.py
+++ b/anvio/taxonomyops/__init__.py
@@ -1399,7 +1399,7 @@ class PopulateContigsDatabaseWithTaxonomy(TerminologyHelper):
         """Takes a dictionary that includes a key `accession` and populates the dictionary with taxonomy"""
 
         if not mode:
-            if not 'accession' in d:
+            if 'accession' not in d:
                 raise ConfigError("`add_taxonomy_to_dict` is speaking: the dictionary sent here does not have a member "
                                   "with key `accession`.")
 

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -1186,7 +1186,8 @@ class SetupLocalSCGTaxonomyData(SCGTaxonomyArgs, SanityCheck):
 
             # then, we will have to copy all relevant files from the anvi'o source directory to
             # the new setup database
-            import shutil, glob
+            import shutil
+            import glob
             shutil.copy(ctx.accession_to_taxonomy_file_path, self.SCGs_taxonomy_data_dir)
             shutil.copy(ctx.database_version_file_path, self.SCGs_taxonomy_data_dir)
 

--- a/anvio/tests/run_unit_tests_for_consensus_taxonomy.py
+++ b/anvio/tests/run_unit_tests_for_consensus_taxonomy.py
@@ -40,7 +40,7 @@ scg_raw_hits = [{'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'T x'},
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'T x'}]
 
-assert cT('t_species') == None
+assert cT('t_species') is None
 assert cT('t_genus') == 'F'
 
 #########################################
@@ -49,8 +49,8 @@ scg_raw_hits = [{'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'G x'},
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'W', 't_species': 'T x'}]
 
-assert cT('t_species') == None
-assert cT('t_genus') == None
+assert cT('t_species') is None
+assert cT('t_genus') is None
 assert cT('t_family') == 'E'
 
 #########################################
@@ -76,7 +76,7 @@ assert cT('t_species') == 'G x'
 scg_dict = {1: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'G x'},
             3: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'T x'}}
 
-assert pT('t_species') == None
+assert pT('t_species') is None
 assert pT('t_genus') == 'F'
 
 #########################################
@@ -96,7 +96,7 @@ scg_dict = {1: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D'
             5: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'W', 't_species': 'T x'},
             6: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'W', 't_species': 'T x'}}
 
-assert pT('t_species') == None
-assert pT('t_genus') == None
-assert pT('t_family') == None
+assert pT('t_species') is None
+assert pT('t_genus') is None
+assert pT('t_family') is None
 assert pT('t_order') == 'D'

--- a/anvio/trnaidentifier.py
+++ b/anvio/trnaidentifier.py
@@ -12,8 +12,7 @@ from collections import OrderedDict
 import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import TRNAIdentifierError
-from anvio.filesnpaths import is_file_exists, is_output_file_writable
-from anvio.constants import WC_BASE_PAIRS, WC_PLUS_WOBBLE_BASE_PAIRS, anticodon_to_AA as ANTICODON_TO_AA
+from anvio.constants import WC_PLUS_WOBBLE_BASE_PAIRS, anticodon_to_AA as ANTICODON_TO_AA
 
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/trnaseq.py
+++ b/anvio/trnaseq.py
@@ -4488,7 +4488,7 @@ class TRNASeqDataset(object):
                     spec_short_5prime_read_count_M += seq_M.spec_read_xtra_5prime_count
             if seq_M.nonspec_read_xtra_5prime_count:
                 if seq_M.nonspec_long_5prime_extension_dict:
-                    nonspec_long_5prime_read_count = sum(seq_M.nonspec_long_5prime_extension_dict.values())
+                    sum(seq_M.nonspec_long_5prime_extension_dict.values())
             length_M = len(seq_M.consensus_string)
             mean_spec_cov = seq_M.mean_spec_cov
             mean_nonspec_cov = seq_M.mean_nonspec_cov
@@ -7368,7 +7368,7 @@ class ResultTabulator(object):
         self.spec_aux_db_info = DBInfo(self.spec_aux_db_path, expecting='auxiliary data for coverages')
         self.nonspec_aux_db_path = os.path.join(os.path.dirname(self.nonspec_profile_db_path), 'AUXILIARY-DATA.db') if self.nonspec_profile_db_path else None
         if self.nonspec_aux_db_path:
-            nonspec_aux_db_info = DBInfo(self.nonspec_aux_db_path, expecting='auxiliary data for coverages')
+            DBInfo(self.nonspec_aux_db_path, expecting='auxiliary data for coverages')
 
         filesnpaths.is_output_dir_writable(self.out_dir)
 
@@ -8064,7 +8064,7 @@ class ResultPlotter(object):
                     continue
 
                 if not taxon_rank_filter and not loop_ranks:
-                    warning(f"A taxon or at least one rank must be given.", "PROGRAM REQUIREMENT")
+                    warning("A taxon or at least one rank must be given.", "PROGRAM REQUIREMENT")
                     continue
 
                 loop_ranks = sorted(loop_ranks, key=lambda rank: RANKS.index(rank))
@@ -8075,7 +8075,7 @@ class ResultPlotter(object):
 
                 if single_aa and single_anticodon:
                     if ANTICODON_AA_DICT[single_anticodon] == single_aa:
-                        warning(f"An amino acid is not needed with the anticodon.", "UNNECESSARY FIELD")
+                        warning("An amino acid is not needed with the anticodon.", "UNNECESSARY FIELD")
                         single_aa = None
                     else:
                         warning(f"The anticodon ('{single_anticodon}') does not decode the amino acid ('{single_aa}').", "INVALID FIELD")
@@ -8306,7 +8306,6 @@ class ResultPlotter(object):
     def print_formatting_options(self):
         self.run.warning("", header="FORMAT OPTIONS", lc='green')
         info_single = self.run.info_single
-        DEFAULT_FORMAT_PARAM_DICT = self.DEFAULT_FORMAT_PARAM_DICT
         info_single("The name and default value of the option is given.", mc='magenta', level=1)
         for param, value in self.DEFAULT_FORMAT_PARAM_DICT.items():
             info_single(f"{param}, {value}", mc='yellow', level=2)
@@ -8340,9 +8339,9 @@ class ResultPlotter(object):
 
         sample_spec_gb = spec_df.groupby(('sample_name', '', ''))
         sample_mod_gb = mod_df.groupby('sample_name')
-        sample_nonspec_gb = nonspec_df.groupby(('sample_name', '', '')) if self.nonspec_txt_path else None
+        nonspec_df.groupby(('sample_name', '', '')) if self.nonspec_txt_path else None
 
-        fig = plt.figure(1)
+        plt.figure(1)
         num_samples = self.num_samples
         GridSpec(num_samples, 1)
 
@@ -8358,7 +8357,6 @@ class ResultPlotter(object):
 
         format_param_dict = self.format_param_dict
         cov_index = self.cov_index
-        cov_cutoff = self.cov_cutoff
         cov_length = self.cov_length
         cov_x_values = self.cov_x_values
         cov_x_labels = self.cov_x_labels

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -25,7 +25,9 @@ try:
     import webbrowser
     import subprocess
     import tracemalloc
-    import urllib.request, urllib.error, urllib.parse
+    import urllib.request
+    import urllib.error
+    import urllib.parse
 
     import numpy as np
     import pandas as pd
@@ -244,7 +246,7 @@ def get_predicted_type_of_items_in_a_dict(d, key):
         # it is either list or dict. we will go through items
         # and return the type of first item that is not None:
         for item in items:
-            if item == None:
+            if item is None:
                 continue
             else:
                 return type(item)
@@ -743,7 +745,7 @@ def store_array_as_TAB_delimited_file(a, output_path, header, exclude_columns=[]
         raise ConfigError("store array: header length (%d) differs from data (%d)..." % (len(header), num_fields))
 
     for col in exclude_columns:
-        if not col in header:
+        if col not in header:
             raise ConfigError("store array: column %s is not in the header array...")
 
     exclude_indices = set([header.index(c) for c in exclude_columns])
@@ -3822,7 +3824,7 @@ def get_groups_txt_file_as_dict(file_path, run=run, progress=progress, include_m
                               f"downstream, so we will stop you right there. Please remove all duplicate items from this file. :)")
         item_to_group_dict[item] = group_name
 
-        if not group_name in group_to_item_dict:
+        if group_name not in group_to_item_dict:
             group_to_item_dict[group_name] = []
         group_to_item_dict[group_name].append(item)
 
@@ -3974,7 +3976,7 @@ def get_TAB_delimited_file_as_dictionary(file_path, expected_fields=None, dict_t
 
         line_fields = [f if f else None for f in line.strip('\n').split(separator)]
 
-        if line_fields and line_fields[0] == None:
+        if line_fields and line_fields[0] is None:
             raise ConfigError("The line number %d in '%s' has no data in its first column, and this doesn't "
                               "seem right at all :/" % (line_counter + 1, file_path))
 
@@ -3983,7 +3985,7 @@ def get_TAB_delimited_file_as_dictionary(file_path, expected_fields=None, dict_t
             updated_line_fields = []
             for i in range(0, len(line_fields)):
                 try:
-                    if line_fields[i] == None and column_mapping[i] in [float, int]:
+                    if line_fields[i] is None and column_mapping[i] in [float, int]:
                         updated_line_fields.append(column_mapping[i](0))
                     else:
                         updated_line_fields.append(column_mapping[i](line_fields[i]))

--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -317,7 +317,7 @@ class ProcessAlleleCounts:
 
     def get_positions_with_competing_items(self, competing_items):
 
-        return np.where(competing_items != None)[0]
+        return np.where(competing_items is not None)[0]
 
 
     def rename_key(self, from_this, to_that):

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -949,7 +949,7 @@ class VariabilitySuper(VariabilityFilter, object):
             self.sample_ids_of_interest = self.get_sample_ids_of_interest()
 
         if not self.genes_of_interest:
-            self.progress.update('Setting up genes of interest ...');
+            self.progress.update('Setting up genes of interest ...')
             # self.genes_of_interest can be injected into this class programatically; this
             # conditional method call prevents overwriting
             self.genes_of_interest = self.get_genes_of_interest()

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -132,7 +132,7 @@ class ContigsDBWorkflow(WorkflowSuperClass):
     def get_contigs_workflow_optional_targets(self):
         optional_targets = []
 
-        run_taxonomy_with_centrifuge = self.get_param_value_from_config(["centrifuge", "run"]) == True
+        run_taxonomy_with_centrifuge = self.get_param_value_from_config(["centrifuge", "run"])
         # sanity check for centrifuge db
         if run_taxonomy_with_centrifuge:
             if not self.get_param_value_from_config(["centrifuge", "db"]):
@@ -143,18 +143,18 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         if run_taxonomy_with_centrifuge:
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_anvi_import_taxonomy_for_genes.done"))
 
-        run_anvi_run_hmms = self.get_param_value_from_config(["anvi_run_hmms", "run"]) == True
+        run_anvi_run_hmms = self.get_param_value_from_config(["anvi_run_hmms", "run"])
         if run_anvi_run_hmms:
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_hmms.done"))
 
-        if self.get_param_value_from_config(["anvi_run_ncbi_cogs", "run"]) == True:
+        if self.get_param_value_from_config(["anvi_run_ncbi_cogs", "run"]):
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_ncbi_cogs.done"))
 
-        run_anvi_run_kofams = self.get_param_value_from_config(["anvi_run_kegg_kofams", "run"]) == True
+        run_anvi_run_kofams = self.get_param_value_from_config(["anvi_run_kegg_kofams", "run"])
         if run_anvi_run_kofams:
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_kegg_kofams.done"))
 
-        run_anvi_run_scg_taxonomy = self.get_param_value_from_config(["anvi_run_scg_taxonomy", "run"]) == True
+        run_anvi_run_scg_taxonomy = self.get_param_value_from_config(["anvi_run_scg_taxonomy", "run"])
         if run_anvi_run_scg_taxonomy:
             if not run_anvi_run_hmms:
                 self.run.warning('You chose to run anvi_run_scg_taxonomy, but you didn\'t choose to run '
@@ -162,11 +162,11 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                                  'don\'t have HMM hits stored already then anvi_run_scg_taxonomy will fail.')
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_scg_taxonomy.done"))
 
-        run_anvi_run_trna_scan = self.get_param_value_from_config(["anvi_run_trna_scan", "run"]) == True
+        run_anvi_run_trna_scan = self.get_param_value_from_config(["anvi_run_trna_scan", "run"])
         if run_anvi_run_trna_scan:
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_run_trna_scan.done"))
 
-        if self.get_param_value_from_config(["anvi_script_run_eggnog_mapper", "run"]) == True:
+        if self.get_param_value_from_config(["anvi_script_run_eggnog_mapper", "run"]):
             optional_targets.append(os.path.join(self.dirs_dict["CONTIGS_DIR"], "{group}-steps", "anvi_script_run_eggnog_mapper.done"))
 
         # import external functions if provided

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -7,7 +7,6 @@ import anvio
 import argparse
 import pandas as pd
 
-import anvio
 import anvio.utils as u
 import anvio.terminal as terminal
 import anvio.constants as constants
@@ -22,7 +21,6 @@ from anvio.genomedescriptions import GenomeDescriptions
 from anvio.genomedescriptions import MetagenomeDescriptions
 from anvio.artifacts.samples_txt import SamplesTxt
 
-import anvio.constants as constants
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ['mschecht']
@@ -206,11 +204,11 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                     self.metagenomes_name_list = list(self.metagenomes_dict.keys())
                     self.metagenomes_path_list = [value['contigs_db_path'] for key,value in self.metagenomes_dict.items()]
 
-                    with open(sanity_checked_metagenomes_file, 'w') as fp:
+                    with open(sanity_checked_metagenomes_file, 'w'):
                         pass
                 else:
-                    self.run.warning(f"You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
-                                     f"for any genomes or metagenomes that cause issues downstream in ecophylo.")
+                    self.run.warning("You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
+                                     "for any genomes or metagenomes that cause issues downstream in ecophylo.")
                     self.metagenomes_name_list = self.metagenomes_df.name.to_list()
                     self.metagenomes_path_list = self.metagenomes_df.contigs_db_path.to_list()
             else:
@@ -244,7 +242,7 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                     self.external_genomes_names_list = list(self.external_genomes_dict.keys())
                     self.external_genomes_path_list = [value['contigs_db_path'] for key,value in self.external_genomes_dict.items()]
 
-                    with open(sanity_checked_genomes_file, 'w') as fp:
+                    with open(sanity_checked_genomes_file, 'w'):
                         pass
                 else:
                     self.external_genomes_names_list = self.external_genomes_df.name.to_list()
@@ -281,12 +279,12 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
 
             self.sample_names_for_mapping_list = self.samples_txt.samples()
 
-            if self.AA_mode == True:
+            if self.AA_mode:
                 raise ConfigError("You provided a samples.txt so you're in profile mode! Please change AA_mode to false.")
 
         else:
-            self.run.warning(f"Since you did not provide a samples.txt, EcoPhylo will assume you do not want "
-                             f"to profile the ecology of your proteins and will just be making trees for now!")
+            self.run.warning("Since you did not provide a samples.txt, EcoPhylo will assume you do not want "
+                             "to profile the ecology of your proteins and will just be making trees for now!")
 
         # Pick which tree algorithm
         self.run_iqtree = self.get_param_value_from_config(['iqtree', 'run'])
@@ -313,7 +311,7 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                                   "so Snakemake knows how many jobs to run at the same time on the HPC.")
 
             jobs_param = any("--jobs" in param for param in metagenomics_workflow_snakemake_additional_params_list)
-            if jobs_param == False:
+            if not jobs_param:
                 raise ConfigError("The EcoPhylo workflow did not detect the parameter '--jobs' in `snakemake_additional_params`. "
                                   "Please include '--jobs'. You can read about it with snakemake -h")
 
@@ -329,11 +327,11 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                               f"Please check your config file {self.config_file} and change cluster_representative_method to one of the following: 'mmseqs' and 'cluster_rep_with_coverages'")
 
         if self.cluster_representative_method == 'cluster_rep_with_coverages' and len(self.contigs_db_name_bam_dict) == 0:
-            raise ConfigError(f"The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages without BAM files..."
-                              f"Please edit your metagenomes.txt or external-genomes.txt and add BAM files.")
+            raise ConfigError("The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages without BAM files..."
+                              "Please edit your metagenomes.txt or external-genomes.txt and add BAM files.")
 
-        if self.cluster_representative_method == 'cluster_rep_with_coverages' and self.AA_mode == True:
-            raise ConfigError(f"The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages in AA_mode")
+        if self.cluster_representative_method == 'cluster_rep_with_coverages' and self.AA_mode:
+            raise ConfigError("The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages in AA_mode")
 
         # Parse clustering parameter space
         self.clustering_param_space = self.get_param_value_from_config(['cluster_X_percent_sim_mmseqs', 'clustering_threshold_for_OTUs'])
@@ -363,7 +361,7 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
 
         for hmm, value in self.hmm_dict.items():
             group = value['group']
-            hmm_source = value['source']
+            value['source']
             target_file = os.path.join(self.dirs_dict['RIBOSOMAL_PROTEIN_MSA_STATS'], f"{group}", f"{group}_stats.tsv")
             target_files.append(target_file)
 
@@ -462,7 +460,7 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
 
         try:
             hmm_df = pd.read_csv(self.hmm_list_path, sep='\t', index_col=False)
-        except AttributeError as e:
+        except AttributeError:
             raise ConfigError(f"The hmm_list.txt file, {self.hmm_list_path}, does not appear to be properly formatted. "
                               f"This is the error from trying to load it: {self.hmm_list_path}")
 
@@ -547,6 +545,6 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
         # TODO: I hope we can change that in the future, probably by making a contigs.db for the representative sequence,
         # in tree mode or not.
         if len(unique_group) < len(self.hmm_dict) and self.run_scg_taxonomy:
-            raise ConfigError(f"You have one or more 'group' in your HMM list file (or multiple identical entries - but you "
-                              f"shouldn't be doing that) and at the moment it is not compatible with anvi-estimate-scg-taxonomy. "
-                              f"The good news is that you can turn off anvi-run-scg-taxonmy in your config file.")
+            raise ConfigError("You have one or more 'group' in your HMM list file (or multiple identical entries - but you "
+                              "shouldn't be doing that) and at the moment it is not compatible with anvi-estimate-scg-taxonomy. "
+                              "The good news is that you can turn off anvi-run-scg-taxonmy in your config file.")

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -227,9 +227,9 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
 
         self.use_scaffold_from_metaspades = self.get_param_value_from_config(['metaspades', 'use_scaffolds'])
         self.use_scaffold_from_idba_ud = self.get_param_value_from_config(['idba_ud', 'use_scaffolds'])
-        self.run_qc = self.get_param_value_from_config(['iu_filter_quality_minoche', 'run']) == True
-        self.run_summary = self.get_param_value_from_config(['anvi_summarize', 'run']) == True
-        self.run_split = self.get_param_value_from_config(['anvi_split', 'run']) == True
+        self.run_qc = self.get_param_value_from_config(['iu_filter_quality_minoche', 'run'])
+        self.run_summary = self.get_param_value_from_config(['anvi_summarize', 'run'])
+        self.run_split = self.get_param_value_from_config(['anvi_split', 'run'])
         self.references_mode = self.get_param_value_from_config('references_mode')
         self.fasta_txt_file = self.get_param_value_from_config('fasta_txt')
         self.profile_databases = {}
@@ -314,7 +314,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         if self.run_split:
             split = [os.path.join(self.dirs_dict["SPLIT_PROFILES_DIR"],\
                                   g + "-split.done")\
-                                  for g in self.collections.keys() if not 'default_collection' in self.collections[g]]
+                                  for g in self.collections.keys() if 'default_collection' not in self.collections[g]]
             target_files.extend(split)
 
         targets_files_for_binning = self.get_target_files_for_anvi_cluster_contigs()
@@ -419,7 +419,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
             self.group_sizes = dict.fromkeys(self.group_names, len(self.sample_names))
 
         # 6) Assembly mode requires reformat_fasta (saves assembler output out of tmp)
-        if (not self.references_mode) and not (self.get_param_value_from_config(['anvi_script_reformat_fasta', 'run']) is True):
+        if (not self.references_mode) and self.get_param_value_from_config(['anvi_script_reformat_fasta', 'run']) is not True:
             raise ConfigError("You are running the metagenomics workflow in assembly mode. In this mode you can't skip "
                               "`anvi_script_reformat_fasta`. Please add this rule to your config with `'run': true`.")
 
@@ -514,10 +514,10 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
     def init_kraken(self):
         '''Making sure the sample names and file paths the provided kraken.txt file are valid'''
         kraken_txt = self.get_param_value_from_config('kraken_txt')
-        self.run_krakenuniq = self.get_param_value_from_config(['krakenuniq', 'run']) == True
+        self.run_krakenuniq = self.get_param_value_from_config(['krakenuniq', 'run'])
 
         if kraken_txt:
-            if self.get_param_value_from_config(['krakenuniq', 'run']) == True:
+            if self.get_param_value_from_config(['krakenuniq', 'run']):
                 raise ConfigError("You supplied a kraken_txt file (\"%s\") but you set krakenuniq "
                                   "to run in the config file. anvi'o is confused and "
                                   "is officially going on a strike. Ok, let's clarify, "
@@ -790,7 +790,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         if not pre_ref_removal:
             post_ref_removal = self.remove_short_reads_based_on_references
 
-        zipped = self.get_param_value_from_config(['gzip_fastqs', 'run']) == True
+        zipped = self.get_param_value_from_config(['gzip_fastqs', 'run'])
 
         rs = self.readsets_by_id.get(readset)
 
@@ -843,7 +843,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
     def get_target_files_for_anvi_cluster_contigs(self):
         import anvio.workflows as w
         w.D(self.get_param_value_from_config(['anvi_cluster_contigs', 'run']))
-        if self.get_param_value_from_config(['anvi_cluster_contigs', 'run']) != True:
+        if not self.get_param_value_from_config(['anvi_cluster_contigs', 'run']):
             # the user doesn't want to run this
             return
         w.D('hi2')

--- a/anvio/workflows/sra_download/__init__.py
+++ b/anvio/workflows/sra_download/__init__.py
@@ -110,7 +110,7 @@ class SRADownloadWorkflow(WorkflowSuperClass):
     def get_target_files(self):
         """Get list of target files for snakemake target rule"""
 
-        target_files = [os.path.join(self.dirs_dict['FASTAS'], f"generate_samples_txt.done")]
+        target_files = [os.path.join(self.dirs_dict['FASTAS'], "generate_samples_txt.done")]
 
         return target_files
 

--- a/anvio/workflows/trnaseq/__init__.py
+++ b/anvio/workflows/trnaseq/__init__.py
@@ -476,7 +476,7 @@ class TRNASeqWorkflow(WorkflowSuperClass):
                 target_files.append(os.path.join(out_dir, "IDENT.done"))
 
         if self.run_anvi_merge_trnaseq:
-            project_name = self.get_param_value_from_config(['anvi_merge_trnaseq', '--project-name'])
+            self.get_param_value_from_config(['anvi_merge_trnaseq', '--project-name'])
             target_files.append(os.path.join(self.dirs_dict['CONVERT_DIR'], "CONVERT.done"))
 
         if self.run_anvi_run_trna_taxonomy:

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,3 +8,8 @@ extend-select = [
     # https://docs.astral.sh/ruff/rules/trailing-whitespace/
     "W291",
 ]
+ignore = [
+    # https://docs.astral.sh/ruff/rules/lambda-assignment/
+    # https://github.com/merenlab/anvio/pull/2582#issuecomment-4337119754
+    "E731",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
+# https://docs.astral.sh/ruff/configuration/
+
 [lint]
 # https://docs.astral.sh/ruff/rules/
-select = [
+extend-select = [
     # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/
     "UP009",
     # https://docs.astral.sh/ruff/rules/trailing-whitespace/


### PR DESCRIPTION
This change allows the default config to be effective. By the date of the PR, the default lint.select is `["E4", "E7", "E9", "F"]`

https://docs.astral.sh/ruff/configuration/