### PR TITLE
Fix CI - Tests workflow

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -22,7 +22,11 @@ jobs:
         persist-credentials: false
     - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
-        miniconda-version: 'latest'
+        # FIXME:
+        #   The next version (26.3.2-2) causes https://github.com/merenlab/anvio/issues/2590
+        #   Release notes: https://www.anaconda.com/docs/getting-started/miniconda/release-notes
+        #   Available versions: https://repo.continuum.io/miniconda/
+        miniconda-version: "py310_26.1.1-1"
         auto-update-conda: true
         activate-environment: anvio_env
         environment-file: .conda/environment.yaml

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: "Install npm dependencies for Anvi'o interactive interfaces"
       shell: bash -l {0}
       run: |
-        cd ${ interactive_dir_path }
+        cd "$interactive_dir_path"
         npm install
         cd -
     - name: "Run component tests"


### PR DESCRIPTION
Fixes #2590

Turned out miniconda [released a new version yesterday](https://www.anaconda.com/docs/getting-started/miniconda/release-notes#miniconda-26-3-2-2), and the workflow started to use it automatically, thanks to `miniconda-version: 'latest'`

On top of that, 85735407452fa5d16614052d12e6a2c744808e6a had an issue with bash syntax.

Successful workflow run after the fixes: https://github.com/merenlab/anvio/actions/runs/25125976761/job/73638995385