### PR TITLE
Optimize Test CI

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -16,10 +16,12 @@ jobs:
       matrix:
         python-version: ["3.10"]
       fail-fast: false
+
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+
     - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
         # FIXME:
@@ -31,44 +33,53 @@ jobs:
         activate-environment: anvio_env
         environment-file: .conda/environment.yaml
         python-version: ${{ matrix.python-version }}
+
     - name: "Install Bioconductor qvalue package for R"
       shell: bash -l {0}
       run: |
         Rscript -e 'install.packages("BiocManager", repos="https://cran.rstudio.com"); BiocManager::install("qvalue")'
+
     - name: "Conda environment summary"
       shell: bash -l {0}
       run: |
         conda info
         conda list
+
     - name: "Install anvi'o from the codebase"
       shell: bash -l {0}
       run: |
         pip install uv
         uv pip install .
+
     - name: "Set Anvi'o interactive directory path"
       shell: bash -l {0}
       run: |
         interactive_dir=$(python -c "import site; print(site.getsitepackages()[0] + '/anvio/data/interactive')")
         echo "interactive_dir_path=$interactive_dir" >> $GITHUB_ENV
+
     - name: "Install npm dependencies for Anvi'o interactive interfaces"
       shell: bash -l {0}
       run: |
         cd "$interactive_dir_path"
         npm install
         cd -
+
     - name: "Run component tests"
       shell: bash -l {0}
       run: |
         anvi-self-test --suite metagenomics-full --no-interactive
         anvi-self-test --suite pangenomics --no-interactive
         anvi-self-test --suite inversions --no-interactive
+
 # the following steps cause our actions to fail on GitHub runners
 # due to space limitations :/ please do not uncomment this until we
 # have a solution for this :/
+
     #- name: "Run component tests for metabolism framework"
     #  shell: bash -l {0}
     #  run: |
     #    anvi-self-test --suite metabolism --no-interactive
+    #
     #- name: "Migrate ancient anvi'o databases"
     #  shell: bash -l {0}
     #  run: |

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -11,11 +11,12 @@ permissions:
 
 jobs:
   build:
-    name: Component Tests (Python ${{ matrix.python-version }})
+    name: ${{ matrix.suite }} (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]
+        suite: ["metagenomics-full", "pangenomics", "inversions"]
       fail-fast: false
 
     steps:
@@ -51,9 +52,7 @@ jobs:
     - name: "Run component tests"
       shell: bash -l {0}
       run: |
-        anvi-self-test --suite metagenomics-full --no-interactive
-        anvi-self-test --suite pangenomics --no-interactive
-        anvi-self-test --suite inversions --no-interactive
+        anvi-self-test --suite ${{ matrix.suite }} --no-interactive
 
 # the following steps cause our actions to fail on GitHub runners
 # due to space limitations :/ please do not uncomment this until we

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -23,28 +23,11 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+    - name: Install uv & Python ${{ matrix.PYTHON_VERSION }}
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        # FIXME:
-        #   The next version (26.3.2-2) causes https://github.com/merenlab/anvio/issues/2590
-        #   Release notes: https://www.anaconda.com/docs/getting-started/miniconda/release-notes
-        #   Available versions: https://repo.continuum.io/miniconda/
-        miniconda-version: "py310_26.1.1-1"
-        auto-update-conda: true
-        activate-environment: anvio_env
-        environment-file: .conda/environment.yaml
-        python-version: ${{ matrix.python-version }}
-
-    - name: "Install Bioconductor qvalue package for R"
-      shell: bash -l {0}
-      run: |
-        Rscript -e 'install.packages("BiocManager", repos="https://cran.rstudio.com"); BiocManager::install("qvalue")'
-
-    - name: "Conda environment summary"
-      shell: bash -l {0}
-      run: |
-        conda info
-        conda list
+        python-version: ${{ env.PYTHON_VERSION }}
+        activate-environment: "true"
 
     - name: "Install anvi'o from the codebase"
       shell: bash -l {0}

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"
+  pull_request:
 
 permissions:
   contents: read

--- a/anvio/sequencefeatures.py
+++ b/anvio/sequencefeatures.py
@@ -695,9 +695,15 @@ class Palindromes:
                                     -strand minus"""
 
         p = subprocess.Popen(search_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True, executable='/bin/bash')
-        BLAST_output = p.communicate()[0]
+        com_result = p.communicate()
+        BLAST_output = com_result[0]
 
         # parse the BLAST XML output
+        # Debug
+        if not BLAST_output:
+            print(f"p.communicate() result: {com_result}")
+            raise Exception("BLAST_output is empty.")
+
         root = ET.fromstring(BLAST_output.decode())
         for query_sequence_xml in root.findall('BlastOutput_iterations/Iteration'):
             for hit_xml in query_sequence_xml.findall('Iteration_hits/Hit'):


### PR DESCRIPTION
Currently, a single run of "Component Tests and Migrations" workflow takes more than 13 minutes. Looking at one of the latest successful runs, https://github.com/merenlab/anvio/actions/runs/25046167874/job/73361693210, I believe there is room for couple of improvements:

* `conda-incubator/setup-miniconda@v4` - 1m30s
  * It looks like this step installing a small but rich envrironment, which I believe includes some unused packages too.
  * It's not cached and packages are being downloaded and installed everytime.
* `Install anvi'o from the codebase` - 1m16s
  * Installing packages with uv instead of vanilla pip shaves of a minute, even with a cold cache.
  * With a warm cache, the step can be skipped.
* `Run component tests` - 9m 35s
  * This step includes 3 test suites without parallelization.
  * None of test suites make use of `num_threads`.