### PR TITLE
Remove actions/setup-node step

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -50,9 +50,6 @@ jobs:
       run: |
         interactive_dir=$(python -c "import site; print(site.getsitepackages()[0] + '/anvio/data/interactive')")
         echo "interactive_dir_path=$interactive_dir" >> $GITHUB_ENV
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: 18
     - name: "Install npm dependencies for Anvi'o interactive interfaces"
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
After realizing `.conda/environment.yaml` already has nodejs listed as a dependency, I thought the node setup in the workflow may be redundant. The workflow works just fine without that step: https://github.com/merenlab/anvio/actions/runs/25219232420/job/73947027280