### PR TITLE
Enrich ruff rules

### DIFF
--- a/anvio/argparse.py
+++ b/anvio/argparse.py
@@ -286,7 +286,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
 
 
     def fill_in_contigs_db(self, db_hash=None):
-        if not 'contigs_db' in self.args:
+        if 'contigs_db' not in self.args:
             return
 
         if self.args.contigs_db:
@@ -308,7 +308,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
 
 
     def fill_in_genomes_storage_db(self, db_hash=None):
-        if not 'genomes_storage' in self.args:
+        if 'genomes_storage' not in self.args:
             return
 
         if self.args.genomes_storage:
@@ -334,7 +334,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
             return
 
         FindAnvioDBs.__init__(self, run=self.run, progress=self.progress) if not self.anvio_dbs_found else None
-        if not 'profile' in self.anvio_dbs:
+        if 'profile' not in self.anvio_dbs:
             self.__args_failed.append(('profile_db', 'No profile databases around :/'))
             return
 
@@ -379,7 +379,7 @@ class PopulateAnvioDBArgs(FindAnvioDBs):
             return
 
         FindAnvioDBs.__init__(self, run=self.run, progress=self.progress) if not self.anvio_dbs_found else None
-        if not 'pan' in self.anvio_dbs:
+        if 'pan' not in self.anvio_dbs:
             return self.__args_failed.append(('pan_db', 'No pan databases around :/'))
 
         pan_dbs = self.anvio_dbs['pan']

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -1443,7 +1443,7 @@ class ReadsMappingToARange:
                         L.reverse = pileupread.alignment.is_reverse
                         L.sequence = pileupread.alignment.query
 
-                        if not L.read_unique_id in read_ids:
+                        if L.read_unique_id not in read_ids:
                             data.append(L)
                             read_ids.add(L.read_unique_id)
 

--- a/anvio/ccollections.py
+++ b/anvio/ccollections.py
@@ -222,7 +222,7 @@ class Collections:
         bins_info_dict = self.get_bins_info_dict(collection_name)
         collection_dict = self.get_collection_dict(collection_name)
 
-        invalid_bin_names = [b for b in bin_names_list if not b in collection_dict]
+        invalid_bin_names = [b for b in bin_names_list if b not in collection_dict]
         if invalid_bin_names:
             raise ConfigError("Some of the bin names you want to merge is not in the collection %s :/ Here "
                               "is a list of them: %s" % (collection_name, ', '.join(invalid_bin_names)))

--- a/anvio/cli/delete_state.py
+++ b/anvio/cli/delete_state.py
@@ -44,7 +44,7 @@ def main():
                               "You don't know which state name you want to get rid of? We heard that the '--list-states' "
                               "flag helps for that.")
 
-        if not args.state in states:
+        if args.state not in states:
             raise ConfigError("The state name '%s' does not seem to appear in this database. But we have %s instead: "
                                "%s." % ((args.state, 'this one' if len(states) == 1 else 'these ones', ', '.join(list(states.keys())))))
 

--- a/anvio/cli/export_state.py
+++ b/anvio/cli/export_state.py
@@ -49,7 +49,7 @@ def main():
                                "did you try '--list-states' flag? You can press `1` for yes, `2` for no, and `3` for "
                                "maybe.")
 
-        if not args.state in states:
+        if args.state not in states:
             raise ConfigError("The state name '%s' does not seem to appear in this database. But we have %s instead: "
                                "%s." % ((args.state, 'this one' if len(states) == 1 else 'these ones', ', '.join(list(states.keys())))))
 

--- a/anvio/cli/get_sequences_for_hmm_hits.py
+++ b/anvio/cli/get_sequences_for_hmm_hits.py
@@ -91,7 +91,7 @@ def run_program():
         defline_data_dict = hmmops.SequencesForHMMHits(None).defline_data_dict
         defline_format = hmmops.SequencesForHMMHits(None).defline_format
 
-        run.warning(f"Here are the variables you can use to provide a user-defined defline template: ")
+        run.warning("Here are the variables you can use to provide a user-defined defline template: ")
         for key in defline_data_dict.keys():
             run.info_single("{%s}" % key)
         run.info_single("Remember, by default, anvi'o will use the following template to format the deflines of "

--- a/anvio/cli/get_split_coverages.py
+++ b/anvio/cli/get_split_coverages.py
@@ -62,7 +62,7 @@ def run_program():
     # this extra flag is necessary for avoiding args.gene_caller_id == 0 which could evaluate to False
     # when gene caller id is 0 :)
     has_valid_gene_caller_id_arg = False
-    if args.gene_caller_id != None:
+    if args.gene_caller_id is not None:
         has_valid_gene_caller_id_arg = utils.is_gene_caller_id(args.gene_caller_id)
         if not args.contigs_db:
             raise ConfigError("If you wish to work with a gene caller id, you also need to provide "

--- a/anvio/cli/matrix_to_newick.py
+++ b/anvio/cli/matrix_to_newick.py
@@ -38,7 +38,7 @@ def main():
         # a quick check of the data to see if there are any missing
         # values
         _, _, _, vectors = utils.get_vectors_from_TAB_delim_matrix(args.input_matrix, run=run)
-        num_missing_data = len([item for sublist in vectors for item in sublist if item == None])
+        num_missing_data = len([item for sublist in vectors for item in sublist if item is None])
         if num_missing_data:
             run.warning(f"Oy. Your file contains {PL('missing data item', num_missing_data)}. Anvi'o will do its "
                         f"best to accomodate for it, but you should take a careful look at your output tree (that, "

--- a/anvio/cli/merge_collections.py
+++ b/anvio/cli/merge_collections.py
@@ -55,7 +55,7 @@ def run_program():
 
     combined_dict = {}
     for contig_name in contig_names:
-        if not contig_name in contig_name_to_splits:
+        if contig_name not in contig_name_to_splits:
             raise ConfigError("Oh. You have the wrong stuff. Probably. Because, the contig '%s' does not match to any of "
                                "the contig names in your database. Here is a random contig name you have in it in "
                                "comparison: '%s'." % (contig_name, list(contig_name_to_splits.keys())[0]))

--- a/anvio/cli/migrate.py
+++ b/anvio/cli/migrate.py
@@ -242,7 +242,7 @@ class Migrater(object):
         for i in range(self.artifact_version, self.target_version):
             script_name = "v%s_to_v%s" % (i, i + 1)
 
-            if not self.artifact_type in migration_scripts or not script_name in migration_scripts[self.artifact_type]:
+            if self.artifact_type not in migration_scripts or script_name not in migration_scripts[self.artifact_type]:
                 raise ConfigError("Anvi'o can not find a migrate script required for this operation. (Artifact Type: %s, Script name: %s) " % (self.artifact_type, script_name))
 
             tasks.append(script_name)

--- a/anvio/cli/predict_CPR_genomes.py
+++ b/anvio/cli/predict_CPR_genomes.py
@@ -76,7 +76,7 @@ def run_program():
     if not len(completeness.sources):
         raise ConfigError("HMM's were not run for this contigs database :/")
 
-    if not 'Campbell_et_al' in completeness.sources:
+    if 'Campbell_et_al' not in completeness.sources:
         raise ConfigError("This classifier uses Campbell et al. single-copy gene collections, and it is not among the available HMM sources in your "
                            "contigs database :/ Bad news.")
 

--- a/anvio/cli/reformat_bam.py
+++ b/anvio/cli/reformat_bam.py
@@ -45,7 +45,7 @@ def load_dict_from_tsv(path):
         for line in fh:
             if line.startswith("#"):
                 continue
-            if not '\t' in line:
+            if '\t' not in line:
                 raise Exception(f"ERROR: Invalid line in {path} (missing tab): {line}")
             new, old = line.strip().split("\t")
             utils.is_this_name_OK_for_database('contig name prefix', new)

--- a/anvio/clustering.py
+++ b/anvio/clustering.py
@@ -106,7 +106,7 @@ def get_vectors_for_vectors_with_missing_data(vectors):
     Modified from the solution at https://stackoverflow.com/questions/31420912/python-hierarchical-clustering-with-missing-values
     """
 
-    vectors[vectors == None] = np.nan
+    vectors[vectors is None] = np.nan
 
     Npat = vectors.shape[0]
     dist = np.ndarray(shape=(Npat,Npat))

--- a/anvio/clusteringconfuguration.py
+++ b/anvio/clusteringconfuguration.py
@@ -266,7 +266,7 @@ class ClusteringConfiguration:
 
                 dbc = db.DB(database_path, None, ignore_version=True)
 
-                if not table in dbc.get_table_names():
+                if table not in dbc.get_table_names():
                     raise ConfigError('The table you requested (%s) does not seem to be in %s :/' % (table, database))
 
                 # here we know we are working with a database table that we have access to. however, in anvi'o database

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -1084,7 +1084,7 @@ class COGsSetup:
             open(self.COG_data_dir_version, 'w').write(COG_DATA_VERSION)
 
         for file_name in self.files:
-            if not 'url' in self.files[file_name]:
+            if 'url' not in self.files[file_name]:
                 continue
 
             file_path = os.path.join(self.raw_NCBI_files_dir, file_name)
@@ -1099,7 +1099,7 @@ class COGsSetup:
         for file_name in self.files:
             file_path = os.path.join(self.raw_NCBI_files_dir, file_name)
 
-            if not 'func' in self.files[file_name]:
+            if 'func' not in self.files[file_name]:
                 continue
 
             self.files[file_name]['func'](file_path, os.path.join(self.COG_data_dir, self.files[file_name]['formatted_file_name']))

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -807,7 +807,7 @@ class ContigsSuperclass(object):
                 hmm_hit = hmm_hits_table[e['hmm_hit_entry_id']]
                 hmm_source = e['source']
 
-                if not e['split'] in self.hmm_searches_dict:
+                if e['split'] not in self.hmm_searches_dict:
                     self.hmm_searches_dict[e['split']] = copy.deepcopy(sources_tmpl)
 
                 search_type = 'hmms_%s' % self.hmm_sources_info[e['source']]['search_type']
@@ -834,7 +834,7 @@ class ContigsSuperclass(object):
         _ = self.nt_positions_info
 
         if (not self.a_meta['genes_are_called']) or \
-           (not contig_name in self.nt_positions_info) or \
+           (contig_name not in self.nt_positions_info) or \
            (not len(self.nt_positions_info[contig_name])):
             return (0, 0, 0)
 
@@ -1415,7 +1415,7 @@ class ContigsSuperclass(object):
         _ = self.nt_positions_info
 
         if (not self.a_meta['genes_are_called']) or \
-           (not contig_name in self.nt_positions_info) or \
+           (contig_name not in self.nt_positions_info) or \
            (not len(self.nt_positions_info[contig_name])):
             # In these cases everything gets 0
             pass
@@ -3425,7 +3425,7 @@ class PanSuperclass(object):
                 # of the final gene clusters stored in the pan database due to various reasons. for
                 # instance, if the user set a min occurrence parameter, a singleton will not be found
                 # in the pan db yet it will return a functional hit.
-                if not gene_caller_id in self.gene_callers_id_to_gene_cluster[genome_name]:
+                if gene_caller_id not in self.gene_callers_id_to_gene_cluster[genome_name]:
                     gene_cluster_id = 'n/a'
                     found_mismatch = True
                 else:
@@ -4236,7 +4236,7 @@ class ProfileSuperclass(object):
 
 
     def get_variability_information_for_split(self, split_name, skip_outlier_SNVs=False, return_raw_results=False):
-        if not split_name in self.split_names:
+        if split_name not in self.split_names:
             raise ConfigError("get_variability_information_for_split: The split name '%s' does not seem to be "
                                "represented in this profile database. Are you sure you are looking for it "
                                "in the right database?" % split_name)
@@ -4269,7 +4269,7 @@ class ProfileSuperclass(object):
         return d
 
     def get_indels_information_for_split(self, split_name):
-        if not split_name in self.split_names:
+        if split_name not in self.split_names:
             raise ConfigError("get_indels_information_for_split: The split name '%s' does not seem to be "
                                "represented in this profile database. Are you sure you are looking for it "
                                "in the right database?" % split_name)
@@ -5610,7 +5610,7 @@ class AA_counts(ContigsSuperclass):
         if not len(collections_info_table):
             raise ConfigError("There are no collections stored in the profile database :/")
 
-        if not self.collection_name in collections_info_table:
+        if self.collection_name not in collections_info_table:
             valid_collections = ', '.join(list(collections_info_table.keys()))
             raise ConfigError("'%s' is not a valid collection name. But %s: '%s'." \
                                     % (self.collection_name,

--- a/anvio/drivers/MODELLER.py
+++ b/anvio/drivers/MODELLER.py
@@ -359,7 +359,7 @@ class MODELLER:
         "gene_2_ModelAvg.pdb"
         """
 
-        if not "get_model.py" in self.scripts.keys():
+        if "get_model.py" not in self.scripts.keys():
             raise ConfigError("You are out of line calling tidyup without running get_model.py")
 
         # remove all copies of all scripts that were ran

--- a/anvio/drivers/vmatch.py
+++ b/anvio/drivers/vmatch.py
@@ -216,7 +216,7 @@ class Vmatch(object):
 
         pid = "Vmatch"
         self.progress.new(pid)
-        self.progress.update(f"Setting up search")
+        self.progress.update("Setting up search")
 
         with open(self.fasta_query_path) as query_file:
             for line_num, line in enumerate(query_file, 1):

--- a/anvio/genomesimilarity.py
+++ b/anvio/genomesimilarity.py
@@ -173,11 +173,11 @@ class Dereplicate:
                         "are now burdened with the responsibility of knowing what parameters you used to generate "
                         "these results.%s" % additional_msg)
 
-        if self.ani_dir and not self.program_name in ['pyANI', 'fastANI']:
+        if self.ani_dir and self.program_name not in ['pyANI', 'fastANI']:
             raise ConfigError("You provided a pre-existing directory of ANI results (--ani-dir), but also provided a program "
                               "name ('%s') that was not compatible with ANI." % self.program_name)
 
-        if self.mash_dir and not self.program_name in ['sourmash']:
+        if self.mash_dir and self.program_name not in ['sourmash']:
             raise ConfigError("You provided a pre-existing directory of mash results (--mash-dir), but also provided a program "
                               "name ('%s') that was not compatible with mash." % self.program_name)
 

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -447,7 +447,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
             self.progress.update('for "%s" ...' % layer)
             layer_type = utils.get_predicted_type_of_items_in_a_dict(self.items_additional_data_dict, layer)
 
-            if layer_type == None:
+            if layer_type is None:
                 skipped_additional_data_layers.append(layer)
                 continue
 
@@ -461,7 +461,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                     else:
                         item_layer_data_tuple.append(('', item))
                 else:
-                    if self.items_additional_data_dict[item][layer] == None:
+                    if self.items_additional_data_dict[item][layer] is None:
                         if layer_type != str:
                             items_for_which_we_put_zeros_for_missing_values.add(item)
                             item_layer_data_tuple.append((0.0, item))
@@ -2009,7 +2009,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                 if layer_name in layer_names_considered:
                     continue
 
-                if layer_types[layer_name] == None:
+                if layer_types[layer_name] is None:
                     # all items in this layer has type None, there can't possibly
                     # be anything worth showing here.
                     layer_names_considered.add(layer_name)

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -1660,7 +1660,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
         # if the user specifies a view, set it as default:
         if self.view:
-            if not self.view in self.views:
+            if self.view not in self.views:
                 raise ConfigError("The requested view ('%s') is not available for this run. Please see "
                                          "available views by running this program with --show-views flag." % self.view)
 
@@ -1689,7 +1689,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                              "by using `anvi-script-generate-auxiliary-data-from-summary-cp` script."))
 
         if self.state_autoload:
-            if not self.state_autoload in self.states_table.states:
+            if self.state_autoload not in self.states_table.states:
                 raise ConfigError("The requested state ('%s') is not available for this run. Please see "
                                          "available states by running this program with --show-states flag." % self.state_autoload)
 
@@ -2444,7 +2444,7 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
             remove_column = True
 
             # If there is a "!" it is of stacked-bar type
-            if not "!" in layer_name:
+            if "!" not in layer_name:
                 for sample_name in samples_in_layer_data:
                     # loops through samples until it finds evidence the column is string-type
                     if isinstance(additional_layer_dict[sample_name][layer_name], str):

--- a/anvio/migrations/__init__.py
+++ b/anvio/migrations/__init__.py
@@ -15,7 +15,7 @@ for script_full_path in Path(base_path).glob('*/v*_to_v*.py'):
     script_name = script_filename[:-3]
     db_type = os.path.basename(script_path)
 
-    if not db_type in migration_scripts:
+    if db_type not in migration_scripts:
         migration_scripts[db_type] = {}
 
     spec = importlib.util.spec_from_file_location(script_name, script_full_path)

--- a/anvio/parsers/centrifuge.py
+++ b/anvio/parsers/centrifuge.py
@@ -85,7 +85,7 @@ class Centrifuge(Parser):
             gene_callers_id = hit['gene_callers_id']
             taxon_id = hit['taxon_id']
 
-            if not taxon_id in report:
+            if taxon_id not in report:
                 continue
 
             taxon = report[taxon_id]['t_species']

--- a/anvio/pfam.py
+++ b/anvio/pfam.py
@@ -307,7 +307,7 @@ class Pfam(object):
         if '.' in accession:
             accession = accession.split('.')[0]
 
-        if not accession in self.function_catalog:
+        if accession not in self.function_catalog:
             if ok_if_missing_from_catalog:
                 return "Unknown function with PFAM accession %s" % accession
             else:

--- a/anvio/programs.py
+++ b/anvio/programs.py
@@ -131,7 +131,7 @@ def parse_help_output(output):
 
         section, desc, _params = get_param_set(output)
 
-        if section == None:
+        if section is None:
             break
 
         if _params == '':

--- a/anvio/programs.py
+++ b/anvio/programs.py
@@ -1236,7 +1236,7 @@ class ProgramsNetwork(AnvioPrograms):
         for program in self.programs.values():
             for artifact in program.meta_info['provides']['value'] + program.meta_info['requires']['value']:
                 artifacts_seen[artifact.id] += 1
-                if not artifact.id in artifact_names_seen:
+                if artifact.id not in artifact_names_seen:
                     all_artifacts.append(artifact)
                     artifact_names_seen.add(artifact.id)
 

--- a/anvio/reactionnetwork.py
+++ b/anvio/reactionnetwork.py
@@ -6644,7 +6644,7 @@ class Constructor:
         cdb = ContigsDatabase(contigs_db, run=self.run)
         cdb_db: DB = cdb.db
         sources: List[str] = cdb.meta['gene_function_sources']
-        if not sources or not 'KOfam' in sources:
+        if not sources or 'KOfam' not in sources:
             raise ConfigError(
                 "The contigs database indicates that genes were never annotated with KOs. This is "
                 "especially strange since to load a reaction network means that a network had to "
@@ -7222,7 +7222,7 @@ class Constructor:
                     network.kegg_modelseed_aliases[kegg_reaction_id] = [reaction_id]
                 modelseed_kegg_aliases.append(kegg_reaction_id)
                 for ko in kos:
-                    if not reaction_id in ko.reaction_ids:
+                    if reaction_id not in ko.reaction_ids:
                         # This is the first time encountering the reaction as a reference of the KO.
                         ko.reaction_ids.append(reaction_id)
                     try:
@@ -7249,7 +7249,7 @@ class Constructor:
                     network.ec_number_modelseed_aliases[ec_number] = [reaction_id]
                 modelseed_ec_number_aliases.append(ec_number)
                 for ko in kos:
-                    if not reaction_id in ko.reaction_ids:
+                    if reaction_id not in ko.reaction_ids:
                         # This is the first time encountering the reaction as a reference of the KO.
                         ko.reaction_ids.append(reaction_id)
                     try:
@@ -7754,7 +7754,7 @@ class Constructor:
         cdb = ContigsDatabase(contigs_db)
         cdb_db: DB = cdb.db
         sources: List[str] = cdb.meta['gene_function_sources']
-        if not sources or not 'KOfam' in sources:
+        if not sources or 'KOfam' not in sources:
             raise ConfigError(
                 "The contigs database indicates that genes were never annotated with KOs, which is "
                 "required to build a reaction network. This can be solved by running "
@@ -8788,10 +8788,10 @@ class Constructor:
                 network.modelseed_ec_number_aliases[modelseed_reaction_id] = []
 
             if DEBUG:
-                assert not modelseed_reaction_id in ko.kegg_reaction_aliases
+                assert modelseed_reaction_id not in ko.kegg_reaction_aliases
             ko.kegg_reaction_aliases[modelseed_reaction_id] = kegg_reaction_ids
             if DEBUG:
-                assert not modelseed_reaction_id in ko.ec_number_aliases
+                assert modelseed_reaction_id not in ko.ec_number_aliases
             ko.ec_number_aliases[modelseed_reaction_id] = []
 
         # Add ModelSEED reactions aliasing newly encountered EC numbers to the network.

--- a/anvio/reactionnetwork.py
+++ b/anvio/reactionnetwork.py
@@ -4082,7 +4082,7 @@ class GenomicNetwork(ReactionNetwork):
             if remove_missing_objective_metabolites:
                 self.remove_missing_objective_metabolites(objective_dict)
             json_reactions.append(objective_dict)
-        elif objective != None:
+        elif objective is not None:
             raise ConfigError(
                 f"Anvi'o does not recognize an objective with the name, '{objective}'."
             )
@@ -5279,7 +5279,7 @@ class PangenomicNetwork(ReactionNetwork):
             if remove_missing_objective_metabolites:
                 self.remove_missing_objective_metabolites(objective_dict)
             json_reactions.append(objective_dict)
-        elif objective != None:
+        elif objective is not None:
             raise ConfigError(
                 f"Anvi'o does not recognize an objective with the name, '{objective}'."
             )

--- a/anvio/sequencefeatures.py
+++ b/anvio/sequencefeatures.py
@@ -478,7 +478,7 @@ class Palindromes:
 
         A = lambda x: args.__dict__[x] if x in args.__dict__ else None
         self.palindrome_search_algorithm = A('palindrome_search_algorithm')
-        self.min_palindrome_length = 10 if A('min_palindrome_length') == None else A('min_palindrome_length')
+        self.min_palindrome_length = 10 if A('min_palindrome_length') is None else A('min_palindrome_length')
         self.max_num_mismatches = A('max_num_mismatches') or 0
         self.min_distance = A('min_distance') or 0
         self.min_mismatch_distance_to_first_base = A('min_mismatch_distance_to_first_base') or 1

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -224,7 +224,7 @@ class StructureDatabase(object):
     def get_pdb_content(self, corresponding_gene_call):
         """Returns the file content (as a string) of a pdb for a given gene"""
 
-        if not corresponding_gene_call in self.genes_with_structure:
+        if corresponding_gene_call not in self.genes_with_structure:
             raise ConfigError('The gene caller id {} was not found in the structure database :('.format(corresponding_gene_call))
 
         return self.db.get_single_column_from_table(

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -139,7 +139,7 @@ class SummarizerSuperClass(object):
         self.cog_data_dir = A('cog_data_dir')
         self.report_aa_seqs_for_gene_calls = A('report_aa_seqs_for_gene_calls')
         self.report_DNA_sequences = A('report_DNA_sequences')
-        self.delete_output_directory_if_exists = False if A('delete_output_directory_if_exists') == None else A('delete_output_directory_if_exists')
+        self.delete_output_directory_if_exists = False if A('delete_output_directory_if_exists') is None else A('delete_output_directory_if_exists')
         self.just_do_it = A('just_do_it')
         self.reformat_contig_names = A('reformat_contig_names')
 
@@ -791,7 +791,7 @@ class ProfileSummarizer(DatabasesMetaclass, SummarizerSuperClass):
         # I am not sure whether this is the best place to do this,
         T = lambda x: 'True' if x else 'False'
 
-        J = lambda x: x in self.p_meta and self.p_meta[x] != None
+        J = lambda x: x in self.p_meta and self.p_meta[x] is not None
 
         self.summary['basics_pretty'] = {'profile': [
                                                      ('Created on', self.p_meta['creation_date']),

--- a/anvio/tables/collections.py
+++ b/anvio/tables/collections.py
@@ -94,9 +94,9 @@ class TablesForCollections(Table):
 
         if bins_info_dict:
             if set(collection_dict.keys()) - set(bins_info_dict.keys()):
-                raise ConfigError(f"Bins in the collection dict do not match to the ones in the bins info dict. "
-                                  f"They do not have to be identical, but for each bin id, there must be a unique "
-                                  f"entry in the bins informaiton dict. There is something wrong with your input :/")
+                raise ConfigError("Bins in the collection dict do not match to the ones in the bins info dict. "
+                                  "They do not have to be identical, but for each bin id, there must be a unique "
+                                  "entry in the bins informaiton dict. There is something wrong with your input :/")
 
         if drop_collection:
             # remove any pre-existing information for 'collection_name'

--- a/anvio/taxonomyops/__init__.py
+++ b/anvio/taxonomyops/__init__.py
@@ -1398,7 +1398,7 @@ class PopulateContigsDatabaseWithTaxonomy(TerminologyHelper):
         """Takes a dictionary that includes a key `accession` and populates the dictionary with taxonomy"""
 
         if not mode:
-            if not 'accession' in d:
+            if 'accession' not in d:
                 raise ConfigError("`add_taxonomy_to_dict` is speaking: the dictionary sent here does not have a member "
                                   "with key `accession`.")
 

--- a/anvio/tests/run_unit_tests_for_consensus_taxonomy.py
+++ b/anvio/tests/run_unit_tests_for_consensus_taxonomy.py
@@ -40,7 +40,7 @@ scg_raw_hits = [{'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'T x'},
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'T x'}]
 
-assert cT('t_species') == None
+assert cT('t_species') is None
 assert cT('t_genus') == 'F'
 
 #########################################
@@ -49,8 +49,8 @@ scg_raw_hits = [{'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'G x'},
                 {'percent_identity': 100.0, 't_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'W', 't_species': 'T x'}]
 
-assert cT('t_species') == None
-assert cT('t_genus') == None
+assert cT('t_species') is None
+assert cT('t_genus') is None
 assert cT('t_family') == 'E'
 
 #########################################
@@ -76,7 +76,7 @@ assert cT('t_species') == 'G x'
 scg_dict = {1: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'G x'},
             3: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'F', 't_species': 'T x'}}
 
-assert pT('t_species') == None
+assert pT('t_species') is None
 assert pT('t_genus') == 'F'
 
 #########################################
@@ -96,7 +96,7 @@ scg_dict = {1: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D'
             5: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'W', 't_species': 'T x'},
             6: {'t_domain': 'A', 't_phylum': 'B', 't_class': 'C', 't_order': 'D', 't_family': 'E', 't_genus': 'W', 't_species': 'T x'}}
 
-assert pT('t_species') == None
-assert pT('t_genus') == None
-assert pT('t_family') == None
+assert pT('t_species') is None
+assert pT('t_genus') is None
+assert pT('t_family') is None
 assert pT('t_order') == 'D'

--- a/anvio/trnaseq.py
+++ b/anvio/trnaseq.py
@@ -8063,7 +8063,7 @@ class ResultPlotter(object):
                     continue
 
                 if not taxon_rank_filter and not loop_ranks:
-                    warning(f"A taxon or at least one rank must be given.", "PROGRAM REQUIREMENT")
+                    warning("A taxon or at least one rank must be given.", "PROGRAM REQUIREMENT")
                     continue
 
                 loop_ranks = sorted(loop_ranks, key=lambda rank: RANKS.index(rank))
@@ -8074,7 +8074,7 @@ class ResultPlotter(object):
 
                 if single_aa and single_anticodon:
                     if ANTICODON_AA_DICT[single_anticodon] == single_aa:
-                        warning(f"An amino acid is not needed with the anticodon.", "UNNECESSARY FIELD")
+                        warning("An amino acid is not needed with the anticodon.", "UNNECESSARY FIELD")
                         single_aa = None
                     else:
                         warning(f"The anticodon ('{single_anticodon}') does not decode the amino acid ('{single_aa}').", "INVALID FIELD")

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -742,7 +742,7 @@ def store_array_as_TAB_delimited_file(a, output_path, header, exclude_columns=[]
         raise ConfigError("store array: header length (%d) differs from data (%d)..." % (len(header), num_fields))
 
     for col in exclude_columns:
-        if not col in header:
+        if col not in header:
             raise ConfigError("store array: column %s is not in the header array...")
 
     exclude_indices = set([header.index(c) for c in exclude_columns])
@@ -3821,7 +3821,7 @@ def get_groups_txt_file_as_dict(file_path, run=run, progress=progress, include_m
                               f"downstream, so we will stop you right there. Please remove all duplicate items from this file. :)")
         item_to_group_dict[item] = group_name
 
-        if not group_name in group_to_item_dict:
+        if group_name not in group_to_item_dict:
             group_to_item_dict[group_name] = []
         group_to_item_dict[group_name].append(item)
 

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -243,7 +243,7 @@ def get_predicted_type_of_items_in_a_dict(d, key):
         # it is either list or dict. we will go through items
         # and return the type of first item that is not None:
         for item in items:
-            if item == None:
+            if item is None:
                 continue
             else:
                 return type(item)
@@ -3973,7 +3973,7 @@ def get_TAB_delimited_file_as_dictionary(file_path, expected_fields=None, dict_t
 
         line_fields = [f if f else None for f in line.strip('\n').split(separator)]
 
-        if line_fields and line_fields[0] == None:
+        if line_fields and line_fields[0] is None:
             raise ConfigError("The line number %d in '%s' has no data in its first column, and this doesn't "
                               "seem right at all :/" % (line_counter + 1, file_path))
 
@@ -3982,7 +3982,7 @@ def get_TAB_delimited_file_as_dictionary(file_path, expected_fields=None, dict_t
             updated_line_fields = []
             for i in range(0, len(line_fields)):
                 try:
-                    if line_fields[i] == None and column_mapping[i] in [float, int]:
+                    if line_fields[i] is None and column_mapping[i] in [float, int]:
                         updated_line_fields.append(column_mapping[i](0))
                     else:
                         updated_line_fields.append(column_mapping[i](line_fields[i]))

--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -316,7 +316,7 @@ class ProcessAlleleCounts:
 
     def get_positions_with_competing_items(self, competing_items):
 
-        return np.where(competing_items != None)[0]
+        return np.where(competing_items is not None)[0]
 
 
     def rename_key(self, from_this, to_that):

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -205,8 +205,8 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                     with open(sanity_checked_metagenomes_file, 'w') as fp:
                         pass
                 else:
-                    self.run.warning(f"You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
-                                     f"for any genomes or metagenomes that cause issues downstream in ecophylo.")
+                    self.run.warning("You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
+                                     "for any genomes or metagenomes that cause issues downstream in ecophylo.")
                     self.metagenomes_name_list = self.metagenomes_df.name.to_list()
                     self.metagenomes_path_list = self.metagenomes_df.contigs_db_path.to_list()
             else:
@@ -281,8 +281,8 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                 raise ConfigError("You provided a samples.txt so you're in profile mode! Please change AA_mode to false.")
 
         else:
-            self.run.warning(f"Since you did not provide a samples.txt, EcoPhylo will assume you do not want "
-                             f"to profile the ecology of your proteins and will just be making trees for now!")
+            self.run.warning("Since you did not provide a samples.txt, EcoPhylo will assume you do not want "
+                             "to profile the ecology of your proteins and will just be making trees for now!")
 
         # Pick which tree algorithm
         self.run_iqtree = self.get_param_value_from_config(['iqtree', 'run'])
@@ -325,11 +325,11 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                               f"Please check your config file {self.config_file} and change cluster_representative_method to one of the following: 'mmseqs' and 'cluster_rep_with_coverages'")
 
         if self.cluster_representative_method == 'cluster_rep_with_coverages' and len(self.contigs_db_name_bam_dict) == 0:
-            raise ConfigError(f"The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages without BAM files..."
-                              f"Please edit your metagenomes.txt or external-genomes.txt and add BAM files.")
+            raise ConfigError("The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages without BAM files..."
+                              "Please edit your metagenomes.txt or external-genomes.txt and add BAM files.")
 
         if self.cluster_representative_method == 'cluster_rep_with_coverages' and self.AA_mode == True:
-            raise ConfigError(f"The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages in AA_mode")
+            raise ConfigError("The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages in AA_mode")
 
         # Parse clustering parameter space
         self.clustering_param_space = self.get_param_value_from_config(['cluster_X_percent_sim_mmseqs', 'clustering_threshold_for_OTUs'])
@@ -543,6 +543,6 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
         # TODO: I hope we can change that in the future, probably by making a contigs.db for the representative sequence,
         # in tree mode or not.
         if len(unique_group) < len(self.hmm_dict) and self.run_scg_taxonomy:
-            raise ConfigError(f"You have one or more 'group' in your HMM list file (or multiple identical entries - but you "
-                              f"shouldn't be doing that) and at the moment it is not compatible with anvi-estimate-scg-taxonomy. "
-                              f"The good news is that you can turn off anvi-run-scg-taxonmy in your config file.")
+            raise ConfigError("You have one or more 'group' in your HMM list file (or multiple identical entries - but you "
+                              "shouldn't be doing that) and at the moment it is not compatible with anvi-estimate-scg-taxonomy. "
+                              "The good news is that you can turn off anvi-run-scg-taxonmy in your config file.")

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -312,7 +312,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         if self.run_split:
             split = [os.path.join(self.dirs_dict["SPLIT_PROFILES_DIR"],\
                                   g + "-split.done")\
-                                  for g in self.collections.keys() if not 'default_collection' in self.collections[g]]
+                                  for g in self.collections.keys() if 'default_collection' not in self.collections[g]]
             target_files.extend(split)
 
         targets_files_for_binning = self.get_target_files_for_anvi_cluster_contigs()

--- a/anvio/workflows/sra_download/__init__.py
+++ b/anvio/workflows/sra_download/__init__.py
@@ -109,7 +109,7 @@ class SRADownloadWorkflow(WorkflowSuperClass):
     def get_target_files(self):
         """Get list of target files for snakemake target rule"""
 
-        target_files = [os.path.join(self.dirs_dict['FASTAS'], f"generate_samples_txt.done")]
+        target_files = [os.path.join(self.dirs_dict['FASTAS'], "generate_samples_txt.done")]
 
         return target_files
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
 [lint]
 # https://docs.astral.sh/ruff/rules/
 select = [
+    # https://docs.astral.sh/ruff/rules/none-comparison/
+    "E711",
     # https://docs.astral.sh/ruff/rules/unused-import/
     "F401",
     # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,6 +3,8 @@
 select = [
     # https://docs.astral.sh/ruff/rules/none-comparison/
     "E711",
+    # https://docs.astral.sh/ruff/rules/not-in-test/
+    "E713",
     # https://docs.astral.sh/ruff/rules/unused-import/
     "F401",
     # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,6 +7,8 @@ select = [
     "E713",
     # https://docs.astral.sh/ruff/rules/unused-import/
     "F401",
+    # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/
+    "F541",
     # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/
     "UP009",
     # https://docs.astral.sh/ruff/rules/trailing-whitespace/


### PR DESCRIPTION
Coming from https://github.com/merenlab/anvio/pull/2582#issuecomment-4343760088, enables E711, E713 and F541

- E711: https://docs.astral.sh/ruff/rules/none-comparison/
- E713: https://docs.astral.sh/ruff/rules/not-in-test/
- F541: https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/

