### PR TITLE
Add GHA security checks to git hooks

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: "Install npm dependencies for Anvi'o interactive interfaces"
       shell: bash -l {0}
       run: |
-        cd ${{ env.interactive_dir_path }}
+        cd ${ interactive_dir_path }
         npm install
         cd -
     - name: "Run component tests"

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 9 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Component Tests (Python ${{ matrix.python-version }})

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -15,6 +15,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
         miniconda-version: 'latest'

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -14,8 +14,8 @@ jobs:
         python-version: ["3.10"]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v6
-    - uses: conda-incubator/setup-miniconda@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
         miniconda-version: 'latest'
         auto-update-conda: true
@@ -40,7 +40,7 @@ jobs:
       run: |
         interactive_dir=$(python -c "import site; print(site.getsitepackages()[0] + '/anvio/data/interactive')")
         echo "interactive_dir_path=$interactive_dir" >> $GITHUB_ENV
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 18
     - name: "Install npm dependencies for Anvi'o interactive interfaces"

--- a/.github/workflows/git-hooks.yaml
+++ b/.github/workflows/git-hooks.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run prek
-        uses: j178/prek-action@v2.0.1
+        uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1

--- a/.github/workflows/git-hooks.yaml
+++ b/.github/workflows/git-hooks.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   run-prek:
     name: prek run --all-files

--- a/.github/workflows/git-hooks.yaml
+++ b/.github/workflows/git-hooks.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run prek
         uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,9 @@ repos:
     rev: 0.37.1
     hooks:
       - id: check-github-workflows
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
+        args: ["--no-progress"]


### PR DESCRIPTION
Adds zizmor to git hooks and applies fixes for the default setup.

> zizmor is a static analysis tool for GitHub Actions. It can find and fix many common security issues in typical GitHub Actions CI/CD setups.

https://docs.zizmor.sh/

