### PR TITLE
Organize imports

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -2,11 +2,17 @@
 
 """Lots of under-the-rug, operational garbage in here. Run. Run away."""
 
-from anvio.version import anvio_version, anvio_codename, major_python_version_required, minor_python_version_required, get_versions
-
-import sys
 import inspect
 import platform
+import sys
+
+from anvio.version import (
+    anvio_codename,
+    anvio_version,
+    get_versions,
+    major_python_version_required,
+    minor_python_version_required,
+)
 
 # make sure anvi'o runs in the right Python environment:
 try:
@@ -42,9 +48,9 @@ except Exception:
 # we are in the right Python environment. import the rest of the libraries
 # and do all the other boring stuff.
 
-import os
-import json
 import copy
+import json
+import os
 
 # very important variable to determine which help docs are relevant for
 # this particlar anvi'o environment
@@ -171,7 +177,6 @@ def TABULATE(table, header, numalign="right", max_width=0):
 
 
 import anvio.constants as constants
-
 
 # a comprehensive arguments dictionary that provides easy access from various programs that interface anvi'o modules:
 D = {

--- a/anvio/agglomeration.py
+++ b/anvio/agglomeration.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
 
-import gc
-import os
-import math
 import argparse
-
+import gc
+import math
+import os
 from collections import deque
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.drivers.vmatch import Vmatch
-from anvio.sequence import Alignment, AlignedQuery, AlignedTarget
-
+from anvio.sequence import AlignedQuery, AlignedTarget, Alignment
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/argparse.py
+++ b/anvio/argparse.py
@@ -1,22 +1,20 @@
 # pylint: disable=line-too-long
 """Overloading Python argparse for anvi'o purposes"""
 
+import argparse
 import os
 import sys
-import argparse
 import textwrap
 
-from colored import fg, attr
+from colored import attr, fg
 from rich_argparse import RichHelpFormatter
 
 import anvio
 import anvio.docs as docs
 import anvio.terminal as terminal
-
-from anvio.programs import Program
-from anvio.errors import ConfigError
 from anvio.dbinfo import FindAnvioDBs
-
+from anvio.errors import ConfigError
+from anvio.programs import Program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/artifacts/samples_txt.py
+++ b/anvio/artifacts/samples_txt.py
@@ -1,11 +1,11 @@
 # pylint: disable=line-too-long
 
 import os
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
 from pathlib import Path
+
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 

--- a/anvio/authors.py
+++ b/anvio/authors.py
@@ -4,11 +4,9 @@
 import os
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/auxiliarydataops.py
+++ b/anvio/auxiliarydataops.py
@@ -2,16 +2,15 @@
 """Module to deal with HDF5 files"""
 
 import time
+
 import numpy as np
 
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import AuxiliaryDataError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -3,25 +3,24 @@
 """Classes for anything BAM-related"""
 
 
+import hashlib
 import os
 import sys
-import pysam
-import numpy as np
-import hashlib
-
-from numba import jit
 from collections import Counter
 from dataclasses import dataclass, field
 
-import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.dbops as dbops
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
-import anvio.ccollections as ccollections
+import numpy as np
+import pysam
+from numba import jit
 
+import anvio
+import anvio.ccollections as ccollections
+import anvio.constants as constants
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -6,26 +6,21 @@
     anvi-interactive, or anvi-refine.
 """
 
-import os
-import re
-import io
-import sys
-import math
-import copy
-import time
-import json
-import base64
-import random
-import getpass
 import argparse
+import base64
+import copy
 import datetime
+import getpass
 import importlib
-
+import io
+import json
+import math
+import os
+import random
+import re
+import sys
+import time
 from hashlib import md5
-from ete3 import Tree
-from bottle import Bottle
-from bottle import BaseRequest
-from bottle import redirect, static_file
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -34,23 +29,23 @@ from bottle import redirect, static_file
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
+from bottle import BaseRequest, Bottle, redirect, static_file
+from ete3 import Tree
 
 import anvio
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.drivers as drivers
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.summarizer as summarizer
-import anvio.filesnpaths as filesnpaths
-import anvio.taxonomyops.scg as scgtaxonomyops
 import anvio.auxiliarydataops as auxiliarydataops
-
+import anvio.constants as constants
+import anvio.dbops as dbops
+import anvio.drivers as drivers
+import anvio.filesnpaths as filesnpaths
+import anvio.summarizer as summarizer
+import anvio.taxonomyops.scg as scgtaxonomyops
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.errors import ConfigError, RefineError
 from anvio.serverAPI import AnviServerAPI
-from anvio.errors import RefineError, ConfigError
-from anvio.tables.miscdata import TableForLayerOrders
 from anvio.tables.collections import TablesForCollections
-
+from anvio.tables.miscdata import TableForLayerOrders
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["A. Murat Eren"]
@@ -109,7 +104,7 @@ class BottleApplication(Bottle):
             request = mock_request
             response = mock_response
         else:
-            from bottle import response, request
+            from bottle import request, response
 
         # if there is a contigs database, and scg taxonomy was run on it get an instance
         # of the SCG Taxonomy class early on:

--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python
 """This file contains CAZyme related classes."""
 
-import os
 import glob
+import os
 import shutil
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
-from anvio.drivers.hmmer import HMMer
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsDatabase
+from anvio.drivers.hmmer import HMMer
+from anvio.errors import ConfigError
 from anvio.parsers import parser_modules
 from anvio.tables.genefunctions import TableForGeneFunctions
 

--- a/anvio/ccollections.py
+++ b/anvio/ccollections.py
@@ -15,14 +15,12 @@ import copy
 
 import anvio
 import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.collections import TablesForCollections
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/add_default_collection.py
+++ b/anvio/cli/add_default_collection.py
@@ -4,11 +4,9 @@
 import sys
 
 import anvio
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.collections import TablesForCollections
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/analyze_synteny.py
+++ b/anvio/cli/analyze_synteny.py
@@ -16,12 +16,10 @@ See anvio/docs/programs/anvi-analyze-synteny.md for more information and how to 
 import sys
 
 import anvio
-
-from anvio.synteny import NGram
-from anvio.terminal import time_program
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.synteny import NGram
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/annotate_fragmented_genes.py
+++ b/anvio/cli/annotate_fragmented_genes.py
@@ -6,9 +6,7 @@ import sys
 import anvio
 import anvio.panops as panops
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2026, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Sean Crosson"]

--- a/anvio/cli/as_markdown.py
+++ b/anvio/cli/as_markdown.py
@@ -3,9 +3,7 @@
 import sys
 
 import anvio
-
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/augustus_output_to_external_gene_calls.py
+++ b/anvio/cli/augustus_output_to_external_gene_calls.py
@@ -3,12 +3,10 @@
 import sys
 
 import anvio
-import anvio.utils as u
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as u
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/checkm_tree_to_interactive.py
+++ b/anvio/cli/checkm_tree_to_interactive.py
@@ -6,11 +6,10 @@ import sys
 from ete3 import Tree
 
 import anvio
-import anvio.utils as utils
+import anvio.filesnpaths as filesnpaths
 import anvio.tables as tables
 import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 

--- a/anvio/cli/cluster_contigs.py
+++ b/anvio/cli/cluster_contigs.py
@@ -1,23 +1,21 @@
 #!/usr/bin/env python
 """A script to run automatic binning algorithms on a merged anvi'o profile"""
-import os
-import sys
-import shutil
-import random
 import argparse
+import os
+import random
+import shutil
+import sys
 
 import anvio
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.drivers import driver_modules
-from anvio.ttycolors import color_text as c
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.collections import TablesForCollections
-
+from anvio.ttycolors import color_text as c
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Christopher Quince"]

--- a/anvio/cli/compute_ani.py
+++ b/anvio/cli/compute_ani.py
@@ -4,7 +4,6 @@ import sys
 
 from anvio.errors import ConfigError
 
-
 __description__ = ("This program has been superseded by the beefier `anvi-compute-genome-similarity`")
 
 

--- a/anvio/cli/compute_ani_for_fasta.py
+++ b/anvio/cli/compute_ani_for_fasta.py
@@ -2,22 +2,19 @@
 """A script to export run ANI on every contig in a FASTA file."""
 
 import os
-import sys
 import shutil
-from anvio.argparse import ArgumentParser
+import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.fastalib as fastalib
-import anvio.terminal as terminal
 import anvio.clustering as clustering
-import anvio.filesnpaths as filesnpaths
-
-from anvio.drivers import pyani
-
-from anvio.errors import ConfigError, FilesNPathsError
 import anvio.errors
-
+import anvio.fastalib as fastalib
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
+from anvio.drivers import pyani
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/compute_bayesian_pan_core.py
+++ b/anvio/cli/compute_bayesian_pan_core.py
@@ -4,10 +4,9 @@ import sys
 
 import anvio
 import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 import anvio.genomestorage as genomestorage
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import TableForItemAdditionalData

--- a/anvio/cli/compute_completeness.py
+++ b/anvio/cli/compute_completeness.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
 import anvio.dbops as dbops
+import anvio.tables as t
 import anvio.terminal as terminal
-
-from anvio.errors import ConfigError, FilesNPathsError
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.completeness import Completeness
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/compute_functional_enrichment_across_genomes.py
+++ b/anvio/cli/compute_functional_enrichment_across_genomes.py
@@ -5,9 +5,8 @@ import os
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.genomedescriptions import AggregateFunctions
 

--- a/anvio/cli/compute_functional_enrichment_in_pan.py
+++ b/anvio/cli/compute_functional_enrichment_in_pan.py
@@ -5,12 +5,10 @@ import os
 import sys
 
 import anvio
-import anvio.terminal as terminal
-import anvio.summarizer as summarizer
 import anvio.filesnpaths as filesnpaths
-
+import anvio.summarizer as summarizer
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/compute_gene_cluster_homogeneity.py
+++ b/anvio/cli/compute_gene_cluster_homogeneity.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.summarizer as summarizer
 import anvio.filesnpaths as filesnpaths
+import anvio.summarizer as summarizer
 import anvio.tables.miscdata as miscdata
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/compute_genome_similarity.py
+++ b/anvio/cli/compute_genome_similarity.py
@@ -2,14 +2,12 @@
 """A script to export a FASTA files from sequence sources and compute genome similarity matrices."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.terminal as terminal
 import anvio.genomesimilarity as genomesimilarity
-
+import anvio.terminal as terminal
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/compute_metabolic_enrichment.py
+++ b/anvio/cli/compute_metabolic_enrichment.py
@@ -4,12 +4,10 @@
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.metabolism.enrichment import KeggModuleEnrichment
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/compute_rarefaction_curves.py
+++ b/anvio/cli/compute_rarefaction_curves.py
@@ -5,10 +5,9 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
-from anvio.panops import RarefactionAnalysis
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.panops import RarefactionAnalysis
 
 __copyright__ = "Copyleft 2015-2025, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/db_info.py
+++ b/anvio/cli/db_info.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.db as db
-import anvio.tables as t
 import anvio.dbinfo as dbi
-import anvio.utils as utils
 import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/delete_collection.py
+++ b/anvio/cli/delete_collection.py
@@ -3,12 +3,10 @@
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.collections import TablesForCollections
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/delete_functions.py
+++ b/anvio/cli/delete_functions.py
@@ -3,13 +3,11 @@
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.dbops import ContigsDatabase
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.genefunctions import TableForGeneFunctions
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/delete_hmms.py
+++ b/anvio/cli/delete_hmms.py
@@ -5,11 +5,9 @@ import sys
 import anvio
 import anvio.hmmops as hmmops
 import anvio.terminal as terminal
-
+from anvio.dbops import ContigsDatabase
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.hmmhits import TablesForHMMHits
-from anvio.dbops import ContigsDatabase
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/delete_misc_data.py
+++ b/anvio/cli/delete_misc_data.py
@@ -2,14 +2,12 @@
 """Remove stuff from misc data tables"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import MiscDataTableFactory
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/delete_state.py
+++ b/anvio/cli/delete_state.py
@@ -3,12 +3,10 @@
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.states import TablesForStates
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/dereplicate_genomes.py
+++ b/anvio/cli/dereplicate_genomes.py
@@ -2,11 +2,10 @@
 """A script to remove replicated genomes from a list of internal and external genome databases or fasta files"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.genomesimilarity import Dereplicate
 

--- a/anvio/cli/display_codon_frequencies.py
+++ b/anvio/cli/display_codon_frequencies.py
@@ -4,14 +4,12 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/display_contigs_stats.py
+++ b/anvio/cli/display_contigs_stats.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 import anvio.interactive as interactive
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
-
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/display_functions.py
+++ b/anvio/cli/display_functions.py
@@ -2,16 +2,14 @@
 """A program to display the distribution of functions across genomes."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
-
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/display_metabolism.py
+++ b/anvio/cli/display_metabolism.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
-
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/display_pan.py
+++ b/anvio/cli/display_pan.py
@@ -5,16 +5,14 @@ The massage of the data is being taken care of in the interactive module,
 and this file implements the bottle callbacks."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
-
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError, HDF5Error
-
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError, HDF5Error
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/display_structure.py
+++ b/anvio/cli/display_structure.py
@@ -3,14 +3,12 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
-from anvio.bottleroutes import BottleApplication
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
+from anvio.bottleroutes import BottleApplication
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python
 DESCRIPTION = "Write KEGG pathway map files incorporating data sourced from anvi'o databases"
 
+import functools
+import importlib
 import os
 import re
 import sys
-import functools
-import importlib
-import pandas as pd
-
 from argparse import Namespace
 
+import pandas as pd
+
 import anvio.filesnpaths as filesnpaths
-
-from anvio.keggmapping import Mapper
+from anvio import A, K
+from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-from anvio import A, K, __version__ as VERSION
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.keggmapping import Mapper
 from anvio.metabolism.context import KeggContext
-
 
 __authors__ = ["semiller10"]
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/estimate_genome_completeness.py
+++ b/anvio/cli/estimate_genome_completeness.py
@@ -4,16 +4,14 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
+import anvio.filesnpaths as filesnpaths
 import anvio.genomedescriptions as genomedescriptions
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.completeness import Completeness
-from anvio.errors import ConfigError, FilesNPathsError
 from anvio.dbops import ContigsSuperclass
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/estimate_genome_size.py
+++ b/anvio/cli/estimate_genome_size.py
@@ -3,9 +3,8 @@
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 
 SOME_GENOME_SIZE = 42

--- a/anvio/cli/estimate_genome_taxonomy.py
+++ b/anvio/cli/estimate_genome_taxonomy.py
@@ -4,7 +4,6 @@ import sys
 
 from anvio.errors import ConfigError
 
-
 __description__ = ("This program has been superseded by `anvi-estimate-scg-taxonomy`")
 
 

--- a/anvio/cli/estimate_metabolic_independence.py
+++ b/anvio/cli/estimate_metabolic_independence.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
-import anvio
-import argparse
 
 import pandas as pd
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 
+import anvio
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
 from anvio.dbinfo import DBInfo as dbi
 from anvio.dbops import ContigsDatabase
 from anvio.errors import ConfigError, FilesNPathsError
-
 from anvio.metabolism.context import KeggContext
 from anvio.metabolism.estimate import KeggMetabolismEstimator
 

--- a/anvio/cli/estimate_metabolism.py
+++ b/anvio/cli/estimate_metabolism.py
@@ -3,10 +3,12 @@
 import sys
 
 import anvio
-
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.metabolism.estimate import (
+    KeggMetabolismEstimator,
+    KeggMetabolismEstimatorMulti,
+)
 from anvio.terminal import time_program
-from anvio.metabolism.estimate import KeggMetabolismEstimator, KeggMetabolismEstimatorMulti
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/estimate_scg_taxonomy.py
+++ b/anvio/cli/estimate_scg_taxonomy.py
@@ -3,11 +3,9 @@
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.taxonomyops.scg as scgtaxonomyops
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/estimate_trna_taxonomy.py
+++ b/anvio/cli/estimate_trna_taxonomy.py
@@ -4,12 +4,10 @@ import os
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 import anvio.taxonomyops.trna as trnataxonomyops
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/experimental_organization.py
+++ b/anvio/cli/experimental_organization.py
@@ -1,18 +1,16 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
+import anvio.clustering as clustering
+import anvio.constants as constants
 import anvio.dbops as dbops
 import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.clustering as clustering
-
-from anvio.errors import ConfigError, FilesNPathsError
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.clusteringconfuguration import ClusteringConfiguration
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_collection.py
+++ b/anvio/cli/export_collection.py
@@ -4,15 +4,13 @@
    Output files can directly be used by anvi-import-collection"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_contigs.py
+++ b/anvio/cli/export_contigs.py
@@ -2,16 +2,14 @@
 """A script to export a FASTA file of contigs (or splits) from a contigs database."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError, FilesNPathsError
 import anvio.errors
-
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_functions.py
+++ b/anvio/cli/export_functions.py
@@ -3,14 +3,12 @@
 import sys
 
 import anvio
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_gene_calls.py
+++ b/anvio/cli/export_gene_calls.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 
 import sys
+
 import pandas as pd
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_gene_clusters.py
+++ b/anvio/cli/export_gene_clusters.py
@@ -3,14 +3,12 @@
 import sys
 
 import anvio
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
 __copyright__ = "Copyleft 2015-2024, the Meren Lab (http://merenlab.org/)"

--- a/anvio/cli/export_gene_coverage_and_detection.py
+++ b/anvio/cli/export_gene_coverage_and_detection.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
 import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_items_order.py
+++ b/anvio/cli/export_items_order.py
@@ -5,12 +5,10 @@ import sys
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_locus.py
+++ b/anvio/cli/export_locus.py
@@ -19,13 +19,11 @@
 """
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-
-from anvio.splitter import LocusSplitter
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.splitter import LocusSplitter
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_misc_data.py
+++ b/anvio/cli/export_misc_data.py
@@ -2,13 +2,11 @@
 """Export misc data from target tables into TAB-delimited files"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import MiscDataTableFactory
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_splits_and_coverages.py
+++ b/anvio/cli/export_splits_and_coverages.py
@@ -9,16 +9,14 @@ via available parsers in anvi-populate-collections table."""
 
 import os
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_splits_taxonomy.py
+++ b/anvio/cli/export_splits_taxonomy.py
@@ -2,13 +2,11 @@
 """Takes a contigs database, and export taxonomy information from it."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.dbops as dbops
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_state.py
+++ b/anvio/cli/export_state.py
@@ -3,13 +3,11 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.states import TablesForStates
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_structures.py
+++ b/anvio/cli/export_structures.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
 import sys
+
 import anvio
-from anvio.argparse import ArgumentParser
-
-import anvio.utils as utils
 import anvio.filesnpaths as filesnpaths
-
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.structureops import StructureDatabase
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/export_table.py
+++ b/anvio/cli/export_table.py
@@ -7,14 +7,12 @@ import sys
 import pandas as pd
 
 import anvio
-import anvio.db as db
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
+import anvio.db as db
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/filter_fasta_by_blast.py
+++ b/anvio/cli/filter_fasta_by_blast.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 import sys
+
 import pandas as pd
 
 # maybe not all are needed, who is to say?
 import anvio
 import anvio.fastalib as u
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/filter_hmm_hits_table.py
+++ b/anvio/cli/filter_hmm_hits_table.py
@@ -10,9 +10,8 @@ import sys
 import anvio
 import anvio.data.hmm
 import anvio.terminal as terminal
-
-from anvio.tables.hmmhits import FilterHmmHitsTable
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.tables.hmmhits import FilterHmmHitsTable
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/find_misassemblies.py
+++ b/anvio/cli/find_misassemblies.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 import sys
-import anvio
+
+import multiprocess as multiprocessing
 import numpy as np
 
+import anvio
 import anvio.bamops as bamops
 import anvio.terminal as terminal
-import multiprocess as multiprocessing
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 

--- a/anvio/cli/fix_homopolymer_indels.py
+++ b/anvio/cli/fix_homopolymer_indels.py
@@ -5,14 +5,12 @@ import sys
 import xml.etree.ElementTree as ET
 
 import anvio
-import anvio.terminal as terminal
 import anvio.fastalib as fastalib
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
-from anvio.errors import ConfigError, FilesNPathsError
 from anvio.drivers.blast import BLAST
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_CPR_classifier.py
+++ b/anvio/cli/gen_CPR_classifier.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import random
+import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.filesnpaths as filesnpaths
-
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.learning import RF
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Tom O. Delmont"]

--- a/anvio/cli/gen_contigs_database.py
+++ b/anvio/cli/gen_contigs_database.py
@@ -5,9 +5,7 @@ import sys
 import anvio
 import anvio.dbops as dbops
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_defense_finder_models_to_hmm_directory.py
+++ b/anvio/cli/gen_defense_finder_models_to_hmm_directory.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import json
+import os
 import shutil
+import sys
 import tarfile
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/gen_distribution_of_genes_in_a_bin.py
+++ b/anvio/cli/gen_distribution_of_genes_in_a_bin.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
 import sys
+
 import numpy as numpy
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.summarizer as summarizer
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/gen_fixation_index_matrix.py
+++ b/anvio/cli/gen_fixation_index_matrix.py
@@ -4,12 +4,9 @@
 import sys
 
 import anvio
-
 from anvio.argparse import ArgumentParser
-from anvio.variabilityops import variability_engines
 from anvio.errors import ConfigError, FilesNPathsError
-from anvio.variabilityops import VariabilityFixationIndex
-
+from anvio.variabilityops import VariabilityFixationIndex, variability_engines
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_function_matrix_across_genomes.py
+++ b/anvio/cli/gen_function_matrix_across_genomes.py
@@ -5,13 +5,11 @@ import os
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 from anvio.genomedescriptions import AggregateFunctions
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_functions_per_group_stats_output.py
+++ b/anvio/cli/gen_functions_per_group_stats_output.py
@@ -2,14 +2,12 @@
 """A program to generate a functions across groups stats output."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.genomedescriptions import AggregateFunctions
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_gene_consensus_sequences.py
+++ b/anvio/cli/gen_gene_consensus_sequences.py
@@ -4,11 +4,9 @@
 import sys
 
 import anvio
-from anvio.argparse import ArgumentParser
 import anvio.variabilityops as variabilityops
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_gene_level_stats_databases.py
+++ b/anvio/cli/gen_gene_level_stats_databases.py
@@ -3,19 +3,16 @@
 
 import os
 import sys
-
 from argparse import Namespace
 
 import anvio
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.dbops as dbops
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.genelevelcoverages import TableForGeneLevelCoverages
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_genomes_file.py
+++ b/anvio/cli/gen_genomes_file.py
@@ -7,13 +7,12 @@ import sys
 from collections import Counter
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbinfo import FindAnvioDBs
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_genomes_storage.py
+++ b/anvio/cli/gen_genomes_storage.py
@@ -4,11 +4,9 @@
 import sys
 
 import anvio
-import anvio.genomestorage as genomestorage
 import anvio.genomedescriptions as genomedescriptions
-
+import anvio.genomestorage as genomestorage
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_help_pages.py
+++ b/anvio/cli/gen_help_pages.py
@@ -5,7 +5,6 @@ import sys
 import anvio
 import anvio.programs as programs
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 

--- a/anvio/cli/gen_hmm_hits_matrix_across_genomes.py
+++ b/anvio/cli/gen_hmm_hits_matrix_across_genomes.py
@@ -3,14 +3,12 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 import anvio.hmmopswrapper as hmmopswrapper
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/gen_network.py
+++ b/anvio/cli/gen_network.py
@@ -4,13 +4,11 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.dbops as dbops
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.utils import gen_gexf_network_file
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_phylogenomic_tree.py
+++ b/anvio/cli/gen_phylogenomic_tree.py
@@ -3,17 +3,15 @@
 
 import os
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-from anvio.fastalib import ReadFasta, SequenceSource
+import anvio.terminal as terminal
+from anvio.argparse import ArgumentParser
 from anvio.drivers import driver_modules
-
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
+from anvio.fastalib import ReadFasta, SequenceSource
 from anvio.utils import check_contig_names
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_programs_network.py
+++ b/anvio/cli/gen_programs_network.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.programs as programs
-
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/gen_programs_vignette.py
+++ b/anvio/cli/gen_programs_vignette.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.programs as programs
-
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/gen_pseudo_paired_reads_from_fastq.py
+++ b/anvio/cli/gen_pseudo_paired_reads_from_fastq.py
@@ -3,10 +3,9 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/gen_reads.py
+++ b/anvio/cli/gen_reads.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import math
-import random
 import bisect
+import math
+import os
+import random
+import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.fastalib as fastalib
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2026, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_scg_domain_classifier.py
+++ b/anvio/cli/gen_scg_domain_classifier.py
@@ -8,10 +8,8 @@
 import sys
 
 import anvio
-
-from anvio.scgdomainclassifier import Train
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.scgdomainclassifier import Train
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_short_reads.py
+++ b/anvio/cli/gen_short_reads.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import random
 import configparser
+import random
+import sys
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_structure_database.py
+++ b/anvio/cli/gen_structure_database.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
+
 import anvio
-from anvio.argparse import ArgumentParser
-
-import anvio.terminal as terminal
 import anvio.structureops as structops
-
+import anvio.terminal as terminal
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError, ModellerError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_user_module_file.py
+++ b/anvio/cli/gen_user_module_file.py
@@ -7,12 +7,11 @@ field can be left blank because the script can look it up.
 Users can pass the ENTRY, NAME, DEFINITION, and CLASS lines as parameters.
 """
 
-import sys
 import os
+import sys
 
 import anvio
 import anvio.utils as utils
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.metabolism.estimate import module_definition_to_enzyme_accessions

--- a/anvio/cli/gen_variability_network.py
+++ b/anvio/cli/gen_variability_network.py
@@ -2,14 +2,12 @@
 """Creates a network file for a given variability profile output"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.variabilityops import VariabilityNetwork
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/gen_variability_profile.py
+++ b/anvio/cli/gen_variability_profile.py
@@ -2,14 +2,12 @@
 """Fetches information from the variable positions table"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 from anvio.variabilityops import variability_engines
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_aa_counts.py
+++ b/anvio/cli/get_aa_counts.py
@@ -5,10 +5,8 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
-from anvio.errors import ConfigError, FilesNPathsError
 from anvio.dbops import AA_counts
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_codon_frequencies.py
+++ b/anvio/cli/get_codon_frequencies.py
@@ -2,17 +2,16 @@
 """Get codon or amino acid frequency statistics from genomes, genes, and functions."""
 
 import sys
+
 import pandas as pd
 
 import anvio
-import anvio.terminal as terminal
-import anvio.constants as constants
 import anvio.codonusage as codonusage
+import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_codon_usage_bias.py
+++ b/anvio/cli/get_codon_usage_bias.py
@@ -4,17 +4,16 @@
 
 import os
 import sys
+
 import pandas as pd
 
 import anvio
-import anvio.terminal as terminal
-import anvio.constants as constants
 import anvio.codonusage as codonusage
+import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_coverage_from_bam.py
+++ b/anvio/cli/get_coverage_from_bam.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 import sys
+
 import numpy as np
 import pandas as pd
 
 import anvio
 import anvio.bamops as bamops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 

--- a/anvio/cli/get_hmm_hits_per_gene_call.py
+++ b/anvio/cli/get_hmm_hits_per_gene_call.py
@@ -3,15 +3,13 @@
 import sys
 
 import anvio
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/get_metabolic_model_file.py
+++ b/anvio/cli/get_metabolic_model_file.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 DESCRIPTION = """This program exports a metabolic reaction network to a file suitable for flux balance analysis."""
 
-from sys import exit
 from argparse import Namespace
+from sys import exit
 
 import anvio.reactionnetwork as reactionnetwork
-
 from anvio import A, K
-from anvio.errors import ConfigError
 from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_pn_ps_ratio.py
+++ b/anvio/cli/get_pn_ps_ratio.py
@@ -9,12 +9,10 @@ import sys
 import numpy as np
 
 import anvio
-
-import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.constants as constants
+import anvio.dbops as dbops
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.variabilityops import VariabilityData

--- a/anvio/cli/get_sequences_for_gene_calls.py
+++ b/anvio/cli/get_sequences_for_gene_calls.py
@@ -4,14 +4,12 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 import anvio.genomestorage as genomestorage
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.dbops import ContigsDatabase, ContigsSuperclass
 from anvio.errors import ConfigError, FilesNPathsError
-from anvio.dbops import ContigsSuperclass, ContigsDatabase
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_sequences_for_gene_clusters.py
+++ b/anvio/cli/get_sequences_for_gene_clusters.py
@@ -3,17 +3,15 @@
 
 import os
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.summarizer as summarizer
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
+import anvio.summarizer as summarizer
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Ryan Bartelme", "Jay Osvatic"]

--- a/anvio/cli/get_sequences_for_hmm_hits.py
+++ b/anvio/cli/get_sequences_for_hmm_hits.py
@@ -37,18 +37,16 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.hmmops as hmmops
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
-import anvio.hmmopswrapper as hmmopswrapper
+import anvio.filesnpaths as filesnpaths
 import anvio.genomedescriptions as genomedescriptions
-
-from anvio.dbops import ContigsSuperclass, ContigsDatabase
+import anvio.hmmops as hmmops
+import anvio.hmmopswrapper as hmmopswrapper
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
+from anvio.dbops import ContigsDatabase, ContigsSuperclass
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_short_reads_from_bam.py
+++ b/anvio/cli/get_short_reads_from_bam.py
@@ -8,10 +8,8 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.bamops import GetReadsFromBAM
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_short_reads_mapping_to_a_gene.py
+++ b/anvio/cli/get_short_reads_mapping_to_a_gene.py
@@ -6,14 +6,12 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.dbops import ContigsSuperclass
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.bamops import ReadsMappingToARange
+from anvio.dbops import ContigsSuperclass
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_split_coverages.py
+++ b/anvio/cli/get_split_coverages.py
@@ -2,21 +2,18 @@
 """A script to export coverage values across samples of a given split in an anvi'o contigs db"""
 
 import sys
-
 from operator import itemgetter
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.dbops as dbops
-import anvio.terminal as terminal
-import anvio.summarizer as summarizer
-import anvio.filesnpaths as filesnpaths
 import anvio.auxiliarydataops as auxiliarydataops
-
-from anvio.errors import ConfigError, FilesNPathsError
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.summarizer as summarizer
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/get_tlen_dist_from_bam.py
+++ b/anvio/cli/get_tlen_dist_from_bam.py
@@ -5,7 +5,6 @@ import sys
 import anvio
 import anvio.bamops as bamops
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 

--- a/anvio/cli/help.py
+++ b/anvio/cli/help.py
@@ -3,9 +3,8 @@
 import sys
 
 import anvio
-
-from anvio.errors import ConfigError
 from anvio.argparse import ArgumentParser
+from anvio.errors import ConfigError
 from anvio.programsearch import ProgramSearch
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/hmm_to_hmm_directory.py
+++ b/anvio/cli/hmm_to_hmm_directory.py
@@ -5,10 +5,9 @@ import sys
 import time
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/import_collection.py
+++ b/anvio/cli/import_collection.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 """A script to import collections (and their colors)"""
 
-import sys
 import copy
+import sys
 from collections import Counter
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.collections import TablesForCollections
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_functions.py
+++ b/anvio/cli/import_functions.py
@@ -3,13 +3,11 @@
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
-from anvio.parsers import parser_modules
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.parsers import parser_modules
 from anvio.tables.genefunctions import TableForGeneFunctions
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_items_order.py
+++ b/anvio/cli/import_items_order.py
@@ -5,12 +5,10 @@ import sys
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_metabolite_profile.py
+++ b/anvio/cli/import_metabolite_profile.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 DESCRIPTION = """This program imports metabolite abundance data and stores it in a profile database."""
 
+from argparse import Namespace
+from sys import exit
+
 import pandas as pd
 
-from sys import exit
-from argparse import Namespace
-
 import anvio.tables as tables
-
 from anvio import A, K
-from anvio.errors import ConfigError
-from anvio.dbops import ProfileDatabase
 from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-
+from anvio.dbops import ProfileDatabase
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_misc_data.py
+++ b/anvio/cli/import_misc_data.py
@@ -2,14 +2,12 @@
 """Populate misc data tables"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import MiscDataTableFactory
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_protein_profile.py
+++ b/anvio/cli/import_protein_profile.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 DESCRIPTION = """This program imports protein abundance data into a profile database."""
 
+from argparse import Namespace
+from sys import exit
+
 import pandas as pd
 
-from sys import exit
-from argparse import Namespace
-
 import anvio.tables as tables
-
 from anvio import A, K
-from anvio.errors import ConfigError
-from anvio.dbops import ProfileDatabase
 from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-
+from anvio.dbops import ProfileDatabase
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_state.py
+++ b/anvio/cli/import_state.py
@@ -3,13 +3,11 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.states import TablesForStates
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_taxonomy_for_genes.py
+++ b/anvio/cli/import_taxonomy_for_genes.py
@@ -3,13 +3,11 @@
 import sys
 
 import anvio
+import anvio.parsers as parsers
 import anvio.tables as t
 import anvio.terminal as terminal
-import anvio.parsers as parsers
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.taxonomy import TablesForGeneLevelTaxonomy
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/import_taxonomy_for_layers.py
+++ b/anvio/cli/import_taxonomy_for_layers.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
 import anvio.parsers as parsers
+import anvio.tables as t
 import anvio.terminal as terminal
-
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.constants import levels_of_taxonomy
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import TableForLayerAdditionalData
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/init_bam.py
+++ b/anvio/cli/init_bam.py
@@ -2,15 +2,13 @@
 
 import os
 import sys
+
 import pysam
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
-from anvio.errors import FilesNPathsError
-
+import anvio.terminal as terminal
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/inspect.py
+++ b/anvio/cli/inspect.py
@@ -4,10 +4,9 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
 from anvio.errors import ConfigError, FilesNPathsError

--- a/anvio/cli/interactive.py
+++ b/anvio/cli/interactive.py
@@ -5,14 +5,13 @@ The massage of the data is being taken care of in the interactive module,
 and this file implements the bottle callbacks."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
-
 from anvio.errors import ConfigError, FilesNPathsError, GenesDBError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/matrix_to_newick.py
+++ b/anvio/cli/matrix_to_newick.py
@@ -3,13 +3,11 @@
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.clustering as clustering
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/mcg_classifier.py
+++ b/anvio/cli/mcg_classifier.py
@@ -4,12 +4,10 @@
 import sys
 
 import anvio
-import anvio.summarizer as summarizer
 import anvio.filesnpaths as filesnpaths
-
+import anvio.summarizer as summarizer
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.mcgclassifier import MetagenomeCentricGeneClassifier
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/merge.py
+++ b/anvio/cli/merge.py
@@ -2,14 +2,12 @@
 """Script to merge multiple profiles."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.merger as merger
 import anvio.constants as constants
-
+import anvio.merger as merger
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/merge_bins.py
+++ b/anvio/cli/merge_bins.py
@@ -2,15 +2,13 @@
 """Allows you to merge multiple bins in a collection"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/merge_collections.py
+++ b/anvio/cli/merge_collections.py
@@ -6,8 +6,8 @@ import os
 import sys
 
 import anvio
-import anvio.utils as u
 import anvio.terminal as terminal
+import anvio.utils as u
 from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/merge_trnaseq.py
+++ b/anvio/cli/merge_trnaseq.py
@@ -3,9 +3,8 @@
 import sys
 
 import anvio
-import anvio.trnaseq as trnaseq
 import anvio.terminal as terminal
-
+import anvio.trnaseq as trnaseq
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 

--- a/anvio/cli/meta_pan_genome.py
+++ b/anvio/cli/meta_pan_genome.py
@@ -2,14 +2,12 @@
 """Entering anvi'o metapangenomic workflow"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.metapanops as metapanops
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError, HDF5Error
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/migrate.py
+++ b/anvio/cli/migrate.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import copy
-from anvio.argparse import ArgumentParser
+import os
 import shutil
+import sys
 
 import anvio
 import anvio.db as db
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
+from anvio.errors import ConfigError, FilesNPathsError
 from anvio.migrations import migration_scripts
 from anvio.version import versions_for_db_types
-from anvio.errors import ConfigError, FilesNPathsError
-
 
 __description__ = "Migrates any anvi'o artifact, whether it is a database or a config file, to a newer version. Pure magic."
 __authors__ = ['meren', 'ozcan', 'ekiefl', 'ivagljiva', 'semiller10', 'mschecht']

--- a/anvio/cli/oligotype_linkmers.py
+++ b/anvio/cli/oligotype_linkmers.py
@@ -7,12 +7,10 @@ import sys
 from collections import Counter
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/pan_genome.py
+++ b/anvio/cli/pan_genome.py
@@ -4,12 +4,10 @@
 import sys
 
 import anvio
+import anvio.constants as constants
 import anvio.panops as panops
 import anvio.terminal as terminal
-import anvio.constants as constants
-
 from anvio.errors import ConfigError, FilesNPathsError, HDF5Error
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/permute_trnaseq_seeds.py
+++ b/anvio/cli/permute_trnaseq_seeds.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python
 
 import sys
-
-import anvio
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
 from functools import partial
 from itertools import combinations, product
 
-from anvio.dbinfo import DBInfo
+import anvio
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
+from anvio.dbinfo import DBInfo
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/pfam_accessions_to_hmms_directory.py
+++ b/anvio/cli/pfam_accessions_to_hmms_directory.py
@@ -4,10 +4,9 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/plot_trnaseq.py
+++ b/anvio/cli/plot_trnaseq.py
@@ -5,10 +5,8 @@ import sys
 
 import anvio
 import anvio.trnaseq as trnaseq
-
-from anvio.errors import ConfigError
 from anvio.argparse import ArgumentParser
-
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/predict_CPR_genomes.py
+++ b/anvio/cli/predict_CPR_genomes.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
 
+import copy
 import os
 import sys
-import copy
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
-
-from anvio.learning import RF
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.completeness import Completeness
+from anvio.dbops import ContigsSuperclass
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.hmmops import SequencesForHMMHits
-from anvio.dbops import ContigsSuperclass
-
+from anvio.learning import RF
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Tom O. Delmont"]

--- a/anvio/cli/predict_metabolic_exchanges.py
+++ b/anvio/cli/predict_metabolic_exchanges.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import sys
+
 import anvio
 import anvio.metabolicexchanges as me
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 

--- a/anvio/cli/process_genbank.py
+++ b/anvio/cli/process_genbank.py
@@ -3,10 +3,8 @@
 import sys
 
 import anvio
-
 from anvio.contigops import GenbankToAnvio
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/process_genbank_metadata.py
+++ b/anvio/cli/process_genbank_metadata.py
@@ -3,10 +3,8 @@
 import sys
 
 import anvio
-
 from anvio.contigops import GenbankToAnvioWrapper
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/profile.py
+++ b/anvio/cli/profile.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
-import anvio.profiler as profiler
+import sys
 
 import anvio
-
-from anvio.terminal import time_program
+import anvio.profiler as profiler
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/profile_blitz.py
+++ b/anvio/cli/profile_blitz.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.profiler import BAMProfilerQuick

--- a/anvio/cli/push.py
+++ b/anvio/cli/push.py
@@ -3,14 +3,13 @@
 
    Takes multiple files in, sends them to the server."""
 
-import sys
 import getpass
-from anvio.argparse import ArgumentParser
+import sys
 
 import anvio
-
-from anvio.serverAPI import AnviServerAPI
+from anvio.argparse import ArgumentParser
 from anvio.errors import AnviServerError
+from anvio.serverAPI import AnviServerAPI
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/reaction_network.py
+++ b/anvio/cli/reaction_network.py
@@ -2,14 +2,14 @@
 DESCRIPTION = """This program generates a metabolic reaction network in an anvi'o contigs or pan database"""
 
 import sys
-
 from argparse import Namespace
 
+from anvio import A as A
+from anvio import K as K
+from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-from anvio.reactionnetwork import Constructor
 from anvio.errors import ConfigError, FilesNPathsError
-from anvio import A as A, K as K, __version__ as VERSION
-
+from anvio.reactionnetwork import Constructor
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/refine.py
+++ b/anvio/cli/refine.py
@@ -6,16 +6,14 @@
 """
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.interactive as interactive
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.bottleroutes import BottleApplication
-
-from anvio.errors import ConfigError, FilesNPathsError, DictIOError
-
+from anvio.errors import ConfigError, DictIOError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/reformat_bam.py
+++ b/anvio/cli/reformat_bam.py
@@ -2,14 +2,13 @@
 
 import os
 import sys
+
 import pysam
 
-
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/reformat_fasta.py
+++ b/anvio/cli/reformat_fasta.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python
 
-import sys
 import math
 import shutil
 import statistics
+import sys
 
 import numpy as np
 import pandas as pd
 
 import anvio
-import anvio.fastalib as u
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
+import anvio.fastalib as u
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/rename_bins.py
+++ b/anvio/cli/rename_bins.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python
 
-import sys
 import copy
 import operator
+import sys
 
 import anvio
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
-
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.completeness import Completeness
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.collections import TablesForCollections
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/reorient_genomes.py
+++ b/anvio/cli/reorient_genomes.py
@@ -4,10 +4,9 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
-from anvio.genomereorientation import GenomeReorienter
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.genomereorientation import GenomeReorienter
 
 __copyright__ = "Copyleft 2015-2025, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/report_circularity.py
+++ b/anvio/cli/report_circularity.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.argparse import ArgumentParser
 from anvio.bamops import CircularityPredictor
 from anvio.errors import ConfigError, FilesNPathsError

--- a/anvio/cli/report_inversions.py
+++ b/anvio/cli/report_inversions.py
@@ -4,9 +4,8 @@ import sys
 
 import anvio
 import anvio.inversions as inversions
-
 from anvio.errors import ConfigError, FilesNPathsError
-from anvio.terminal import time_program, Run
+from anvio.terminal import Run, time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/report_linkmers.py
+++ b/anvio/cli/report_linkmers.py
@@ -7,10 +7,8 @@
 import sys
 
 import anvio
-
-from anvio.errors import ConfigError, FilesNPathsError
 from anvio.bamops import LinkMers
-
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/run_cazymes.py
+++ b/anvio/cli/run_cazymes.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.cazymes as cazymes
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 

--- a/anvio/cli/run_eggnog_mapper.py
+++ b/anvio/cli/run_eggnog_mapper.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import shutil
+import sys
 
 import anvio
 import anvio.filesnpaths as filesnpaths
-
 from anvio.drivers.emapper import EggNOGMapper
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/run_hmms.py
+++ b/anvio/cli/run_hmms.py
@@ -4,8 +4,8 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
+import anvio.utils as utils
 
 with terminal.SuppressAllOutput():
     import anvio.data.hmm as hmm_data
@@ -14,10 +14,9 @@ with terminal.SuppressAllOutput():
 available_hmm_sources = list(hmm_data.sources.keys())
 
 from anvio.errors import ConfigError, FilesNPathsError
-from anvio.terminal import time_program
 from anvio.tables.hmmhits import TablesForHMMHits
 from anvio.tables.trnahits import TablesForTransferRNAs
-
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/run_interacdome.py
+++ b/anvio/cli/run_interacdome.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.interacdome as interacdome
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 

--- a/anvio/cli/run_kegg_kofams.py
+++ b/anvio/cli/run_kegg_kofams.py
@@ -3,10 +3,9 @@
 import sys
 
 import anvio
-
-from anvio.terminal import time_program
-from anvio.metabolism.annotate import RunKOfams
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.metabolism.annotate import RunKOfams
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/run_ncbi_cogs.py
+++ b/anvio/cli/run_ncbi_cogs.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python
 
 import sys
-
 from argparse import Namespace
 
 import anvio
 import anvio.terminal as terminal
-
-from anvio.cogs import COGs
-from anvio.terminal import time_program
 from anvio.argparse import ArgumentParser
+from anvio.cogs import COGs
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/run_pfams.py
+++ b/anvio/cli/run_pfams.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.pfam as pfam
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.terminal import time_program
 

--- a/anvio/cli/run_scg_taxonomy.py
+++ b/anvio/cli/run_scg_taxonomy.py
@@ -3,11 +3,9 @@
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.taxonomyops.scg as scgtaxonomyops
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/run_trna_taxonomy.py
+++ b/anvio/cli/run_trna_taxonomy.py
@@ -3,11 +3,9 @@
 import sys
 
 import anvio
-import anvio.terminal as terminal
 import anvio.taxonomyops.trna as trnataxonomyops
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/run_workflow.py
+++ b/anvio/cli/run_workflow.py
@@ -3,11 +3,9 @@
 import sys
 
 import anvio
-import anvio.workflows as w
 import anvio.terminal as terminal
-
+import anvio.workflows as w
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/scan_trnas.py
+++ b/anvio/cli/scan_trnas.py
@@ -4,11 +4,9 @@ import sys
 
 import anvio
 import anvio.terminal as terminal
-
-from anvio.tables.trnahits import TablesForTransferRNAs
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.tables.trnahits import TablesForTransferRNAs
 from anvio.terminal import time_program
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/search_functions.py
+++ b/anvio/cli/search_functions.py
@@ -4,13 +4,11 @@
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
-from anvio.errors import ConfigError, FilesNPathsError
+import anvio.utils as utils
 from anvio.dbops import ContigsSuperclass, PanSuperclass
+from anvio.errors import ConfigError, FilesNPathsError
 from anvio.genomedescriptions import GenomeDescriptions
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/search_palindromes.py
+++ b/anvio/cli/search_palindromes.py
@@ -4,12 +4,10 @@
 import sys
 
 import anvio
-
-from anvio.terminal import time_program
 from anvio.argparse import ArgumentParser
-from anvio.sequencefeatures import Palindromes
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.sequencefeatures import Palindromes
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/search_primers.py
+++ b/anvio/cli/search_primers.py
@@ -3,7 +3,6 @@
 import sys
 
 import anvio
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.sequencefeatures import PrimerSearch
 

--- a/anvio/cli/search_sequence_motifs.py
+++ b/anvio/cli/search_sequence_motifs.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python
 
+import argparse
 import re
 import sys
-import argparse
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.utils as utils
 import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.dbinfo import DBInfo as dbi
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import TableForItemAdditionalData
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/self_test.py
+++ b/anvio/cli/self_test.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import glob
+import itertools
+import os
 import shutil
 import signal
-import itertools
 import subprocess
+import sys
 
 import anvio
-import anvio.tests as tests
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import FilesNPathsError, ConfigError
-
+import anvio.terminal as terminal
+import anvio.tests as tests
+from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/setup_cazymes.py
+++ b/anvio/cli/setup_cazymes.py
@@ -4,9 +4,7 @@ import sys
 
 import anvio
 import anvio.cazymes as cazymes
-
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/setup_interacdome.py
+++ b/anvio/cli/setup_interacdome.py
@@ -4,9 +4,7 @@ import sys
 
 import anvio
 import anvio.interacdome as interacdome
-
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/setup_kegg_data.py
+++ b/anvio/cli/setup_kegg_data.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio
-
+from anvio.errors import ConfigError, FilesNPathsError
+from anvio.metabolism.downloads import KOfamDownload, ModulesDownload
+from anvio.metabolism.setup import KeggSetup
 from anvio.terminal import time_program
 from anvio.ttycolors import color_text as c
-from anvio.errors import ConfigError, FilesNPathsError
-
-from anvio.metabolism.setup import KeggSetup
-from anvio.metabolism.downloads import KOfamDownload, ModulesDownload
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/setup_modelseed_database.py
+++ b/anvio/cli/setup_modelseed_database.py
@@ -2,17 +2,14 @@
 DESCRIPTION = """This program downloads and sets up the ModelSEED Biochemistry database."""
 
 import os
-
-from sys import exit
 from argparse import Namespace
+from sys import exit
 
 import anvio.reactionnetwork as reactionnetwork
-
 from anvio import A, K
-from anvio.errors import ConfigError
 from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/setup_ncbi_cogs.py
+++ b/anvio/cli/setup_ncbi_cogs.py
@@ -3,10 +3,8 @@
 import sys
 
 import anvio
-
 from anvio.cogs import COGsSetup
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/setup_pdb_database.py
+++ b/anvio/cli/setup_pdb_database.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
 import sys
+
 import anvio
-from anvio.argparse import ArgumentParser
-
-import anvio.terminal as terminal
 import anvio.structureops as structops
-
+import anvio.terminal as terminal
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/setup_pfams.py
+++ b/anvio/cli/setup_pfams.py
@@ -4,9 +4,7 @@ import sys
 
 import anvio
 import anvio.pfam as pfam
-
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/setup_scg_taxonomy.py
+++ b/anvio/cli/setup_scg_taxonomy.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.taxonomyops.scg as scgtaxonomyops
-
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/setup_trna_taxonomy.py
+++ b/anvio/cli/setup_trna_taxonomy.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.taxonomyops.trna as trnataxonomyops
-
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/setup_user_modules.py
+++ b/anvio/cli/setup_user_modules.py
@@ -3,10 +3,9 @@
 import sys
 
 import anvio
-
-from anvio.terminal import time_program
-from anvio.metabolism.setup import KeggSetup
 from anvio.errors import ConfigError, FilesNPathsError
+from anvio.metabolism.setup import KeggSetup
+from anvio.terminal import time_program
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/cli/show_collections_and_bins.py
+++ b/anvio/cli/show_collections_and_bins.py
@@ -5,12 +5,10 @@ of bins and collections found in it."""
 import sys
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/show_misc_data.py
+++ b/anvio/cli/show_misc_data.py
@@ -2,14 +2,12 @@
 """List misc data keys in pan or profile databases"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.tables.miscdata import MiscDataTableFactory
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/snvs_to_interactive.py
+++ b/anvio/cli/snvs_to_interactive.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 
-import sys
 import random
+import sys
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.interactive as interactive
 import anvio.filesnpaths as filesnpaths
-
+import anvio.interactive as interactive
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Tom O. Delmont"]

--- a/anvio/cli/split.py
+++ b/anvio/cli/split.py
@@ -2,14 +2,12 @@
 """Split an anvi'o profile into smaller pieces."""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
-import anvio.splitter as splitter
 import anvio.constants as constants
-
+import anvio.splitter as splitter
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/summarize.py
+++ b/anvio/cli/summarize.py
@@ -5,13 +5,11 @@ import os
 import sys
 
 import anvio
-import anvio.utils as utils
 import anvio.dbops as dbops
-import anvio.summarizer as summarizer
 import anvio.filesnpaths as filesnpaths
-
+import anvio.summarizer as summarizer
+import anvio.utils as utils
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/summarize_blitz.py
+++ b/anvio/cli/summarize_blitz.py
@@ -2,19 +2,18 @@
 """Script to quickly summarize many single profiles."""
 
 import sys
+
 import numpy as np
-from anvio.argparse import ArgumentParser
 
 import anvio
+import anvio.constants as constants
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-import anvio.constants as constants
-
+import anvio.utils as utils
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.filesnpaths import AppendableFile
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/tabulate.py
+++ b/anvio/cli/tabulate.py
@@ -3,9 +3,7 @@
 import sys
 
 import anvio
-
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/tabulate_trnaseq.py
+++ b/anvio/cli/tabulate_trnaseq.py
@@ -6,10 +6,8 @@ import sys
 
 import anvio
 import anvio.trnaseq as trnaseq
-
-from anvio.errors import ConfigError
 from anvio.argparse import ArgumentParser
-
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/transpose_matrix.py
+++ b/anvio/cli/transpose_matrix.py
@@ -4,7 +4,6 @@ import sys
 
 import anvio
 import anvio.utils as utils
-
 from anvio.errors import ConfigError, FilesNPathsError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/trnaseq.py
+++ b/anvio/cli/trnaseq.py
@@ -4,12 +4,10 @@
 import sys
 
 import anvio
-import anvio.trnaseq as trnaseq
 import anvio.trnaidentifier as trnaidentifier
-
+import anvio.trnaseq as trnaseq
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/update_db_description.py
+++ b/anvio/cli/update_db_description.py
@@ -2,13 +2,11 @@
 """A script to upgrade the description in an anvi'o db"""
 
 import sys
-from anvio.argparse import ArgumentParser
 
 import anvio
 import anvio.dbops as dbops
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/update_structure_database.py
+++ b/anvio/cli/update_structure_database.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
+
 import anvio
-from anvio.argparse import ArgumentParser
-
 import anvio.structureops as structops
-
+from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError, ModellerError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cli/variability_to_vcf.py
+++ b/anvio/cli/variability_to_vcf.py
@@ -4,23 +4,19 @@ Converts anvi'o variability output to VCF
 """
 
 
-import sys
 import datetime
+import sys
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
 
-from collections import defaultdict
-
 import anvio
-
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.argparse import ArgumentParser
 from anvio.errors import ConfigError, FilesNPathsError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/clustering.py
+++ b/anvio/clustering.py
@@ -3,20 +3,18 @@
 
 import numpy as np
 import pandas as pd
-
-from sklearn import manifold
-from sklearn import preprocessing
 from scipy.cluster import hierarchy
 from scipy.spatial import distance as scipy_distance
 from scipy.spatial.distance import pdist, squareform
+from sklearn import manifold, preprocessing
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
+
 with terminal.SuppressAllOutput():
     from ete3 import Tree
 

--- a/anvio/clusteringconfuguration.py
+++ b/anvio/clusteringconfuguration.py
@@ -1,24 +1,21 @@
 # pylint: disable=line-too-long
 """To make sense of config files for mixed clustering"""
 
-import os
 import argparse
 import configparser
+import os
 
 import anvio
 import anvio.db as db
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
 import anvio.tables as t
-
-from anvio.utils import check_sample_id
-from anvio.utils import store_array_as_TAB_delimited_file as store_array
-from anvio.utils import store_dict_as_TAB_delimited_file
-from anvio.utils import is_all_columns_present_in_TAB_delim_file as cols_present
-from anvio.utils import get_vectors_from_TAB_delim_matrix as get_vectors
+import anvio.terminal as terminal
 from anvio.errors import ConfigError
 from anvio.tables.miscdata import TableForItemAdditionalData
+from anvio.utils import check_sample_id, store_dict_as_TAB_delimited_file
+from anvio.utils import get_vectors_from_TAB_delim_matrix as get_vectors
+from anvio.utils import is_all_columns_present_in_TAB_delim_file as cols_present
+from anvio.utils import store_array_as_TAB_delimited_file as store_array
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/codonusage.py
+++ b/anvio/codonusage.py
@@ -2,25 +2,23 @@
 """Module for codon usage analyses at the levels of genes, groups of genes, and genomes"""
 
 
+import argparse
 import copy
 import inspect
-import argparse
+from collections import Counter
+from functools import partial
+
 import numpy as np
 import pandas as pd
 
-from functools import partial
-from collections import Counter
-
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.constants as constants
 import anvio.ccollections as ccollections
-
-from anvio.errors import ConfigError
+import anvio.constants as constants
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsSuperclass
+from anvio.errors import ConfigError
 from anvio.genomedescriptions import GenomeDescriptions
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -3,23 +3,22 @@
     Making sense of COGs
 """
 
-import os
-import gzip
 import glob
-import shutil
+import gzip
 import hashlib
+import os
+import shutil
 
 import anvio
-import anvio.fastalib as u
-import anvio.utils as utils
 import anvio.dbops as dbops
 import anvio.dictio as dictio
-import anvio.terminal as terminal
+import anvio.fastalib as u
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.drivers.blast import BLAST
 from anvio.drivers.diamond import Diamond
+from anvio.errors import ConfigError
 from anvio.tables.genefunctions import TableForGeneFunctions
 
 # just to make sure things don't break too far when they do:

--- a/anvio/completeness.py
+++ b/anvio/completeness.py
@@ -9,12 +9,11 @@ import argparse
 from collections import Counter
 
 import anvio
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.scgdomainclassifier as scgdomainclassifier
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError, remove_spaces
 
 with terminal.SuppressAllOutput():

--- a/anvio/constants.py
+++ b/anvio/constants.py
@@ -1,12 +1,12 @@
 # pylint: disable=line-too-long
 
-import os
-import sys
 import glob
-import numpy
+import os
 import string
-
+import sys
 from collections import Counter
+
+import numpy
 
 import anvio
 

--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -3,26 +3,29 @@
    from contigs and splits. Also includes classes to deal with external
    contig data such as GenbankToAnvio."""
 
+import argparse
+import gzip
+import io
 import os
 import re
-import io
-import gzip
-import numpy as np
 import string
-import argparse
-
-from Bio import SeqIO
 from collections import OrderedDict
 
+import numpy as np
+from Bio import SeqIO
+
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.variability import VariablityTestFactory, ProcessNucleotideCounts, ProcessCodonCounts, ProcessIndelCounts
-
+from anvio.variability import (
+    ProcessCodonCounts,
+    ProcessIndelCounts,
+    ProcessNucleotideCounts,
+    VariablityTestFactory,
+)
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ["Mike Lee", "Faruk Uzun"]

--- a/anvio/data/SSMs/__init__.py
+++ b/anvio/data/SSMs/__init__.py
@@ -1,13 +1,12 @@
 # pylint: disable=line-too-long
 """Gather data from SSMs"""
 
-import os
 import glob
+import os
 
-import anvio.utils as u
-import anvio.terminal as terminal
 import anvio.constants as constants
-
+import anvio.terminal as terminal
+import anvio.utils as u
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/data/hmm/__init__.py
+++ b/anvio/data/hmm/__init__.py
@@ -1,9 +1,8 @@
-import os
 import glob
+import os
 
-import anvio.utils as u
 import anvio.terminal as terminal
-
+import anvio.utils as u
 from anvio.terminal import pluralize as P
 
 run = terminal.Run()

--- a/anvio/data/misc/MODELLER/scripts/add_chain_identifiers_to_best_model.py
+++ b/anvio/data/misc/MODELLER/scripts/add_chain_identifiers_to_best_model.py
@@ -1,6 +1,8 @@
 # Step 5: adds chain identifier to a single model structure
 import sys
+
 from modeller import *
+
 ENV = sys.argv[1]
 NAME = sys.argv[2]
 

--- a/anvio/data/misc/MODELLER/scripts/align_to_templates.py
+++ b/anvio/data/misc/MODELLER/scripts/align_to_templates.py
@@ -5,6 +5,7 @@
 # and compare them. Then align the target sequence with this block of
 # aligned structures to generate an alignment suitable for modeling.
 import sys
+
 TARGET_PIR            = sys.argv[1]
 TARGET_ID             = sys.argv[2]
 TEMPLATE_IDS_FILE     = sys.argv[3]

--- a/anvio/data/misc/MODELLER/scripts/binarize_database.py
+++ b/anvio/data/misc/MODELLER/scripts/binarize_database.py
@@ -4,6 +4,7 @@ Positional arguments:
 2. OUTPUT - BINARY database
 """
 import sys
+
 PIR = sys.argv[1]
 BIN = sys.argv[2]
 

--- a/anvio/data/misc/MODELLER/scripts/fasta_to_pir.py
+++ b/anvio/data/misc/MODELLER/scripts/fasta_to_pir.py
@@ -4,10 +4,12 @@ Positional arguments:
 2. OUTPUT - file path of output PIR file
 """
 import sys
+
 FASTA = sys.argv[1]
 PIR = sys.argv[2]
 
 from modeller import *
+
 e = environ()
 a = alignment(e, file = FASTA, alignment_format = 'FASTA')
 a.write(file = PIR, alignment_format = 'PIR')

--- a/anvio/data/misc/MODELLER/scripts/get_model.py
+++ b/anvio/data/misc/MODELLER/scripts/get_model.py
@@ -1,5 +1,6 @@
 # Step 4: model building
 import sys
+
 ALIGNMENT          = sys.argv[1]
 TARGET_ID          = sys.argv[2]
 TEMPLATE_IDS_FILE  = sys.argv[3]
@@ -12,7 +13,7 @@ MODEL_INFO         = sys.argv[7]
 template_ids = tuple(["".join(x.strip().split("\t")) for x in open(TEMPLATE_IDS_FILE).readlines()])
 
 from modeller import *
-from modeller.automodel import *    # Load the automodel class
+from modeller.automodel import *  # Load the automodel class
 
 log.verbose()
 env = environ(rand_seed=-12312)

--- a/anvio/data/misc/MODELLER/scripts/pir_to_fasta.py
+++ b/anvio/data/misc/MODELLER/scripts/pir_to_fasta.py
@@ -4,10 +4,12 @@ Positional arguments:
 2. OUTPUT - file path of output PIR file
 """
 import sys
+
 PIR = sys.argv[1]
 FASTA = sys.argv[2]
 
 from modeller import *
+
 e = environ()
 a = alignment(e, file = PIR, alignment_format = 'PIR')
 a.write(file = FASTA, alignment_format = 'FASTA')

--- a/anvio/data/misc/MODELLER/scripts/search.py
+++ b/anvio/data/misc/MODELLER/scripts/search.py
@@ -5,6 +5,7 @@ Positional arguments:
 3. OUTPUT - Alignment table
 """
 import sys
+
 TARGET = sys.argv[1]
 DATABASE = sys.argv[2]
 ALIGNMENT_TABLE = sys.argv[3]

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -3,19 +3,19 @@
     Low-level db operations.
 """
 
-import os
-import time
 import math
-import numpy
-import pandas as pd
+import os
 import sqlite3
+import time
 import warnings
 
+import numpy
+import pandas as pd
+
 import anvio
+import anvio.filesnpaths as filesnpaths
 import anvio.tables as tables
 import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
 from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/dbinfo.py
+++ b/anvio/dbinfo.py
@@ -9,18 +9,15 @@ other to initiate interactive jobs automatically, even when no db
 parameters are provided by the user.
 """
 
-import os
 import json
-
+import os
 from abc import ABC
 
 import anvio
-
 from anvio.db import DB
 from anvio.errors import ConfigError
-from anvio.terminal import Run, Progress
+from anvio.terminal import Progress, Run
 from anvio.version import versions_for_db_types
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3,20 +3,20 @@
     Classes to create, access, and/or populate contigs, tRNASeq, and profile databases.
 """
 
+import argparse
+import copy
+import itertools
+import json
 import os
+import random
 import re
 import sys
-import time
-import copy
-import json
-import numpy
-import random
-import argparse
 import textwrap
 import threading
-import itertools
-import scipy.signal
-import pandas as pd
+import time
+from collections import Counter
+from functools import wraps
+from io import StringIO
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -25,37 +25,36 @@ import pandas as pd
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
-from io import StringIO
-from functools import wraps
-from collections import Counter
+import numpy
+import pandas as pd
+import scipy.signal
 
 import anvio
-import anvio.db as db
-import anvio.tables as t
-import anvio.fastalib as u
-import anvio.utils as utils
-import anvio.terminal as terminal
+import anvio.auxiliarydataops as auxiliarydataops
+import anvio.ccollections as ccolections
 import anvio.constants as constants
 import anvio.contigops as contigops
+import anvio.db as db
+import anvio.fastalib as u
 import anvio.filesnpaths as filesnpaths
-import anvio.ccollections as ccolections
 import anvio.genomestorage as genomestorage
-import anvio.auxiliarydataops as auxiliarydataops
 import anvio.homogeneityindex as homogeneityindex
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.dbinfo import DBInfo as dbi
 from anvio.drivers import Aligners
 from anvio.errors import ConfigError
-from anvio.dbinfo import DBInfo as dbi
-
-from anvio.tables.states import TablesForStates
-from anvio.tables.genecalls import TablesForGeneCalls
-from anvio.tables.ntpositions import TableForNtPositions
-from anvio.tables.miscdata import TableForItemAdditionalData
-from anvio.tables.miscdata import TableForLayerAdditionalData
-from anvio.tables.kmers import KMerTablesForContigsAndSplits
-from anvio.tables.genelevelcoverages import TableForGeneLevelCoverages
 from anvio.tables.contigsplitinfo import TableForContigsInfo, TableForSplitsInfo
+from anvio.tables.genecalls import TablesForGeneCalls
+from anvio.tables.genelevelcoverages import TableForGeneLevelCoverages
+from anvio.tables.kmers import KMerTablesForContigsAndSplits
+from anvio.tables.miscdata import (
+    TableForItemAdditionalData,
+    TableForLayerAdditionalData,
+)
+from anvio.tables.ntpositions import TableForNtPositions
+from anvio.tables.states import TablesForStates
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
@@ -5750,8 +5749,8 @@ def do_hierarchical_clustering_of_items(anvio_db_path, clustering_configs, split
        Ugly but useful --yet another one of those moments in which we sacrifice
        important principles for simple conveniences."""
 
-    from anvio.clusteringconfuguration import ClusteringConfiguration
     from anvio.clustering import order_contigs_simple
+    from anvio.clusteringconfuguration import ClusteringConfiguration
 
     for config_name in clustering_configs:
         config_path = clustering_configs[config_name]

--- a/anvio/dictio.py
+++ b/anvio/dictio.py
@@ -6,7 +6,6 @@ import pickle
 
 from anvio.errors import DictIOError
 
-
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
 __license__ = "GPL 3.0"

--- a/anvio/drivers/MODELLER.py
+++ b/anvio/drivers/MODELLER.py
@@ -2,21 +2,26 @@
 Interface to MODELLER (https://salilab.org/modeller/).
 """
 
-import os
-import anvio
-import shutil
 import argparse
+import os
+import shutil
 import subprocess
 
 import pandas as pd
-import anvio.utils as utils
-import anvio.fastalib as u
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
 
+import anvio
+import anvio.constants as constants
+import anvio.fastalib as u
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.drivers import diamond
-from anvio.errors import ConfigError, ModellerError, ModellerScriptError, FilesNPathsError
+from anvio.errors import (
+    ConfigError,
+    FilesNPathsError,
+    ModellerError,
+    ModellerScriptError,
+)
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/__init__.py
+++ b/anvio/drivers/__init__.py
@@ -1,15 +1,14 @@
 import sys
 
 import anvio.terminal as terminal
-
-from anvio.drivers.fasttree import FastTree
-from anvio.drivers.muscle import Muscle
-from anvio.drivers.famsa import FAMSA
-from anvio.drivers.concoct import CONCOCT
-from anvio.drivers.metabat2 import MetaBAT2
-from anvio.drivers.maxbin2 import MaxBin2
-from anvio.drivers.dastool import DAS_Tool
 from anvio.drivers.binsanity import BinSanity
+from anvio.drivers.concoct import CONCOCT
+from anvio.drivers.dastool import DAS_Tool
+from anvio.drivers.famsa import FAMSA
+from anvio.drivers.fasttree import FastTree
+from anvio.drivers.maxbin2 import MaxBin2
+from anvio.drivers.metabat2 import MetaBAT2
+from anvio.drivers.muscle import Muscle
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/drivers/binsanity.py
+++ b/anvio/drivers/binsanity.py
@@ -1,13 +1,11 @@
 """Interface to BinSanity."""
-import os
 import glob
+import os
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/blast.py
+++ b/anvio/drivers/blast.py
@@ -1,15 +1,13 @@
 """Interface to NCBI's BLAST."""
 
-import os
 import glob
+import os
 import tempfile
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/concoct.py
+++ b/anvio/drivers/concoct.py
@@ -3,9 +3,8 @@
 import os
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/drivers/dastool.py
+++ b/anvio/drivers/dastool.py
@@ -4,12 +4,10 @@
 import os
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/diamond.py
+++ b/anvio/drivers/diamond.py
@@ -1,15 +1,14 @@
 """Interface to Diamond."""
 
 import os
-import pandas as pd
 import tempfile
 
+import pandas as pd
+
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/emapper.py
+++ b/anvio/drivers/emapper.py
@@ -5,15 +5,13 @@ import sys
 import time
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
 import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.genefunctions import TableForGeneFunctions
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/famsa.py
+++ b/anvio/drivers/famsa.py
@@ -5,12 +5,10 @@ import shutil
 
 import anvio
 import anvio.fastalib as f
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/fastani.py
+++ b/anvio/drivers/fastani.py
@@ -1,17 +1,15 @@
 """Interface to fastANI."""
 
 import os
-import pandas as pd
-
 from itertools import product
 
+import pandas as pd
+
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/fasttree.py
+++ b/anvio/drivers/fasttree.py
@@ -1,12 +1,11 @@
 """Interface to FastTree."""
 
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/hmmer.py
+++ b/anvio/drivers/hmmer.py
@@ -1,8 +1,8 @@
 """Interface to HMMer."""
 
-import os
-import io
 import glob
+import io
+import os
 import shutil
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
@@ -14,12 +14,10 @@ import shutil
 import multiprocess as multiprocessing
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/maxbin2.py
+++ b/anvio/drivers/maxbin2.py
@@ -1,11 +1,10 @@
 """Interface to MaxBin2."""
-import os
 import glob
+import os
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/drivers/mcl.py
+++ b/anvio/drivers/mcl.py
@@ -3,12 +3,10 @@
 import os
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/metabat2.py
+++ b/anvio/drivers/metabat2.py
@@ -1,13 +1,11 @@
 """Interface to MetaBAT2."""
-import os
 import glob
+import os
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/muscle.py
+++ b/anvio/drivers/muscle.py
@@ -5,12 +5,10 @@ import shutil
 
 import anvio
 import anvio.fastalib as f
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/prodigal.py
+++ b/anvio/drivers/prodigal.py
@@ -8,12 +8,10 @@ import argparse
 import os
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 from anvio.threadingops import ThreadedProdigalRunner
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/drivers/pyani.py
+++ b/anvio/drivers/pyani.py
@@ -3,12 +3,10 @@
 import os
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/pyrodigal.py
+++ b/anvio/drivers/pyrodigal.py
@@ -4,12 +4,11 @@ import copy
 import multiprocessing.pool
 
 import anvio
-import anvio.fastalib as f
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
+import anvio.fastalib as f
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 try:

--- a/anvio/drivers/sourmash.py
+++ b/anvio/drivers/sourmash.py
@@ -1,19 +1,17 @@
 """Interface to sourmash"""
 
 import os
-import numpy as np
-import pandas as pd
 import shutil
 
+import numpy as np
+import pandas as pd
+from scipy.stats import entropy, kurtosis, skew
+
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from scipy.stats import entropy, skew, kurtosis
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/trnscan_se.py
+++ b/anvio/drivers/trnscan_se.py
@@ -1,12 +1,10 @@
 """An interface for tRNAScan-SE"""
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/drivers/vmatch.py
+++ b/anvio/drivers/vmatch.py
@@ -2,10 +2,10 @@
 """An interface for Vmatch"""
 
 import os
-import time
 import queue
 import shutil
-import pandas as pd
+import time
+from collections import defaultdict
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -14,16 +14,13 @@ import pandas as pd
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
-from collections import defaultdict
+import pandas as pd
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/fastalib.py
+++ b/anvio/fastalib.py
@@ -2,10 +2,10 @@
 # v.140713
 """A very lightweight FASTA I/O library"""
 
-import io
-import sys
 import gzip
 import hashlib
+import io
+import sys
 
 import anvio
 

--- a/anvio/filesnpaths.py
+++ b/anvio/filesnpaths.py
@@ -1,22 +1,18 @@
 # pylint: disable=line-too-long
 """File/Path operations"""
 
-import os
 import json
-import time
+import os
 import shutil
 import tarfile
 import tempfile
+import time
 
 import anvio
-import anvio.fastalib as u
 import anvio.constants as constants
-
-from anvio.terminal import Run
-from anvio.terminal import Progress
-from anvio.terminal import SuppressAllOutput
+import anvio.fastalib as u
 from anvio.errors import FilesNPathsError
-
+from anvio.terminal import Progress, Run, SuppressAllOutput
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/genecalling.py
+++ b/anvio/genecalling.py
@@ -6,14 +6,11 @@
 import shutil
 
 import anvio
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
-
+import anvio.terminal as terminal
 from anvio.drivers.prodigal import Prodigal
 from anvio.drivers.pyrodigal import Pyrodigal_gv
-
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -7,25 +7,22 @@
     Ad hoc access to make sense of internal or external genome descriptions is also welcome.
 """
 
-import os
-import sys
+import argparse
 import copy
 import hashlib
-import argparse
-
+import os
+import sys
 from collections import Counter
 
 import anvio
-import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
+import anvio.db as db
+import anvio.dbops as dbops
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/genomereorientation.py
+++ b/anvio/genomereorientation.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python
 """Reorient circular genomes to match a reference genome coordinate system."""
 
-import os
 import gzip
+import os
 import shutil
-
 from pathlib import Path
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.drivers.hmmer import HMMer
-from anvio.genecalling import GeneCaller
 from anvio.errors import ConfigError, FilesNPathsError
-
+from anvio.genecalling import GeneCaller
 
 __copyright__ = "Copyleft 2015-2025, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/genomesimilarity.py
+++ b/anvio/genomesimilarity.py
@@ -1,26 +1,24 @@
 #!/usr/bin/env python
 """Code for genome similarity calculation"""
 
+import argparse
 import os
 import shutil
-import argparse
+from itertools import combinations
+
 import pandas as pd
 
 import anvio
-import anvio.db as db
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.constants as constants
 import anvio.clustering as clustering
+import anvio.constants as constants
+import anvio.db as db
 import anvio.filesnpaths as filesnpaths
 import anvio.genomedescriptions as genomedescriptions
-
-from itertools import combinations
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.drivers import fastani, pyani, sourmash
 from anvio.errors import ConfigError
-from anvio.drivers import pyani, sourmash, fastani
-from anvio.tables.miscdata import TableForLayerAdditionalData
-from anvio.tables.miscdata import TableForLayerOrders
+from anvio.tables.miscdata import TableForLayerAdditionalData, TableForLayerOrders
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/genomestorage.py
+++ b/anvio/genomestorage.py
@@ -7,19 +7,17 @@
     Ad hoc access to make sene of internal or external genome descriptions is also welcome.
 """
 
-import time
 import hashlib
+import time
 
 import anvio
 import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
 import anvio.fastalib as fastalib
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/hmmops.py
+++ b/anvio/hmmops.py
@@ -11,11 +11,10 @@ from scipy import stats
 
 import anvio
 import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/hmmopswrapper.py
+++ b/anvio/hmmopswrapper.py
@@ -6,14 +6,11 @@
 import argparse
 import hashlib
 
-import anvio.terminal as terminal
 import anvio.ccollections as ccollections
-
+import anvio.terminal as terminal
+from anvio.errors import ConfigError
 from anvio.genomedescriptions import GenomeDescriptions
 from anvio.hmmops import SequencesForHMMHits
-
-
-from anvio.errors import ConfigError
 
 
 class SequencesForHMMHitsWrapperForMultipleContigs(SequencesForHMMHits, GenomeDescriptions):

--- a/anvio/homogeneityindex.py
+++ b/anvio/homogeneityindex.py
@@ -4,10 +4,8 @@
 """
 
 import anvio
-
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/interacdome.py
+++ b/anvio/interacdome.py
@@ -15,26 +15,25 @@ References
   47: 582-593.
 """
 
-import anvio
-import anvio.pfam as pfam
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.tables as tables
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
-
-from anvio.pfam import Pfam
-from anvio.errors import ConfigError
-from anvio.parsers import parser_modules
-from anvio.drivers.hmmer import HMMer
-
+import argparse
 import os
 import shutil
-import argparse
+
 import numpy as np
 import pandas as pd
 
+import anvio
+import anvio.constants as constants
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.pfam as pfam
+import anvio.tables as tables
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.drivers.hmmer import HMMer
+from anvio.errors import ConfigError
+from anvio.parsers import parser_modules
+from anvio.pfam import Pfam
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1,43 +1,51 @@
 # pylint: disable=line-too-long
 """The module that curates data for the interactive interface"""
 
+import argparse
+import copy
 import os
 import sys
-import copy
-import numpy
-import argparse
 import textwrap
+
+import numpy
 import pandas as pd
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.dbops as dbops
-import anvio.hmmops as hmmops
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.summarizer as summarizer
-import anvio.clustering as clustering
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
+import anvio.clustering as clustering
+import anvio.constants as constants
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.hmmops as hmmops
 import anvio.structureops as structureops
+import anvio.summarizer as summarizer
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 import anvio.variabilityops as variabilityops
-
-from anvio.completeness import Completeness
-from anvio.dbops import get_description_in_db
-from anvio.tables.views import TablesForViews
-from anvio.variabilityops import VariabilitySuper
-from anvio.variabilityops import variability_engines
-from anvio.dbops import get_default_item_order_name
-from anvio.genomedescriptions import AggregateFunctions
-from anvio.tables.collections import TablesForCollections
-from anvio.metabolism.estimate import KeggMetabolismEstimator
-from anvio.errors import ConfigError, RefineError, GenesDBError
 from anvio.clusteringconfuguration import ClusteringConfiguration
-from anvio.dbops import ProfileSuperclass, ContigsSuperclass, PanSuperclass, TablesForStates, ProfileDatabase
-from anvio.tables.miscdata import TableForItemAdditionalData, TableForLayerAdditionalData
-from anvio.tables.miscdata import TableForLayerOrders, TableForAminoAcidAdditionalData
-
+from anvio.completeness import Completeness
+from anvio.dbops import (
+    ContigsSuperclass,
+    PanSuperclass,
+    ProfileDatabase,
+    ProfileSuperclass,
+    TablesForStates,
+    get_default_item_order_name,
+    get_description_in_db,
+)
+from anvio.errors import ConfigError, GenesDBError, RefineError
+from anvio.genomedescriptions import AggregateFunctions
+from anvio.metabolism.estimate import KeggMetabolismEstimator
+from anvio.tables.collections import TablesForCollections
+from anvio.tables.miscdata import (
+    TableForAminoAcidAdditionalData,
+    TableForItemAdditionalData,
+    TableForLayerAdditionalData,
+    TableForLayerOrders,
+)
+from anvio.tables.views import TablesForViews
+from anvio.variabilityops import VariabilitySuper, variability_engines
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
@@ -900,8 +908,8 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         # some mode specific imports
         from collections import Counter
 
-        from anvio.dbinfo import DBInfo
         import anvio.codonusage as codonusage
+        from anvio.dbinfo import DBInfo
 
         # these are all going to be filled later nicely.
         self.p_meta['item_orders'] = {}

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -1,12 +1,11 @@
 # pylint: disable=line-too-long
 """A module to characterize Florian's inversions"""
 
-import os
-import copy
 import argparse
-import numpy as np
+import copy
+import os
 import xml.etree.ElementTree as ET
-from collections import OrderedDict, Counter
+from collections import Counter, OrderedDict
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -15,24 +14,21 @@ from collections import OrderedDict, Counter
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
-
+import numpy as np
 
 import anvio
-import anvio.tables as t
+import anvio.auxiliarydataops as auxiliarydataops
+import anvio.bamops as bamops
 import anvio.dbinfo as dbi
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.bamops as bamops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-import anvio.auxiliarydataops as auxiliarydataops
-
-from anvio.errors import ConfigError
-from anvio.summaryhtml import SummaryHTMLOutput
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.artifacts.samples_txt import SamplesTxt
+from anvio.errors import ConfigError
 from anvio.sequencefeatures import Palindromes, PrimerSearch
-
+from anvio.summaryhtml import SummaryHTMLOutput
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -1,38 +1,36 @@
 #!/usr/bin/env python
 """Make KEGG pathway maps incorporating data sourced from anvi'o databases."""
 
-import os
-import re
-import fitz
+import functools
 import json
 import math
+import os
+import re
 import shutil
-import functools
-import numpy as np
-import pandas as pd
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-import matplotlib.colors as mcolors
-
 from argparse import Namespace
 from itertools import combinations
 from typing import Dict, Iterable, List, Literal, Set, Tuple, Union
 
-import anvio.kgml as kgml
-import anvio.utils as utils
-import anvio.dbinfo as dbinfo
-import anvio.terminal as terminal
-import anvio.reactionnetwork as rn
-import anvio.filesnpaths as filesnpaths
+import fitz
+import matplotlib as mpl
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 
+import anvio.dbinfo as dbinfo
+import anvio.filesnpaths as filesnpaths
+import anvio.kgml as kgml
+import anvio.reactionnetwork as rn
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio import FORCE_OVERWRITE, QUIET
+from anvio import __version__ as VERSION
+from anvio.dbops import ContigsDatabase, PanSuperclass
 from anvio.errors import ConfigError
 from anvio.genomestorage import GenomeStorage
-from anvio.dbops import ContigsDatabase, PanSuperclass
-from anvio import FORCE_OVERWRITE, QUIET, __version__ as VERSION
-
-from anvio.metabolism.context import KeggContext
 from anvio.metabolism.constants import GLOBAL_MAP_ID_PATTERN, OVERVIEW_MAP_ID_PATTERN
-
+from anvio.metabolism.context import KeggContext
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
 __copyright__ = "Copyleft 2015-2024, the Meren Lab (http://merenlab.org/)"

--- a/anvio/kgml.py
+++ b/anvio/kgml.py
@@ -16,26 +16,24 @@ from __future__ import annotations
 import os
 import re
 import uuid
-import numpy as np
 import xml.etree.ElementTree as ET
-
-from io import StringIO
 from argparse import Namespace
-from Bio.KEGG.KGML import KGML_parser
-from Bio.Graphics.KGML_vis import KGMLCanvas
-from matplotlib.colors import Colormap, rgb2hex
-
+from io import StringIO
 from typing import Dict, Iterable, List, Literal, Tuple, Union
 
+import numpy as np
+from Bio.Graphics.KGML_vis import KGMLCanvas
+from Bio.KEGG.KGML import KGML_parser
+from matplotlib.colors import Colormap, rgb2hex
+
 import anvio.terminal as terminal
-
+from anvio import FORCE_OVERWRITE
+from anvio import __version__ as VERSION
 from anvio.errors import ConfigError
-from anvio import FORCE_OVERWRITE, __version__ as VERSION
 from anvio.filesnpaths import is_file_exists, is_output_file_writable
-
+from anvio.metabolism.constants import GLOBAL_MAP_ID_PATTERN, OVERVIEW_MAP_ID_PATTERN
 from anvio.metabolism.context import KeggContext
 from anvio.metabolism.downloads import download_org_pathway_image_files
-from anvio.metabolism.constants import GLOBAL_MAP_ID_PATTERN, OVERVIEW_MAP_ID_PATTERN
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
 __copyright__ = "Copyleft 2015-2024, the Meren Lab (http://merenlab.org/)"

--- a/anvio/kgmlnetworkops.py
+++ b/anvio/kgmlnetworkops.py
@@ -1,20 +1,20 @@
 import os
 import sys
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Literal, Union
+
 import pandas as pd
 
-from copy import deepcopy
-from argparse import Namespace
-from typing import Any, Literal, Union
-from dataclasses import dataclass, field
-
-import anvio.metabolism.context as kcontext
 import anvio.kgml as kgml
-import anvio.terminal as terminal
+import anvio.metabolism.context as kcontext
 import anvio.reactionnetwork as rn
-
-from anvio.dbops import ContigsDatabase
+import anvio.terminal as terminal
 from anvio.argparse import ArgumentParser
+from anvio.dbops import ContigsDatabase
 from anvio.errors import ConfigError, FilesNPathsError
+
 
 @dataclass
 class Chain:

--- a/anvio/kmers.py
+++ b/anvio/kmers.py
@@ -5,13 +5,10 @@
 """
 
 import itertools
-
 from collections import Counter
 
 import anvio
-
 from anvio.constants import complements
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/learning.py
+++ b/anvio/learning.py
@@ -2,13 +2,13 @@
 """A simple module with classes for learning operations"""
 
 import pickle
+
 import numpy as np
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 with terminal.SuppressAllOutput():

--- a/anvio/mcgclassifier.py
+++ b/anvio/mcgclassifier.py
@@ -7,23 +7,25 @@
 
 
 import os
-import anvio
+
+import matplotlib
 import numpy as np
 import pandas as pd
-import matplotlib
+
+import anvio
+
 # TODO: according to the warning, this call to set the back-hand is meaningless
 # I need to experiment to see what happens if I delete it.
 matplotlib.use('pdf')
-import anvio.utils as utils
 import matplotlib.pyplot as plt
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
-from scipy import odr as odr
-from anvio.mcgops import MCGPlots
-from anvio.errors import ConfigError, FilesNPathsError
 from matplotlib.backends.backend_pdf import PdfPages
+from scipy import odr as odr
 
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.errors import ConfigError, FilesNPathsError
+from anvio.mcgops import MCGPlots
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/mcgops.py
+++ b/anvio/mcgops.py
@@ -6,11 +6,12 @@
 """
 
 import os
-import anvio
-import numpy as np
-import matplotlib.pyplot as plt
-import anvio.terminal as terminal
 
+import matplotlib.pyplot as plt
+import numpy as np
+
+import anvio
+import anvio.terminal as terminal
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/merger.py
+++ b/anvio/merger.py
@@ -4,25 +4,23 @@
 The default client of this library is under bin/anvi-merge"""
 
 
+import argparse
 import gc
 import os
-import argparse
 
 import anvio
+import anvio.auxiliarydataops as auxiliarydataops
+import anvio.clustering as clustering
+import anvio.constants as constants
 import anvio.db as db
-import anvio.utils as utils
 import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
 import anvio.tables as tables
 import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.clustering as clustering
-import anvio.filesnpaths as filesnpaths
-import anvio.auxiliarydataops as auxiliarydataops
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.tables.miscdata import TableForLayerOrders, TableForLayerAdditionalData
+from anvio.tables.miscdata import TableForLayerAdditionalData, TableForLayerOrders
 from anvio.tables.views import TablesForViews
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/metabolicexchanges.py
+++ b/anvio/metabolicexchanges.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python
 """This file contains classes for predicting metabolic exchanges via the reaction network and KGML processing subsystems."""
 
+import multiprocessing
 import os
 import sys
-import multiprocessing
-from copy import deepcopy
 from argparse import Namespace
 from collections import defaultdict
+from copy import deepcopy
 
 import anvio
+import anvio.filesnpaths as filesnpaths
 import anvio.kgml as kgml
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.kgmlnetworkops as nw
 import anvio.reactionnetwork as rn
-import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsDatabase
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.genomedescriptions import GenomeDescriptions

--- a/anvio/metabolism/algorithms.py
+++ b/anvio/metabolism/algorithms.py
@@ -7,9 +7,8 @@ import statistics
 from scipy import stats
 
 import anvio
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.metabolism.constants import STRAY_KO_ANVIO_SUFFIX
 

--- a/anvio/metabolism/annotate.py
+++ b/anvio/metabolism/annotate.py
@@ -2,18 +2,16 @@ import os
 import shutil
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
-from anvio.drivers.hmmer import HMMer
-from anvio.parsers import parser_modules
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsDatabase, ContigsSuperclass
-from anvio.tables.genefunctions import TableForGeneFunctions
-
+from anvio.drivers.hmmer import HMMer
+from anvio.errors import ConfigError
 from anvio.metabolism.context import KeggContext
 from anvio.metabolism.modulesdb import ModulesDatabase
+from anvio.parsers import parser_modules
+from anvio.tables.genefunctions import TableForGeneFunctions
 
 
 class RunKOfams(KeggContext):

--- a/anvio/metabolism/context.py
+++ b/anvio/metabolism/context.py
@@ -1,9 +1,8 @@
-import os
 import collections
+import os
 
 import anvio
 import anvio.utils as utils
-
 from anvio.errors import ConfigError
 
 

--- a/anvio/metabolism/dbaccess.py
+++ b/anvio/metabolism/dbaccess.py
@@ -4,19 +4,21 @@
 import pandas as pd
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
-
+import anvio.filesnpaths as filesnpaths
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbinfo import DBInfo
 from anvio.errors import ConfigError
-
+from anvio.metabolism.constants import (
+    DEFAULT_OUTPUT_MODE,
+    OUTPUT_HEADERS,
+    OUTPUT_MODES,
+    STRAY_KO_ANVIO_SUFFIX,
+)
 from anvio.metabolism.context import KeggContext
 from anvio.metabolism.modulesdb import ModulesDatabase
-from anvio.metabolism.constants import DEFAULT_OUTPUT_MODE, OUTPUT_MODES, OUTPUT_HEADERS, STRAY_KO_ANVIO_SUFFIX
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"
@@ -482,7 +484,9 @@ class KeggDataLoader(KeggContext):
                                  f"purposes of estimating metabolism.")
 
         self.progress.update('Loading gene call data from contigs DB')
-        from anvio.dbops import ContigsDatabase # <- import here to avoid circular import
+        from anvio.dbops import (
+            ContigsDatabase,  # <- import here to avoid circular import
+        )
         contigs_db = ContigsDatabase(contigs_db_path, run=self.run, progress=self.progress)
 
         split_list = ','.join(["'%s'" % split_name for split_name in splits_to_use])
@@ -581,7 +585,7 @@ class KeggDataLoader(KeggContext):
             (enzyme_accession, gene_cluster_id, split, contig) tuples in which split and contig are both NAs
         """
 
-        from anvio.dbops import PanSuperclass # <- import here to avoid circular import
+        from anvio.dbops import PanSuperclass  # <- import here to avoid circular import
 
         pan_super = PanSuperclass(self.args)
         pan_super.init_gene_clusters(gene_cluster_ids_to_focus = gene_cluster_list)

--- a/anvio/metabolism/downloads.py
+++ b/anvio/metabolism/downloads.py
@@ -1,26 +1,24 @@
-import os
-import re
 import glob
 import json
-import time
-import shutil
-import pandas as pd
 import multiprocessing as mp
+import os
+import re
+import shutil
+import time
 from typing import Dict, List, Tuple, Union
 
-import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
+import pandas as pd
 
-from anvio.errors import ConfigError
-from anvio.parsers import parser_modules
+import anvio
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.drivers.hmmer import HMMer
 from anvio.drivers.muscle import Muscle
-
+from anvio.errors import ConfigError
+from anvio.metabolism.constants import GLOBAL_MAP_ID_PATTERN, STRAY_KO_ANVIO_SUFFIX
 from anvio.metabolism.setup import KeggSetup
-from anvio.metabolism.constants import STRAY_KO_ANVIO_SUFFIX, GLOBAL_MAP_ID_PATTERN
-
+from anvio.parsers import parser_modules
 
 run_quiet = terminal.Run(log_file_path=None, verbose=False)
 progress_quiet = terminal.Progress(verbose=False)

--- a/anvio/metabolism/enrichment.py
+++ b/anvio/metabolism/enrichment.py
@@ -1,13 +1,11 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 from anvio.metabolism.context import KeggContext
 
 

--- a/anvio/metabolism/estimate.py
+++ b/anvio/metabolism/estimate.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python
 """Main KEGG metabolism estimator classes."""
 
-import os
-import re
 import copy
 import json
-import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-import anvio.ccollections as ccollections
+import os
+import re
 
+import anvio
+import anvio.ccollections as ccollections
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbinfo import DBInfo
 from anvio.errors import ConfigError
-from anvio.genomedescriptions import MetagenomeDescriptions, GenomeDescriptions
-
-from anvio.metabolism.modulesdb import ModulesDatabase
+from anvio.genomedescriptions import GenomeDescriptions, MetagenomeDescriptions
 from anvio.metabolism.algorithms import KeggEstimationAlgorithms
-from anvio.metabolism.dbaccess import KeggEstimatorArgs, KeggDataLoader
-from anvio.metabolism.constants import OUTPUT_MODES, MODULE_METADATA_HEADERS, KO_METADATA_HEADERS, STEP_METADATA_HEADERS
+from anvio.metabolism.constants import (
+    KO_METADATA_HEADERS,
+    MODULE_METADATA_HEADERS,
+    OUTPUT_MODES,
+    STEP_METADATA_HEADERS,
+)
+from anvio.metabolism.dbaccess import KeggDataLoader, KeggEstimatorArgs
+from anvio.metabolism.modulesdb import ModulesDatabase
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"
@@ -239,7 +243,9 @@ class KeggMetabolismEstimator(KeggEstimatorArgs, KeggDataLoader, KeggEstimationA
             utils.is_contigs_db(self.contigs_db_path)
             # here we load the contigs DB just for sanity check purposes.
             # We will need to load it again later just before accessing data to avoid SQLite error that comes from different processes accessing the DB
-            from anvio.dbops import ContigsDatabase # <- import here to avoid circular import
+            from anvio.dbops import (
+                ContigsDatabase,  # <- import here to avoid circular import
+            )
             contigs_db = ContigsDatabase(self.contigs_db_path, run=self.run, progress=self.progress)
             self.contigs_db_project_name = contigs_db.meta['project_name']
         elif self.enzymes_txt:
@@ -249,7 +255,9 @@ class KeggMetabolismEstimator(KeggEstimatorArgs, KeggDataLoader, KeggEstimationA
         elif self.estimate_from_json:
             self.contigs_db_project_name = "json_input"
         elif self.pan_db_path:
-            from anvio.dbops import PanDatabase # <- import here to avoid circular import
+            from anvio.dbops import (
+                PanDatabase,  # <- import here to avoid circular import
+            )
             pan_db = PanDatabase(self.pan_db_path, run=self.run, progress=self.progress)
             self.contigs_db_project_name = pan_db.meta['project_name']
         else:
@@ -485,7 +493,9 @@ class KeggMetabolismEstimator(KeggEstimatorArgs, KeggDataLoader, KeggEstimationA
             if not self.profile_db:
                 self.args.skip_consider_gene_dbs = True
 
-                from anvio.dbops import ProfileSuperclass # <- import here to avoid circular import
+                from anvio.dbops import (
+                    ProfileSuperclass,  # <- import here to avoid circular import
+                )
                 self.profile_db = ProfileSuperclass(self.args)
 
             self.coverage_sample_list = self.profile_db.p_meta['samples']

--- a/anvio/metabolism/modulesdb.py
+++ b/anvio/metabolism/modulesdb.py
@@ -1,20 +1,18 @@
-import re
-import os
 import copy
-import json
-import time
 import hashlib
+import json
+import os
+import re
+import time
 
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.terminal import pluralize as P
-
 from anvio.metabolism.context import KeggContext
+from anvio.terminal import pluralize as P
 
 
 class ModulesDatabase(KeggContext):

--- a/anvio/metabolism/setup.py
+++ b/anvio/metabolism/setup.py
@@ -1,20 +1,18 @@
+import glob
 import os
 import re
-import glob
 import shutil
 
 import anvio
 import anvio.db as db
-import anvio.utils as utils
 import anvio.filesnpaths as filesnpaths
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.version import versions_for_db_types
-from anvio.terminal import pluralize as P
-
 from anvio.metabolism.context import KeggContext
 from anvio.metabolism.modulesdb import ModulesDatabase
+from anvio.terminal import pluralize as P
+from anvio.version import versions_for_db_types
 
 
 class KeggSetup(KeggContext):

--- a/anvio/metapanops.py
+++ b/anvio/metapanops.py
@@ -9,14 +9,15 @@ import numpy as numpy
 
 import anvio
 import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.summarizer as summarizer
 import anvio.genomedescriptions as genomedescriptions
-
+import anvio.summarizer as summarizer
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.tables.miscdata import TableForLayerAdditionalData, TableForItemAdditionalData
-
+from anvio.tables.miscdata import (
+    TableForItemAdditionalData,
+    TableForLayerAdditionalData,
+)
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/migrations/__init__.py
+++ b/anvio/migrations/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-import os
 import importlib
+import os
 from pathlib import Path
 
 migration_scripts = {}

--- a/anvio/migrations/config/v0_to_v1.py
+++ b/anvio/migrations/config/v0_to_v1.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import json
 import argparse
+import json
+import sys
 
 import anvio
-import anvio.workflows as w
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.workflows as w
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/config/v1_to_v2.py
+++ b/anvio/migrations/config/v1_to_v2.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import json
 import argparse
+import json
+import sys
 
 import anvio
-import anvio.workflows as w
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.workflows as w
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/config/v2_to_v3.py
+++ b/anvio/migrations/config/v2_to_v3.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import json
 import argparse
+import json
+import sys
 
 import anvio
-import anvio.workflows as w
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.workflows as w
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/config/v3_to_v4.py
+++ b/anvio/migrations/config/v3_to_v4.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import json
 import argparse
+import json
+import sys
 
 import anvio
-import anvio.workflows as w
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.workflows as w
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/config/v4_to_v5.py
+++ b/anvio/migrations/config/v4_to_v5.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import json
 import argparse
+import json
+import sys
 
 import anvio
-import anvio.workflows as w
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.workflows as w
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v10_to_v11.py
+++ b/anvio/migrations/contigs/v10_to_v11.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version = "10"

--- a/anvio/migrations/contigs/v11_to_v12.py
+++ b/anvio/migrations/contigs/v11_to_v12.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v12_to_v13.py
+++ b/anvio/migrations/contigs/v12_to_v13.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v13_to_v14.py
+++ b/anvio/migrations/contigs/v13_to_v14.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v14_to_v15.py
+++ b/anvio/migrations/contigs/v14_to_v15.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v15_to_v16.py
+++ b/anvio/migrations/contigs/v15_to_v16.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
+
 import numpy as np
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v16_to_v17.py
+++ b/anvio/migrations/contigs/v16_to_v17.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v17_to_v18.py
+++ b/anvio/migrations/contigs/v17_to_v18.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v18_to_v19.py
+++ b/anvio/migrations/contigs/v18_to_v19.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v19_to_v20.py
+++ b/anvio/migrations/contigs/v19_to_v20.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v20_to_v21.py
+++ b/anvio/migrations/contigs/v20_to_v21.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v21_to_v22.py
+++ b/anvio/migrations/contigs/v21_to_v22.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v22_to_v23.py
+++ b/anvio/migrations/contigs/v22_to_v23.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/contigs/v23_to_v24.py
+++ b/anvio/migrations/contigs/v23_to_v24.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
-import argparse
+
 import pandas as pd
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.reactionnetwork import ModelSEEDDatabase
 

--- a/anvio/migrations/contigs/v5_to_v6.py
+++ b/anvio/migrations/contigs/v5_to_v6.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/contigs/v6_to_v7.py
+++ b/anvio/migrations/contigs/v6_to_v7.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/contigs/v7_to_v8.py
+++ b/anvio/migrations/contigs/v7_to_v8.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/contigs/v8_to_v9.py
+++ b/anvio/migrations/contigs/v8_to_v9.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
 import anvio.dbops as dbops
+import anvio.tables as t
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/contigs/v9_to_v10.py
+++ b/anvio/migrations/contigs/v9_to_v10.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
+import argparse
+import gzip
 import os
 import sys
-import gzip
-import argparse
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version = "9"

--- a/anvio/migrations/genes/v4_to_v5.py
+++ b/anvio/migrations/genes/v4_to_v5.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/genes/v5_to_v6.py
+++ b/anvio/migrations/genes/v5_to_v6.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/genomestorage/v3_to_v4.py
+++ b/anvio/migrations/genomestorage/v3_to_v4.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 current_version = '3'
 next_version    = '4'

--- a/anvio/migrations/genomestorage/v4_to_v5.py
+++ b/anvio/migrations/genomestorage/v4_to_v5.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
 import time
-import argparse
 
 import anvio.db as db
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 current_version = '4'
 next_version    = '5'

--- a/anvio/migrations/genomestorage/v5_to_v6.py
+++ b/anvio/migrations/genomestorage/v5_to_v6.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
+
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version = '5'

--- a/anvio/migrations/genomestorage/v6_to_v7.py
+++ b/anvio/migrations/genomestorage/v6_to_v7.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/genomestorage/v7_to_v8.py
+++ b/anvio/migrations/genomestorage/v7_to_v8.py
@@ -6,12 +6,11 @@ migration. In Python 3, h5py returns bytes for string data. The v4-to-v5 script
 called str() on those bytes values, producing literal 'b"..."' or "b'...'" text
 in the database instead of clean strings."""
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/modules/v1_to_v2.py
+++ b/anvio/migrations/modules/v1_to_v2.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
 import re
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/modules/v2_to_v3.py
+++ b/anvio/migrations/modules/v2_to_v3.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
 import re
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/modules/v3_to_v4.py
+++ b/anvio/migrations/modules/v3_to_v4.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]
 

--- a/anvio/migrations/pan/v10_to_v11.py
+++ b/anvio/migrations/pan/v10_to_v11.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v11_to_v12.py
+++ b/anvio/migrations/pan/v11_to_v12.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v12_to_v13.py
+++ b/anvio/migrations/pan/v12_to_v13.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v13_to_v14.py
+++ b/anvio/migrations/pan/v13_to_v14.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/pan/v14_to_v15.py
+++ b/anvio/migrations/pan/v14_to_v15.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/pan/v15_to_v16.py
+++ b/anvio/migrations/pan/v15_to_v16.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/pan/v16_to_v17.py
+++ b/anvio/migrations/pan/v16_to_v17.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/pan/v17_to_v18.py
+++ b/anvio/migrations/pan/v17_to_v18.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/pan/v18_to_v19.py
+++ b/anvio/migrations/pan/v18_to_v19.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/pan/v19_to_v20.py
+++ b/anvio/migrations/pan/v19_to_v20.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
-import argparse
+
 import pandas as pd
 
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 from anvio.reactionnetwork import ModelSEEDDatabase
 

--- a/anvio/migrations/pan/v20_to_v21.py
+++ b/anvio/migrations/pan/v20_to_v21.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/pan/v4_to_v5.py
+++ b/anvio/migrations/pan/v4_to_v5.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v5_to_v6.py
+++ b/anvio/migrations/pan/v5_to_v6.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v6_to_v7.py
+++ b/anvio/migrations/pan/v6_to_v7.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v7_to_v8.py
+++ b/anvio/migrations/pan/v7_to_v8.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import shutil
-import tempfile
 import argparse
+import os
+import shutil
+import sys
+import tempfile
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/pan/v8_to_v9.py
+++ b/anvio/migrations/pan/v8_to_v9.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/pan/v9_to_v10.py
+++ b/anvio/migrations/pan/v9_to_v10.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
+
 from ete3 import Tree
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v13_to_v14.py
+++ b/anvio/migrations/profile/v13_to_v14.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v14_to_v15.py
+++ b/anvio/migrations/profile/v14_to_v15.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import sys
-import argparse
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.dictio as dictio
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v15_to_v16.py
+++ b/anvio/migrations/profile/v15_to_v16.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v16_to_v17.py
+++ b/anvio/migrations/profile/v16_to_v17.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v17_to_v18.py
+++ b/anvio/migrations/profile/v17_to_v18.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v18_to_v19.py
+++ b/anvio/migrations/profile/v18_to_v19.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v19_to_v20.py
+++ b/anvio/migrations/profile/v19_to_v20.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v20_to_v21.py
+++ b/anvio/migrations/profile/v20_to_v21.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v21_to_v22.py
+++ b/anvio/migrations/profile/v21_to_v22.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
+import argparse
+import gzip
 import os
 import sys
-import gzip
 import time
-import argparse
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version = "21"

--- a/anvio/migrations/profile/v22_to_v23.py
+++ b/anvio/migrations/profile/v22_to_v23.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import shutil
-import tempfile
 import argparse
+import os
+import shutil
+import sys
+import tempfile
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v23_to_v24.py
+++ b/anvio/migrations/profile/v23_to_v24.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v24_to_v25.py
+++ b/anvio/migrations/profile/v24_to_v25.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
-from anvio.errors import ConfigError
+import anvio.utils as utils
 from anvio.constants import codons
+from anvio.errors import ConfigError
 
 run = terminal.Run()
 progress = terminal.Progress()

--- a/anvio/migrations/profile/v25_to_v26.py
+++ b/anvio/migrations/profile/v25_to_v26.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v26_to_v27.py
+++ b/anvio/migrations/profile/v26_to_v27.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
+
 from ete3 import Tree
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v27_to_v28.py
+++ b/anvio/migrations/profile/v27_to_v28.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v28_to_v29.py
+++ b/anvio/migrations/profile/v28_to_v29.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v29_to_v30.py
+++ b/anvio/migrations/profile/v29_to_v30.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v30_to_v31.py
+++ b/anvio/migrations/profile/v30_to_v31.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v31_to_v32.py
+++ b/anvio/migrations/profile/v31_to_v32.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v32_to_v33.py
+++ b/anvio/migrations/profile/v32_to_v33.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v33_to_v34.py
+++ b/anvio/migrations/profile/v33_to_v34.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/profile/v34_to_v35.py
+++ b/anvio/migrations/profile/v34_to_v35.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v35_to_v36.py
+++ b/anvio/migrations/profile/v35_to_v36.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v36_to_v37.py
+++ b/anvio/migrations/profile/v36_to_v37.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v37_to_v38.py
+++ b/anvio/migrations/profile/v37_to_v38.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v38_to_v39.py
+++ b/anvio/migrations/profile/v38_to_v39.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
-
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v39_to_v40.py
+++ b/anvio/migrations/profile/v39_to_v40.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v40_to_v41.py
+++ b/anvio/migrations/profile/v40_to_v41.py
@@ -16,13 +16,12 @@ The entire operation is wrapped in a single SQLite transaction so that a crash a
 leaves the database unchanged.
 """
 
+import argparse
 import re
 import sys
-import argparse
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/profile/v41_to_v42.py
+++ b/anvio/migrations/profile/v41_to_v42.py
@@ -19,12 +19,11 @@ The entire operation is wrapped in a single SQLite transaction so that a crash
 at any point leaves the database unchanged.
 """
 
-import sys
 import argparse
+import sys
 
 import anvio.dbinfo as dbinfo
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]

--- a/anvio/migrations/structure/v1_to_v2.py
+++ b/anvio/migrations/structure/v1_to_v2.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
 import anvio.db as db
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 
 run = terminal.Run()

--- a/anvio/migrations/trnaseq/v1_to_v2.py
+++ b/anvio/migrations/trnaseq/v1_to_v2.py
@@ -4,9 +4,7 @@ import argparse
 
 import anvio.db as db
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
-
 
 current_version, next_version = [x[1:] for x in __name__.split('_to_')]
 

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -5,16 +5,13 @@
     anvi-pan-genome is the default client using this module
 """
 
-import os
+import argparse
+import copy
 import json
 import math
-import copy
-import argparse
-import numpy as np
-import pandas as pd
-
+import os
 from itertools import chain
-from scipy.optimize import curve_fit
+
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
 # goes like this:
@@ -22,22 +19,23 @@ from scipy.optimize import curve_fit
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
+import numpy as np
+import pandas as pd
+from scipy.optimize import curve_fit
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.dbops as dbops
-import anvio.terminal as terminal
-import anvio.constants as constants
 import anvio.clustering as clustering
+import anvio.constants as constants
+import anvio.dbops as dbops
 import anvio.filesnpaths as filesnpaths
+import anvio.tables as t
 import anvio.tables.miscdata as miscdata
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.drivers import Aligners
 from anvio.drivers.blast import BLAST
 from anvio.drivers.diamond import Diamond
 from anvio.drivers.mcl import MCL
-from anvio.drivers import Aligners
-
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.genomestorage import GenomeStorage
 from anvio.tables.geneclusters import TableForGeneClusters
@@ -201,8 +199,8 @@ class RarefactionAnalysis:
     def store_results_as_svg(self):
         """Stores a nice visualization of the rarefaction curves"""
 
-        import seaborn as sns
         import matplotlib.pyplot as plt
+        import seaborn as sns
 
         # Generate fitted values for plotting
         x_fit = np.linspace(1, self.num_genomes, 100)

--- a/anvio/parsers/__init__.py
+++ b/anvio/parsers/__init__.py
@@ -2,18 +2,15 @@
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
-
-from anvio.parsers.krakenuniq import KrakenUniq
-from anvio.parsers.defaultmatrix import DefaultMatrix
-from anvio.parsers.centrifuge import Centrifuge
-from anvio.parsers.kaiju import Kaiju
-from anvio.parsers.hmmer import HMMERTableOutput, HMMERStandardOutput
-from anvio.parsers.concoct import CONCOCT
-from anvio.parsers.interproscan import InterProScan
 from anvio.parsers.agnostos import AGNOSTOS
-
+from anvio.parsers.centrifuge import Centrifuge
+from anvio.parsers.concoct import CONCOCT
+from anvio.parsers.defaultmatrix import DefaultMatrix
+from anvio.parsers.hmmer import HMMERStandardOutput, HMMERTableOutput
+from anvio.parsers.interproscan import InterProScan
+from anvio.parsers.kaiju import Kaiju
+from anvio.parsers.krakenuniq import KrakenUniq
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/agnostos.py
+++ b/anvio/parsers/agnostos.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 
 import os
+
 import pandas as pd
 
 import anvio
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError
 from anvio.parsers.base import Parser
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/base.py
+++ b/anvio/parsers/base.py
@@ -2,16 +2,14 @@
     Base class for parsers to take care of the boring stuff.
 """
 
-import os
 import hashlib
+import os
 
 import anvio.terminal as terminal
-
-from anvio.errors import ConfigError, StupidHMMError
 from anvio.constants import levels_of_taxonomy
-from anvio.utils import get_TAB_delimited_file_as_dictionary as get_dict
+from anvio.errors import ConfigError, StupidHMMError
 from anvio.utils import get_FASTA_file_as_dictionary as get_dict_f
-
+from anvio.utils import get_TAB_delimited_file_as_dictionary as get_dict
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/centrifuge.py
+++ b/anvio/parsers/centrifuge.py
@@ -4,10 +4,7 @@ from collections import Counter
 
 import anvio
 import anvio.terminal as terminal
-
-from anvio.parsers.base import Parser
-from anvio.parsers.base import TaxonomyHelper
-
+from anvio.parsers.base import Parser, TaxonomyHelper
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/concoct.py
+++ b/anvio/parsers/concoct.py
@@ -6,7 +6,6 @@
 
 from anvio.parsers.base import Parser
 
-
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
 __license__ = "GPL 3.0"

--- a/anvio/parsers/defaultmatrix.py
+++ b/anvio/parsers/defaultmatrix.py
@@ -2,11 +2,8 @@
 
 import anvio
 import anvio.terminal as terminal
-
-from anvio.parsers.base import Parser
-from anvio.parsers.base import TaxonomyHelper
 from anvio.constants import levels_of_taxonomy
-
+from anvio.parsers.base import Parser, TaxonomyHelper
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/hmmer.py
+++ b/anvio/parsers/hmmer.py
@@ -1,16 +1,15 @@
 """Parser for HMMER's various outputs"""
 
-import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-
-from anvio.errors import ConfigError
-from anvio.parsers.base import Parser
-
 import os
+
 import numpy as np
 import pandas as pd
 
+import anvio
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.errors import ConfigError
+from anvio.parsers.base import Parser
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/hmmscan.py
+++ b/anvio/parsers/hmmscan.py
@@ -1,15 +1,13 @@
 """Parser for HMMER's various outputs"""
 
-import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
-
-from anvio.errors import ConfigError
-from anvio.parsers.base import Parser
-
 import numpy as np
 import pandas as pd
 
+import anvio
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.errors import ConfigError
+from anvio.parsers.base import Parser
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/interproscan.py
+++ b/anvio/parsers/interproscan.py
@@ -5,7 +5,6 @@ import pandas as pd
 import anvio
 from anvio.parsers.base import Parser
 
-
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
 __license__ = "GPL 3.0"

--- a/anvio/parsers/kaiju.py
+++ b/anvio/parsers/kaiju.py
@@ -4,14 +4,11 @@ import os
 import random
 
 import anvio
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError
-from anvio.parsers.base import Parser
-from anvio.parsers.base import TaxonomyHelper
-
+from anvio.parsers.base import Parser, TaxonomyHelper
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/parsers/krakenuniq.py
+++ b/anvio/parsers/krakenuniq.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
 import anvio
-import anvio.terminal as terminal
 import anvio.constants as constants
-
+import anvio.terminal as terminal
 from anvio.parsers.base import Parser
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/pfam.py
+++ b/anvio/pfam.py
@@ -1,28 +1,26 @@
 #!/usr/bin/env python
 """This file contains PfamSetup and Pfam classes."""
 
-import anvio
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
-from anvio.drivers.hmmer import HMMer
-from anvio.parsers import parser_modules
-from anvio.errors import ConfigError
-from anvio.tables.genefunctions import TableForGeneFunctions
-
-import os
+import glob
 import gzip
+import os
+import shutil
+from io import BytesIO
+
 import numpy as np
 import pandas as pd
-import shutil
 import requests
-import glob
-
-from io import BytesIO
 from scipy.stats import entropy
 
+import anvio
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.drivers.hmmer import HMMer
+from anvio.errors import ConfigError
+from anvio.parsers import parser_modules
+from anvio.tables.genefunctions import TableForGeneFunctions
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -1,15 +1,10 @@
 # pylint: disable=line-too-long
 """Provides the necessary class to profile BAM files."""
 
-import gc
-import os
-import sys
-import copy
-import json
-import queue
-import shutil
 import argparse
-import numpy as np
+import copy
+import gc
+import json
 
 # We use TWO multiprocessing libraries:
 #
@@ -25,30 +20,33 @@ import numpy as np
 # This combination works because Process uses fork() on Linux/macOS, so Queue objects
 # are inherited by child processes rather than serialized.
 import multiprocessing as stdlib_multiprocessing
-import multiprocess as multiprocessing
-
+import os
+import queue
+import shutil
+import sys
 from collections import OrderedDict
 
-import anvio
-import anvio.db as db
-import anvio.tables as t
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.bamops as bamops
-import anvio.terminal as terminal
-import anvio.contigops as contigops
-import anvio.constants as constants
-import anvio.clustering as clustering
-import anvio.filesnpaths as filesnpaths
-import anvio.auxiliarydataops as auxiliarydataops
+import multiprocess as multiprocessing
+import numpy as np
 
+import anvio
+import anvio.auxiliarydataops as auxiliarydataops
+import anvio.bamops as bamops
+import anvio.clustering as clustering
+import anvio.constants as constants
+import anvio.contigops as contigops
+import anvio.db as db
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.tables.views import TablesForViews
+from anvio.tables.codonfrequencies import TableForCodonFrequencies
 from anvio.tables.indels import TableForIndels
 from anvio.tables.miscdata import TableForLayerAdditionalData
 from anvio.tables.variability import TableForVariability
-from anvio.tables.codonfrequencies import TableForCodonFrequencies
-
+from anvio.tables.views import TablesForViews
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
@@ -297,8 +295,8 @@ class SharedDataStore:
     @classmethod
     def from_existing(cls, shm_name, index, mode='bytes'):
         """Attach to an existing shared memory segment (for use in workers)."""
-        from multiprocessing.shared_memory import SharedMemory
         from multiprocessing import resource_tracker
+        from multiprocessing.shared_memory import SharedMemory
 
         obj = cls.__new__(cls)
         obj.mode = mode

--- a/anvio/programs.py
+++ b/anvio/programs.py
@@ -1,25 +1,22 @@
 # pylint: disable=line-too-long
 """A library to help anvi'o describe itself"""
 
+import argparse
+import copy
+import importlib
+import json
 import os
 import sys
-import json
-import copy
-import argparse
-import importlib
-
 from collections import Counter
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.authors import AnvioAuthors
 from anvio.docs import ANVIO_ARTIFACTS, ANVIO_WORKFLOWS, THIRD_PARTY_PROGRAMS
+from anvio.errors import ConfigError
 from anvio.summaryhtml import SummaryHTMLOutput
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/programsearch.py
+++ b/anvio/programsearch.py
@@ -3,21 +3,19 @@
 
 import sys
 import textwrap
-import pandas as pd
-
 from itertools import groupby
 from operator import itemgetter
-from colored import Fore, Back, Style
+
+import pandas as pd
+from colored import Back, Fore, Style
 
 import anvio
-import anvio.programs as p
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.terminal import tabulate
+import anvio.programs as p
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
+from anvio.terminal import tabulate
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/reactionnetwork.py
+++ b/anvio/reactionnetwork.py
@@ -3,45 +3,45 @@
 
 from __future__ import annotations
 
-import os
-import re
-import glob
-import json
-import math
-import time
-import random
-import shutil
-import hashlib
-import tarfile
-import zipfile
 import argparse
-import tempfile
+import collections
 import fractions
 import functools
-import collections
+import glob
+import hashlib
+import json
+import math
+import multiprocessing as mp
+import os
+import random
+import re
+import shutil
+import tarfile
+import tempfile
+import time
+import zipfile
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Set, Tuple, Union
+
 import numpy as np
 import pandas as pd
-import multiprocessing as mp
 
-from copy import deepcopy
-from argparse import Namespace
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Set, Tuple, Union, Iterable
-
-import anvio.utils as utils
 import anvio.dbinfo as dbinfo
+import anvio.filesnpaths as filesnpaths
 import anvio.tables as tables
 import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
+import anvio.utils as utils
+from anvio import DEBUG
+from anvio import __file__ as ANVIO_PATH
+from anvio import __version__ as VERSION
 from anvio.db import DB
-from anvio.errors import ConfigError
-from anvio import DEBUG, __file__ as ANVIO_PATH, __version__ as VERSION
 from anvio.dbops import ContigsDatabase, PanDatabase, PanSuperclass, ProfileDatabase
-
+from anvio.errors import ConfigError
 from anvio.metabolism.context import KeggContext
-from anvio.metabolism.modulesdb import ModulesDatabase
 from anvio.metabolism.downloads import _download_worker
+from anvio.metabolism.modulesdb import ModulesDatabase
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
 __copyright__ = "Copyleft 2015-2024, the Meren Lab (http://merenlab.org/)"

--- a/anvio/samplesops.py
+++ b/anvio/samplesops.py
@@ -3,12 +3,10 @@
 
 import os
 
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import SamplesError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/scgdomainclassifier.py
+++ b/anvio/scgdomainclassifier.py
@@ -1,20 +1,19 @@
 # pylint: disable=line-too-long
 
-import os
 import glob
-import random
 import itertools
+import os
+import random
 from collections import Counter
 
 import anvio
 import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.learning import RF
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
+from anvio.learning import RF
 
 with terminal.SuppressAllOutput():
     import anvio.data.hmm as hmm_data

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -2,10 +2,13 @@
 
 """Classes for sequence properties and manipulations"""
 
-import gc
 import functools
+import gc
 import itertools
-import numpy as np
+from collections import defaultdict
+from hashlib import sha1
+from itertools import groupby
+from operator import itemgetter
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -14,18 +17,12 @@ import numpy as np
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
-from hashlib import sha1
-from itertools import groupby
-from operator import itemgetter
-from collections import defaultdict
+import numpy as np
 
 import anvio
-import anvio.terminal as terminal
 import anvio.constants as constants
-
+import anvio.terminal as terminal
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/sequencefeatures.py
+++ b/anvio/sequencefeatures.py
@@ -2,26 +2,24 @@
 
 """Classes to deal with sequence features"""
 
+import argparse
+import copy
 import os
 import re
-import copy
-import argparse
 import subprocess
 import xml.etree.ElementTree as ET
 
+import IlluminaUtils.lib.fastqlib as u
 from numba import jit
 from numba.typed import List
 
 import anvio
-import anvio.utils as utils
 import anvio.dbops as dbops
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.artifacts.samples_txt import SamplesTxt
-import IlluminaUtils.lib.fastqlib as u
-
+from anvio.errors import ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/serverAPI.py
+++ b/anvio/serverAPI.py
@@ -1,10 +1,11 @@
 """A simple anvi'server API."""
 
 import json
+
 import requests
 
-from anvio.terminal import Run
 from anvio.errors import AnviServerError
+from anvio.terminal import Run
 
 run = Run()
 

--- a/anvio/sge.py
+++ b/anvio/sge.py
@@ -1,21 +1,19 @@
 # pylint: disable=line-too-long
 """Module to submit/track jobs for SUN Grid Engine"""
 
-import os
-import time
 import glob
+import os
 import random
 import string
 import subprocess
+import time
 
 import anvio
 import anvio.fastalib as u
-import anvio.utils as utils
 import anvio.filesnpaths as filesnpaths
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.terminal import pretty_print as pp
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -4,36 +4,33 @@
 The default client of this library is under bin/anvi-split"""
 
 
+import argparse
+import copy
 import os
 import sys
-import copy
-import argparse
-
 from collections import Counter
 
 import anvio
+import anvio.auxiliarydataops as auxiliarydataops
+import anvio.ccollections as ccollections
+import anvio.clustering as clustering
+import anvio.constants as constants
 import anvio.db as db
-import anvio.tables as t
 import anvio.dbops as dbops
-import anvio.utils as utils
+import anvio.filesnpaths as filesnpaths
 import anvio.hmmops as hmmops
 import anvio.profiler as profiler
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.clustering as clustering
 import anvio.summarizer as summarizer
-import anvio.filesnpaths as filesnpaths
-import anvio.ccollections as ccollections
-import anvio.auxiliarydataops as auxiliarydataops
-
-from anvio.panops import Pangenome
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.clusteringconfuguration import ClusteringConfiguration
 from anvio.errors import ConfigError
-from anvio.tables.views import TablesForViews
-from anvio.tables.kmers import KMerTablesForContigsAndSplits
+from anvio.panops import Pangenome
 from anvio.tables.collections import TablesForCollections
 from anvio.tables.genefunctions import TableForGeneFunctions
-from anvio.clusteringconfuguration import ClusteringConfiguration
-
+from anvio.tables.kmers import KMerTablesForContigsAndSplits
+from anvio.tables.views import TablesForViews
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -2,14 +2,12 @@
 
 """Classes to make sense of genes and variability within the context of protein structure"""
 
-import os
-import time
-import numpy as np
-import shutil
-import pandas as pd
-import sqlite3
-import warnings
 import datetime
+import os
+import shutil
+import sqlite3
+import time
+import warnings
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -18,26 +16,27 @@ import datetime
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
+import numpy as np
+import pandas as pd
 from Bio.PDB import DSSP, PDBParser
 
 import anvio
-import anvio.db as db
-import anvio.utils as utils
-import anvio.dbops as dbops
-import anvio.tables as t
-import anvio.fastalib as u
-import anvio.terminal as terminal
 import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
+import anvio.db as db
+import anvio.dbops as dbops
 import anvio.drivers.MODELLER as MODELLER
-
-from anvio.errors import ConfigError, FilesNPathsError
+import anvio.fastalib as u
+import anvio.filesnpaths as filesnpaths
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsSuperclass
+from anvio.errors import ConfigError, FilesNPathsError
 
 J = lambda x, y: os.path.join(x, y)
 
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
+
 warnings.simplefilter(action='ignore', category=PDBConstructionWarning)
 
 
@@ -382,7 +381,8 @@ class StructureSuperclass(object):
             params_dict = self.structure_db.get_run_params_dict()
             for param, value in params_dict.items():
                 self.run.info(param, value)
-            import sys; sys.exit()
+            import sys
+            sys.exit()
 
         # Determine the modeller parameters and store in db
         # NOTE self.skip_DSSP is down here because get_modeller_params has the potential to

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -23,34 +23,37 @@ import anvio.summarizer as summarizer
 
 """
 
+import argparse
+import gzip
 import os
 import sys
-import gzip
-import numpy
-import mistune
-import argparse
 import textwrap
-import pandas as pd
-
 from collections import Counter
 
+import mistune
+import numpy
+import pandas as pd
+
 import anvio
-import anvio.utils as utils
-import anvio.hmmops as hmmops
-import anvio.sequence as seqlib
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
 import anvio.ccollections as ccollections
 import anvio.completeness as completeness
+import anvio.constants as constants
+import anvio.filesnpaths as filesnpaths
+import anvio.hmmops as hmmops
+import anvio.sequence as seqlib
 import anvio.taxonomyops.scg as scgtaxonomyops
-
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.dbops import (
+    ContigsDatabase,
+    ContigsSuperclass,
+    DatabasesMetaclass,
+    PanSuperclass,
+)
 from anvio.errors import ConfigError
-from anvio.dbops import DatabasesMetaclass, ContigsDatabase, ContigsSuperclass, PanSuperclass
 from anvio.hmmops import SequencesForHMMHits
 from anvio.summaryhtml import SummaryHTMLOutput, humanize_n, pretty
-from anvio.tables.miscdata import TableForLayerAdditionalData, MiscDataTableFactory
-
+from anvio.tables.miscdata import MiscDataTableFactory, TableForLayerAdditionalData
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/summaryhtml.py
+++ b/anvio/summaryhtml.py
@@ -1,15 +1,14 @@
 # pylint: disable=line-too-long
 """Creates an HTML output to act as a front-end for the static summary directory."""
 
-import os
-import json
-import zlib
 import base64
+import json
+import os
 import shutil
+import zlib
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 
 # get django imported
@@ -42,8 +41,8 @@ try:
     except:
         pass
 
-    from django.template.loader import render_to_string
     from django.template.defaultfilters import register
+    from django.template.loader import render_to_string
 except ImportError:
     raise ConfigError('You need to have Django module (http://djangoproject.com) installed on your system to generate HTML output.')
 

--- a/anvio/synteny.py
+++ b/anvio/synteny.py
@@ -7,16 +7,15 @@ to analyze conserved genes and synteny structures across loci.
 """
 
 import sys
-import pandas as pd
-
 from collections import Counter
 
+import pandas as pd
+
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 import anvio.genomestorage as genomestorage
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import PanDatabase
 from anvio.errors import ConfigError
 

--- a/anvio/tables/__init__.py
+++ b/anvio/tables/__init__.py
@@ -1,9 +1,14 @@
 # pylint: disable=line-too-long
 """ Table schemas for databases."""
 
-from anvio.constants import codons, nucleotides, essential_genome_info, TRNA_FEATURE_NAMES
-
 import itertools
+
+from anvio.constants import (
+    TRNA_FEATURE_NAMES,
+    codons,
+    essential_genome_info,
+    nucleotides,
+)
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/codonfrequencies.py
+++ b/anvio/tables/codonfrequencies.py
@@ -3,11 +3,9 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/collections.py
+++ b/anvio/tables/collections.py
@@ -7,12 +7,10 @@ from itertools import chain
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/contigsplitinfo.py
+++ b/anvio/tables/contigsplitinfo.py
@@ -3,9 +3,8 @@
 
 import anvio
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -1,21 +1,20 @@
 # pylint: disable=line-too-long
 
 import os
+
 import numpy
 
 import anvio
-import anvio.db as db
-import anvio.tables as t
-import anvio.fastalib as u
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
+import anvio.db as db
+import anvio.fastalib as u
 import anvio.filesnpaths as filesnpaths
 import anvio.genecalling as genecalling
-
-from anvio.tables.tableops import Table
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
+from anvio.tables.tableops import Table
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/geneclusters.py
+++ b/anvio/tables/geneclusters.py
@@ -5,11 +5,9 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/genefunctions.py
+++ b/anvio/tables/genefunctions.py
@@ -3,12 +3,10 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/genelevelcoverages.py
+++ b/anvio/tables/genelevelcoverages.py
@@ -5,12 +5,10 @@ import numpy as np
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
-from anvio.tables.tableops import Table
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
+from anvio.tables.tableops import Table
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -1,30 +1,28 @@
 # pylint: disable=line-too-long
 
-import os
-import sys
 import gzip
-import shutil
 import hashlib
+import os
+import shutil
+import sys
+
 import pandas as pd
 
 import anvio
-import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.hmmops as hmmops
-import anvio.terminal as terminal
 import anvio.constants as constants
+import anvio.db as db
 import anvio.filesnpaths as filesnpaths
-
+import anvio.hmmops as hmmops
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.dbops import ContigsDatabase, ContigsSuperclass
 from anvio.drivers.hmmer import HMMer
-from anvio.tables.tableops import Table
-from anvio.dbops import ContigsDatabase
-from anvio.parsers import parser_modules
-from anvio.dbops import ContigsSuperclass
 from anvio.errors import ConfigError, StupidHMMError
+from anvio.parsers import parser_modules
 from anvio.tables.genecalls import TablesForGeneCalls
 from anvio.tables.genefunctions import TableForGeneFunctions
-
+from anvio.tables.tableops import Table
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/indels.py
+++ b/anvio/tables/indels.py
@@ -3,11 +3,9 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/kmers.py
+++ b/anvio/tables/kmers.py
@@ -7,7 +7,6 @@ import anvio
 import anvio.kmers as kmers
 import anvio.terminal as terminal
 
-
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
 __license__ = "GPL 3.0"

--- a/anvio/tables/miscdata.py
+++ b/anvio/tables/miscdata.py
@@ -2,18 +2,16 @@
 
 """The fancy additioanl data module"""
 
-import anvio
-import anvio.db as db
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError, GenesDBError
-from anvio.tables.tableops import Table
-
 import pandas as pd
 
+import anvio
+import anvio.db as db
+import anvio.filesnpaths as filesnpaths
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.errors import ConfigError, GenesDBError
+from anvio.tables.tableops import Table
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/ntpositions.py
+++ b/anvio/tables/ntpositions.py
@@ -4,9 +4,8 @@ import numpy
 
 import anvio
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/scgtaxonomy.py
+++ b/anvio/tables/scgtaxonomy.py
@@ -3,12 +3,10 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/states.py
+++ b/anvio/tables/states.py
@@ -5,12 +5,10 @@ import datetime
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
-from anvio.tables.tableops import Table
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
+from anvio.tables.tableops import Table
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/tableops.py
+++ b/anvio/tables/tableops.py
@@ -7,11 +7,9 @@ import os
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/taxonomy.py
+++ b/anvio/tables/taxonomy.py
@@ -5,13 +5,11 @@ from collections import Counter
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
-from anvio.tables.tableops import Table
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.genecalls import GenesInSplits
-
+from anvio.tables.tableops import Table
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/trnahits.py
+++ b/anvio/tables/trnahits.py
@@ -6,21 +6,18 @@
 
 import os
 import shutil
-
 from collections import Counter
 
 import anvio
-import anvio.utils as utils
+import anvio.constants as constants
+import anvio.drivers.trnscan_se as trnascan_se
+import anvio.filesnpaths as filesnpaths
 import anvio.hmmops as hmmops
 import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
-import anvio.drivers.trnscan_se as trnascan_se
-
+import anvio.utils as utils
 from anvio.errors import ConfigError
-from anvio.tables.hmmhits import TablesForHMMHits
 from anvio.tables.genefunctions import TableForGeneFunctions
-
+from anvio.tables.hmmhits import TablesForHMMHits
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/trnataxonomy.py
+++ b/anvio/tables/trnataxonomy.py
@@ -3,13 +3,11 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
+from anvio.constants import anticodon_to_AA
 from anvio.errors import ConfigError
 from anvio.tables.tableops import Table
-
-from anvio.constants import anticodon_to_AA
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/variability.py
+++ b/anvio/tables/variability.py
@@ -3,11 +3,9 @@
 import anvio
 import anvio.db as db
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tables/views.py
+++ b/anvio/tables/views.py
@@ -2,13 +2,11 @@
 
 import anvio
 import anvio.tables as t
-import anvio.utils as utils
 import anvio.terminal as terminal
-
+import anvio.utils as utils
 from anvio.dbops import DBClassFactory
 from anvio.errors import ConfigError
 from anvio.tables.tableops import Table
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/taxonomyops/__init__.py
+++ b/anvio/taxonomyops/__init__.py
@@ -3,14 +3,13 @@
     Common functions and classes for SCG/TRNA taxonomy.
 """
 
+import argparse
+import copy
+import gzip
+import hashlib
 import os
 import sys
-import gzip
-import copy
-import hashlib
-import argparse
-import numpy as np
-import pandas as pd
+from collections import Counter, OrderedDict
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
 # using the multiprocessing module directly results in a pickling error in Python 3.10 which
@@ -19,25 +18,29 @@ import pandas as pd
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
-from collections import OrderedDict, Counter
+import numpy as np
+import pandas as pd
 
 import anvio
-import anvio.tables as t
-import anvio.utils as utils
-import anvio.hmmops as hmmops
-import anvio.terminal as terminal
+import anvio.ccollections as ccollections
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-import anvio.ccollections as ccollections
-
-from anvio.errors import ConfigError
+import anvio.hmmops as hmmops
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
+from anvio.dbops import (
+    ContigsDatabase,
+    ContigsSuperclass,
+    ProfileDatabase,
+    ProfileSuperclass,
+)
 from anvio.drivers.blast import BLAST
 from anvio.drivers.diamond import Diamond
+from anvio.errors import ConfigError
+from anvio.tables.miscdata import TableForLayerAdditionalData
 from anvio.tables.scgtaxonomy import TableForSCGTaxonomy
 from anvio.tables.trnataxonomy import TableForTRNATaxonomy
-from anvio.tables.miscdata import TableForLayerAdditionalData
-from anvio.dbops import ContigsSuperclass, ContigsDatabase, ProfileSuperclass, ProfileDatabase
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -4,26 +4,27 @@ Classes to setup remote SCG databases in local, use local databases to affiliate
 contigs databases with taxon names, and estimate taxonomy for genomes and metagenomes.
 """
 
-import os
 import copy
+import os
 import shutil
+
 import pandas as pd
 import scipy.sparse as sps
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsDatabase, ContigsSuperclass
 from anvio.drivers.diamond import Diamond
+from anvio.errors import ConfigError
 from anvio.genomedescriptions import GenomeDescriptions, MetagenomeDescriptions
-
-from anvio.taxonomyops import AccessionIdToTaxonomy
-from anvio.taxonomyops import TaxonomyEstimatorSingle
-from anvio.taxonomyops import PopulateContigsDatabaseWithTaxonomy
+from anvio.taxonomyops import (
+    AccessionIdToTaxonomy,
+    PopulateContigsDatabaseWithTaxonomy,
+    TaxonomyEstimatorSingle,
+)
 
 run_quiet = terminal.Run(log_file_path=None, verbose=False)
 progress_quiet = terminal.Progress(verbose=False)
@@ -1186,7 +1187,8 @@ class SetupLocalSCGTaxonomyData(SCGTaxonomyArgs, SanityCheck):
 
             # then, we will have to copy all relevant files from the anvi'o source directory to
             # the new setup database
-            import shutil, glob
+            import glob
+            import shutil
             shutil.copy(ctx.accession_to_taxonomy_file_path, self.SCGs_taxonomy_data_dir)
             shutil.copy(ctx.database_version_file_path, self.SCGs_taxonomy_data_dir)
 

--- a/anvio/taxonomyops/trna.py
+++ b/anvio/taxonomyops/trna.py
@@ -4,24 +4,24 @@ Classes to use local databases for tRNA taxonomy to affiliate tRNA seqeunces in 
 databases with taxon names.
 """
 
-import os
 import glob
-import shutil
 import hashlib
+import os
+import shutil
 
 import anvio
-import anvio.utils as utils
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
-from anvio.errors import ConfigError
-from anvio.drivers.blast import BLAST
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.dbops import ContigsDatabase
-
-from anvio.taxonomyops import AccessionIdToTaxonomy
-from anvio.taxonomyops import TaxonomyEstimatorSingle
-from anvio.taxonomyops import PopulateContigsDatabaseWithTaxonomy
+from anvio.drivers.blast import BLAST
+from anvio.errors import ConfigError
+from anvio.taxonomyops import (
+    AccessionIdToTaxonomy,
+    PopulateContigsDatabaseWithTaxonomy,
+    TaxonomyEstimatorSingle,
+)
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -1,25 +1,24 @@
 # pylint: disable=line-too-long
 """Relations with the console output, Progress and Run classes"""
 
+import datetime
+import fcntl
 import os
 import re
-import sys
-import time
-import fcntl
-import numpy as np
 import struct
-import pandas as pd
+import sys
 import termios
-import datetime
 import textwrap
-
-from colored import Fore, Back, Style
+import time
 from collections import OrderedDict
 
-import anvio
-import anvio.dictio as dictio
-import anvio.constants as constants
+import numpy as np
+import pandas as pd
+from colored import Back, Fore, Style
 
+import anvio
+import anvio.constants as constants
+import anvio.dictio as dictio
 from anvio.errors import TerminalError
 from anvio.ttycolors import color_text as c
 

--- a/anvio/tests/run_component_tests_for_reaction_network
+++ b/anvio/tests/run_component_tests_for_reaction_network
@@ -3,13 +3,12 @@ DESCRIPTION = """Run by the shell script of the same name that tests anvi'o reac
 
 from argparse import Namespace
 
-import anvio.terminal as terminal
 import anvio.reactionnetwork as rn
-
-from anvio.errors import ConfigError
+import anvio.terminal as terminal
+from anvio import A, K
+from anvio import __version__ as VERSION
 from anvio.argparse import ArgumentParser
-from anvio import A, K, __version__ as VERSION
-
+from anvio.errors import ConfigError
 
 __author__ = "Developers of anvi'o (see AUTHORS.txt)"
 __copyright__ = "Copyleft 2015-2024, the Meren Lab (http://merenlab.org/)"

--- a/anvio/tests/run_unit_tests_for_consensus_taxonomy.py
+++ b/anvio/tests/run_unit_tests_for_consensus_taxonomy.py
@@ -3,9 +3,9 @@
 
 import argparse
 
-import anvio.terminal as terminal
 import anvio.taxonomyops as taxonomyops
 import anvio.taxonomyops.scg as scgtaxonomyops
+import anvio.terminal as terminal
 
 levels_of_taxonomy = ["t_domain", "t_phylum", "t_class", "t_order", "t_family", "t_genus", "t_species"]
 

--- a/anvio/tests/unit/test_anvi_thread.py
+++ b/anvio/tests/unit/test_anvi_thread.py
@@ -6,7 +6,6 @@ import subprocess
 import unittest
 
 import anvio
-
 from anvio.threadingops import AnviThread
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/tests/unit/test_palindrome.py
+++ b/anvio/tests/unit/test_palindrome.py
@@ -1,11 +1,11 @@
 # pylint: disable=line-too-long
 """Tests for Palindromes"""
 
+import argparse
+import unittest
+
 import anvio
 from anvio.sequencefeatures import Palindromes
-
-import unittest
-import argparse
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/tests/unit/utils/test_split_fasta.py
+++ b/anvio/tests/unit/utils/test_split_fasta.py
@@ -3,14 +3,13 @@
 Unit tests for the split_fasta function.
 """
 
-import unittest as ut
-
 import os
+import unittest as ut
 
 import anvio
 from anvio.errors import FilesNPathsError
-from anvio.utils import split_fasta
 from anvio.fastalib import ReadFasta
+from anvio.utils import split_fasta
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/threadingops.py
+++ b/anvio/threadingops.py
@@ -10,18 +10,14 @@ Exports
 
 # todo check args of everything!
 
-import os
 import abc
-import anvio
-
-from anvio import utils
-from anvio import fastalib
-from anvio import filesnpaths
-
-from anvio.errors import ConfigError, CommandError
+import os
 from collections import UserDict
 from threading import Thread
 
+import anvio
+from anvio import fastalib, filesnpaths, utils
+from anvio.errors import CommandError, ConfigError
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/trnaidentifier.py
+++ b/anvio/trnaidentifier.py
@@ -1,20 +1,19 @@
 # pylint: disable=line-too-long
 """tRNA identification from a nucleotide sequence."""
 
+import itertools
 import re
 import sys
-import itertools
-import pandas as pd
-
-from tabulate import tabulate
 from collections import OrderedDict
 
-import anvio.filesnpaths as filesnpaths
+import pandas as pd
+from tabulate import tabulate
 
+import anvio.filesnpaths as filesnpaths
+from anvio.constants import WC_BASE_PAIRS, WC_PLUS_WOBBLE_BASE_PAIRS
+from anvio.constants import anticodon_to_AA as ANTICODON_TO_AA
 from anvio.errors import TRNAIdentifierError
 from anvio.filesnpaths import is_file_exists, is_output_file_writable
-from anvio.constants import WC_BASE_PAIRS, WC_PLUS_WOBBLE_BASE_PAIRS, anticodon_to_AA as ANTICODON_TO_AA
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/trnaseq.py
+++ b/anvio/trnaseq.py
@@ -101,18 +101,22 @@ Uif: Ui derived from Uf
 Uim: Ui derived from Um
 """
 
+import argparse
 import gc
-import os
-import sys
 import math
-import time
+import os
+import pickle as pkl
 import queue
 import random
 import shutil
-import argparse
-import numpy as np
-import pandas as pd
-import pickle as pkl
+import sys
+import time
+from bisect import bisect_left
+from collections import OrderedDict, defaultdict, deque
+from functools import partial
+from hashlib import sha1
+from itertools import chain
+
 import matplotlib.pyplot as plt
 
 # multiprocess is a fork of multiprocessing that uses the dill serializer instead of pickle
@@ -122,36 +126,30 @@ import matplotlib.pyplot as plt
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
 import multiprocess as multiprocessing
-
-from hashlib import sha1
-from itertools import chain
-from functools import partial
-from bisect import bisect_left
+import numpy as np
+import pandas as pd
 from matplotlib.gridspec import GridSpec
 from matplotlib.ticker import MaxNLocator
-from collections import defaultdict, deque, OrderedDict
 
 import anvio
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.tables as tables
-import anvio.fastalib as fastalib
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.clustering as clustering
-import anvio.filesnpaths as filesnpaths
-import anvio.tables.miscdata as miscdata
-import anvio.trnaidentifier as trnaidentifier
 import anvio.auxiliarydataops as auxiliarydataops
-
+import anvio.clustering as clustering
+import anvio.constants as constants
+import anvio.dbops as dbops
+import anvio.fastalib as fastalib
+import anvio.filesnpaths as filesnpaths
+import anvio.tables as tables
+import anvio.tables.miscdata as miscdata
+import anvio.terminal as terminal
+import anvio.trnaidentifier as trnaidentifier
+import anvio.utils as utils
+from anvio.agglomeration import Agglomerator
 from anvio.dbinfo import DBInfo
+from anvio.drivers.vmatch import Vmatch
 from anvio.errors import ConfigError
 from anvio.sequence import Dereplicator
-from anvio.drivers.vmatch import Vmatch
-from anvio.agglomeration import Agglomerator
-from anvio.tables.views import TablesForViews
 from anvio.tables.miscdata import TableForLayerOrders
-
+from anvio.tables.views import TablesForViews
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/ttycolors.py
+++ b/anvio/ttycolors.py
@@ -4,7 +4,6 @@
 
 import sys
 
-
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
 __license__ = "GPL 3.0"

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -9,44 +9,44 @@
 # imported from so many other modules, it is kind of an appropriate place
 # for this
 try:
-    import os
-    import sys
-    import ssl
-    import yaml
-    import gzip
-    import time
     import copy
-    import socket
-    import shutil
-    import tarfile
+    import gzip
     import hashlib
-    import textwrap
-    import linecache
-    import webbrowser
-    import subprocess
-    import tracemalloc
-    import urllib.request, urllib.error, urllib.parse
-
-    import numpy as np
-    import pandas as pd
-    import Bio.PDB as PDB
     import itertools as it
-
-    from numba import jit
+    import linecache
+    import os
+    import shutil
+    import socket
+    import ssl
+    import subprocess
+    import sys
+    import tarfile
+    import textwrap
+    import time
+    import tracemalloc
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+    import webbrowser
     from collections import Counter
 
-    import anvio
-    import anvio.db as db
-    import anvio.tables as t
-    import anvio.fastalib as u
-    import anvio.constants as constants
-    import anvio.filesnpaths as filesnpaths
+    import Bio.PDB as PDB
+    import numpy as np
+    import pandas as pd
+    import yaml
+    from numba import jit
 
+    import anvio
+    import anvio.constants as constants
+    import anvio.db as db
+    import anvio.fastalib as u
+    import anvio.filesnpaths as filesnpaths
+    import anvio.tables as t
     from anvio.dbinfo import DBInfo as dbi
-    from anvio.sequence import Composition
-    from anvio.version import versions_for_db_types
     from anvio.errors import ConfigError, FilesNPathsError
-    from anvio.terminal import Run, Progress, SuppressAllOutput, get_date, TimeCode
+    from anvio.sequence import Composition
+    from anvio.terminal import Progress, Run, SuppressAllOutput, TimeCode, get_date
+    from anvio.version import versions_for_db_types
 except ModuleNotFoundError as e:
     # Extract just the module name from "No module named 'modulename'"
     module_name = str(e).split("'")[1] if "'" in str(e) else str(e)
@@ -3179,7 +3179,7 @@ def check_contig_names(contig_names, dont_raise=False):
 def create_fasta_dir_from_sequence_sources(genome_desc, fasta_txt=None):
     """genome_desc is an instance of GenomeDescriptions"""
 
-    from anvio.summarizer import ArgsTemplateForSummarizerClass, ProfileSummarizer, Bin
+    from anvio.summarizer import ArgsTemplateForSummarizerClass, Bin, ProfileSummarizer
 
     if genome_desc is None and fasta_txt is None:
         raise ConfigError("Anvi'o was given no internal genomes, no external genomes, and no fasta "
@@ -4761,8 +4761,9 @@ def download_file(url, output_file_path, check_certificate=True, progress=progre
 
 
 def get_remote_file_content(url, gzipped=False, timeout=None):
-    import requests
     from io import BytesIO
+
+    import requests
 
     if timeout:
         remote_file = requests.get(url, timeout=timeout)
@@ -4916,10 +4917,10 @@ def run_selenium_and_export_svg(url, output_file_path, browser_path=None, run=ru
 
     try:
         from selenium import webdriver
-        from selenium.webdriver.common.by import By
-        from selenium.webdriver.support.ui import WebDriverWait
-        from selenium.webdriver.support import expected_conditions as EC
         from selenium.common.exceptions import TimeoutException
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support import expected_conditions as EC
+        from selenium.webdriver.support.ui import WebDriverWait
     except:
         raise ConfigError("You want to export SVGs? Well, you need the Python library 'selenium' to be able to "
                           "do that but you don't have it. If you are lucky, you probably can install it by "

--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -3,12 +3,11 @@
 """Classes to make sense of single nucleotide variation"""
 
 import copy
+
 import numpy as np
 
 import anvio
-
 from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -3,33 +3,31 @@
 """Classes to make sense of sequence variation"""
 
 
-import os
-import sys
-import copy
-import random
-import inspect
 import argparse
+import copy
+import inspect
+import operator as op
+import os
+import random
+import sys
+
 import numpy as np
 import pandas as pd
-import operator as op
-
 from numba import jit
 from scipy.stats import entropy
 
 import anvio
-import anvio.tables as t
-import anvio.dbops as dbops
-import anvio.utils as utils
-import anvio.terminal as terminal
-import anvio.constants as constants
-import anvio.filesnpaths as filesnpaths
-import anvio.ccollections as ccollections
-import anvio.structureops as structureops
 import anvio.auxiliarydataops as auxiliarydataops
-
+import anvio.ccollections as ccollections
+import anvio.constants as constants
+import anvio.dbops as dbops
+import anvio.filesnpaths as filesnpaths
+import anvio.structureops as structureops
+import anvio.tables as t
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.tables.miscdata import TableForAminoAcidAdditionalData
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ['Alon Shaiber']

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -1,21 +1,20 @@
 # pylint: disable=line-too-long
 """Helper functions for the anvi'o snakemake workflows"""
 
+import copy
+import json
 import os
 import sys
-import json
-import copy
+
 import snakemake
 
 import anvio
-import anvio.utils as u
 import anvio.errors as errors
-import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as u
 from anvio.errors import ConfigError
 from anvio.version import versions_for_db_types
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []
@@ -778,12 +777,12 @@ def get_fields_for_fasta_information():
 
 def get_workflow_module_dict():
     from anvio.workflows.contigs import ContigsDBWorkflow
+    from anvio.workflows.ecophylo import EcoPhyloWorkflow
     from anvio.workflows.metagenomics import MetagenomicsWorkflow
     from anvio.workflows.pangenomics import PangenomicsWorkflow
     from anvio.workflows.phylogenomics import PhylogenomicsWorkflow
-    from anvio.workflows.trnaseq import TRNASeqWorkflow
-    from anvio.workflows.ecophylo import EcoPhyloWorkflow
     from anvio.workflows.sra_download import SRADownloadWorkflow
+    from anvio.workflows.trnaseq import TRNASeqWorkflow
 
     workflows_dict = {'contigs': ContigsDBWorkflow,
                       'metagenomics': MetagenomicsWorkflow,

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -5,15 +5,14 @@
 
 
 import os
-import anvio
-import anvio.utils as u
-import anvio.terminal as terminal
-import anvio.workflows as w
-import anvio.filesnpaths as filesnpaths
 
+import anvio
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as u
+import anvio.workflows as w
 from anvio.errors import ConfigError
 from anvio.workflows import WorkflowSuperClass
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -1,28 +1,26 @@
 # pylint: disable=line-too-long
 """ Classes to define and work with anvi'o ecophylo workflows. """
 
-from distutils.command.config import config
-import os
-import anvio
 import argparse
+import os
+from distutils.command.config import config
+
 import pandas as pd
 
 import anvio
-import anvio.utils as u
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
+import anvio.utils as u
 
 with terminal.SuppressAllOutput():
     import anvio.data.hmm
 
-from anvio.errors import ConfigError
-from anvio.workflows import WorkflowSuperClass
-from anvio.genomedescriptions import GenomeDescriptions
-from anvio.genomedescriptions import MetagenomeDescriptions
-from anvio.artifacts.samples_txt import SamplesTxt
-
 import anvio.constants as constants
+from anvio.artifacts.samples_txt import SamplesTxt
+from anvio.errors import ConfigError
+from anvio.genomedescriptions import GenomeDescriptions, MetagenomeDescriptions
+from anvio.workflows import WorkflowSuperClass
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ['mschecht']

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -5,19 +5,19 @@
 
 
 import os
-import anvio
 import shutil
-import pandas as pd
-import anvio.terminal as terminal
-import anvio.filesnpaths as filesnpaths
 
+import pandas as pd
+
+import anvio
+import anvio.filesnpaths as filesnpaths
+import anvio.terminal as terminal
 from anvio import utils as u
+from anvio.artifacts.samples_txt import SamplesTxt
 from anvio.drivers import driver_modules
+from anvio.errors import ConfigError
 from anvio.workflows import WorkflowSuperClass
 from anvio.workflows.contigs import ContigsDBWorkflow
-from anvio.errors import ConfigError
-from anvio.artifacts.samples_txt import SamplesTxt
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/workflows/pangenomics/__init__.py
+++ b/anvio/workflows/pangenomics/__init__.py
@@ -7,12 +7,10 @@ import os
 
 import anvio
 import anvio.terminal as terminal
-
 from anvio.errors import ConfigError
 from anvio.workflows import WorkflowSuperClass
 from anvio.workflows.contigs import ContigsDBWorkflow
 from anvio.workflows.phylogenomics import PhylogenomicsWorkflow
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -7,11 +7,9 @@ import os
 
 import anvio
 import anvio.terminal as terminal
-
+from anvio.errors import ConfigError
 from anvio.workflows import WorkflowSuperClass
 from anvio.workflows.contigs import ContigsDBWorkflow
-from anvio.errors import ConfigError
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/anvio/workflows/sra_download/__init__.py
+++ b/anvio/workflows/sra_download/__init__.py
@@ -1,18 +1,17 @@
 # pylint: disable=line-too-long
 """ Classes to define and work with anvi'o SRA_downloads workflow. """
 
-import os
-import anvio
 import hashlib
+import os
+
 import pandas as pd
 
-import anvio.utils as utils
-import anvio.terminal as terminal
+import anvio
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as utils
 from anvio.errors import ConfigError
 from anvio.workflows import WorkflowSuperClass
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = ['mschecht']

--- a/anvio/workflows/trnaseq/__init__.py
+++ b/anvio/workflows/trnaseq/__init__.py
@@ -2,21 +2,19 @@
 """Sets up an anvi'o tRNA-seq snakemake workflow."""
 
 import os
-import pandas as pd
 
+import pandas as pd
 from snakemake.io import ancient
 
 import anvio
-import anvio.utils as u
-import anvio.workflows as w
-import anvio.terminal as terminal
 import anvio.constants as constants
 import anvio.filesnpaths as filesnpaths
-
+import anvio.terminal as terminal
+import anvio.utils as u
+import anvio.workflows as w
+from anvio.artifacts.samples_txt import SamplesTxt
 from anvio.errors import ConfigError
 from anvio.workflows import WorkflowSuperClass
-from anvio.artifacts.samples_txt import SamplesTxt
-
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __credits__ = []

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,6 +3,8 @@
 select = [
     # https://docs.astral.sh/ruff/rules/#isort-i
     "I",
+    # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
+    "TID",
     # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/
     "UP009",
     # https://docs.astral.sh/ruff/rules/trailing-whitespace/

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
 [lint]
 # https://docs.astral.sh/ruff/rules/
 select = [
+    # https://docs.astral.sh/ruff/rules/#isort-i
+    "I",
     # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/
     "UP009",
     # https://docs.astral.sh/ruff/rules/trailing-whitespace/


### PR DESCRIPTION
Enables import organization-related ruff rules and applies the fixes.

- https://docs.astral.sh/ruff/rules/#isort-i
- https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid

Triggered the workflow manually, it is passing: https://github.com/merenlab/anvio/actions/runs/25054108473/job/73389515218

This PR comes with a small risk of breaking untested things, but I'm not sure how to minimize that risk. Please let me know if there is anything we would like to check explicitly.