### PR TITLE
Match Dockerfiles' miniconda version with CI

### DIFF
--- a/Dockerfiles/anvio-main/Dockerfile
+++ b/Dockerfiles/anvio-main/Dockerfile
@@ -11,7 +11,7 @@
 #     BUILDKIT_PROGRESS=plain docker build -t meren/anvio:$ANVIO_VERSION .
 #
 
-FROM continuumio/miniconda3:4.11.0
+FROM continuumio/miniconda3:26.1.1
 ENV ANVIO_VERSION "8"
 
 SHELL ["/bin/bash", "--login", "-c"]

--- a/Dockerfiles/anvio-structure/Dockerfile
+++ b/Dockerfiles/anvio-structure/Dockerfile
@@ -11,7 +11,7 @@
 #     BUILDKIT_PROGRESS=plain docker build -t meren/anvio:$ANVIO_VERSION .
 #
 
-FROM continuumio/miniconda3:4.11.0
+FROM continuumio/miniconda3:26.1.1
 ENV ANVIO_VERSION "7.1_structure"
 
 SHELL ["/bin/bash", "--login", "-c"]


### PR DESCRIPTION
Docker images are not tagged with Python versions and CI is (py310_26.1.1-1), so this is not exactly a full match but that's close as it gets.

Relates to #2595