### PR TITLE
Remove redundant backslashes

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -4118,13 +4118,13 @@ def K(param_id, params_dict={}):
 (__version__,
  __codename__,
  __contigs__version__,
- __profile__version__, \
- __genes__version__, \
- __pan__version__, \
- __auxiliary_data_version__, \
- __structure__version__, \
- __genomes_storage_version__ , \
- __trnaseq__version__, \
+ __profile__version__,
+ __genes__version__,
+ __pan__version__,
+ __auxiliary_data_version__,
+ __structure__version__,
+ __genomes_storage_version__ ,
+ __trnaseq__version__,
  __workflow_config_version__,
  __kegg_modules_version__) = get_versions()
 

--- a/anvio/bamops.py
+++ b/anvio/bamops.py
@@ -977,16 +977,16 @@ class LinkMers:
         filesnpaths.is_output_file_writable(output_file_path)
 
         output_file = open(output_file_path, 'w')
-        output_file.write('\t'.join(['entry_id', 'sample_id', 'request_id', 'contig_name', 'pos_in_contig',\
-                                     'pos_in_read', 'base', 'read_unique_id', 'read_X', 'reverse',\
+        output_file.write('\t'.join(['entry_id', 'sample_id', 'request_id', 'contig_name', 'pos_in_contig',
+                                     'pos_in_read', 'base', 'read_unique_id', 'read_X', 'reverse',
                                      'sequence']) + '\n')
         entry_id = 0
         for contig_name, positions, data in self.linkmers.data:
             for d in data:
                 entry_id += 1
                 output_file.write('%.9d\t%s\t%.3d\t%s\t%d\t%d\t%s\t%s\t%s\t%s\t%s\n'
-                                % (entry_id, d.sample_id, d.request_id, d.contig_name,\
-                                   d.pos_in_contig, d.pos_in_read, d.base, d.read_unique_id,\
+                                % (entry_id, d.sample_id, d.request_id, d.contig_name,
+                                   d.pos_in_contig, d.pos_in_read, d.base, d.read_unique_id,
                                    d.read_X, d.reverse, d.sequence))
         output_file.close()
 

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -204,7 +204,7 @@ class BottleApplication(Bottle):
             raise ConfigError("Anvi'o uses `%(wsgi)s` as a web server gateway interface, and you don't seem to have it. Which "
                               "means bad news. But the good news is that you can actually install it very easily. If you are "
                               "in a conda environment, try 'conda install %(wsgi)s'. If you are in a Python environment "
-                              "try 'pip install %(wsgi)s'. If you are not sure, start with conda, if it doesn't work, try pip." \
+                              "try 'pip install %(wsgi)s'. If you are not sure, start with conda, if it doesn't work, try pip."
                                     % {'wsgi': self._wsgi_for_bottle})
 
         try:

--- a/anvio/ccollections.py
+++ b/anvio/ccollections.py
@@ -127,7 +127,7 @@ class Collections:
                              'collection, and some of the bins you have in that collection contain a small number '
                              'of contigs that were too short to make it into the merged profile. Well, if you would '
                              'like to figure out what might be the scenario for your experiment, here is the list of '
-                             'bin names that did not go through: %s.' \
+                             'bin names that did not go through: %s.'
                                 % (len(bins_with_zero_splits_in_profile_db), len(collection_dict), ", ".join(bins_with_zero_splits_in_profile_db)))
 
         return (collection_dict, bins_info_dict, split_names_in_db_but_missing_in_collection)
@@ -336,7 +336,7 @@ class GetSplitNamesInBins:
         if self.collection_name not in self.collections.collections_dict:
             progress.reset()
             raise ConfigError('The collection id "%s" does not seem to be in the profile database. These are the '
-                               'collections that are available through this profile database: "%s".'\
+                               'collections that are available through this profile database: "%s".'
                                                     % (self.collection_name, ', '.join(self.collections.collections_dict)))
 
         self.collection_dict = self.collections.get_collection_dict(self.collection_name)

--- a/anvio/cli/cluster_contigs.py
+++ b/anvio/cli/cluster_contigs.py
@@ -280,7 +280,7 @@ def cluster_contigs(args, unknown, subparsers, modules):
 
     store_clusters_in_db(args.contigs_db, args.profile_db, clusters, collection_name, driver, cluster_type)
 
-    run.info_single("%s formed %d clusters, which are being added to the database as a collection named %s." % \
+    run.info_single("%s formed %d clusters, which are being added to the database as a collection named %s." %
                             (driver, len(clusters), collection_name), nl_before=1, nl_after=1, mc="green")
 
 

--- a/anvio/cli/compute_ani_for_fasta.py
+++ b/anvio/cli/compute_ani_for_fasta.py
@@ -16,7 +16,6 @@ import anvio.filesnpaths as filesnpaths
 from anvio.drivers import pyani
 
 from anvio.errors import ConfigError, FilesNPathsError
-import anvio.errors
 
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
@@ -58,7 +57,7 @@ def run_program():
             raise ConfigError("At least one of the deflines in your FASTA File does not comply with the 'simple deflines' "
                               "requirement of anvi'o. You can either use the script `anvi-script-reformat-fasta` to take "
                               "care of this issue, or do it manually, but you must know that anvi'o is very upset for "
-                              "making you deal with this. Here is more info on simple deflines %s" % \
+                              "making you deal with this. Here is more info on simple deflines %s" %
                                    ('http://merenlab.org/2016/06/22/anvio-tutorial-v2/#take-a-look-at-your-fasta-file'))
         num_contigs += 1
     fasta.reset()
@@ -108,7 +107,7 @@ def get_args():
                          the pyANI help for v0.2.7 at https://github.com/widdowquinn/pyani, the method 'ANIm' uses\
                          MUMmer (NUCmer) to align the input sequences. 'ANIb' uses BLASTN+ to align 1020nt fragments\
                          of the input sequences. 'ANIblastall': uses the legacy BLASTN to align 1020nt fragments\
-                         Finally, 'TETRA': calculates tetranucleotide frequencies of each input sequence",\
+                         Finally, 'TETRA': calculates tetranucleotide frequencies of each input sequence",
                          choices=['ANIm', 'ANIb', 'ANIblastall', 'TETRA'])
     parser.add_argument(*anvio.A('distance'), **anvio.K('distance', {'help': 'The distance metric for the hierarchical \
                          clustering. The default is "%(default)s".'}))

--- a/anvio/cli/compute_completeness.py
+++ b/anvio/cli/compute_completeness.py
@@ -48,7 +48,7 @@ def compute_completeness(args):
                 run.warning('None of the split names you provided in %s matched split names in the database...' % args.splits_of_interest)
                 sys.exit()
             else:
-                run.warning('Only %d of %d split names you listed in "%s" matched split names in the database...'\
+                run.warning('Only %d of %d split names you listed in "%s" matched split names in the database...'
                                                 % (len(splits_of_interest), len(splits_in_users_list), args.splits_of_interest))
     else:
         splits_of_interest = splits_in_db

--- a/anvio/cli/compute_genome_similarity.py
+++ b/anvio/cli/compute_genome_similarity.py
@@ -91,7 +91,7 @@ def get_args():
                          the pyANI help for v0.2.7 at https://github.com/widdowquinn/pyani, the method 'ANIm' uses\
                          MUMmer (NUCmer) to align the input sequences. 'ANIb' uses BLASTN+ to align 1020nt fragments\
                          of the input sequences. 'ANIblastall': uses the legacy BLASTN to align 1020nt fragments\
-                         Finally, 'TETRA': calculates tetranucleotide frequencies of each input sequence",\
+                         Finally, 'TETRA': calculates tetranucleotide frequencies of each input sequence",
                          choices=['ANIm', 'ANIb', 'ANIblastall', 'TETRA'])
     group_PYANI.add_argument(*anvio.A('min-alignment-fraction'), **anvio.K('min-alignment-fraction'))
     group_PYANI.add_argument(*anvio.A('significant-alignment-length'), **anvio.K('significant-alignment-length'))

--- a/anvio/cli/dereplicate_genomes.py
+++ b/anvio/cli/dereplicate_genomes.py
@@ -84,7 +84,7 @@ def get_args():
                          the pyANI help for v0.2.7 at https://github.com/widdowquinn/pyani, the method 'ANIm' uses\
                          MUMmer (NUCmer) to align the input sequences. 'ANIb' uses BLASTN+ to align 1020nt fragments\
                          of the input sequences. 'ANIblastall': uses the legacy BLASTN to align 1020nt fragments\
-                         Finally, 'TETRA': calculates tetranucleotide frequencies of each input sequence",\
+                         Finally, 'TETRA': calculates tetranucleotide frequencies of each input sequence",
                          choices=['ANIm', 'ANIb', 'ANIblastall', 'TETRA'])
     groupE.add_argument(*anvio.A('min-alignment-fraction'), **anvio.K('min-alignment-fraction', params_dict={'default':0.25}))
     groupE.add_argument(*anvio.A('significant-alignment-length'), **anvio.K('significant-alignment-length'))

--- a/anvio/cli/estimate_genome_completeness.py
+++ b/anvio/cli/estimate_genome_completeness.py
@@ -179,7 +179,7 @@ def print_for_internal_or_external_genomes(args):
             else:
                 raise ConfigError("%d of %d of your genomes in the external genomes file are missing HMMs for single-copy core "
                                   "genes. To see the full list, run the same command with `--debug` flag. If you want avni'o "
-                                  "to simply ignore the ones that do not have HMMs, run the same command wiht `--just-do-it` flag." \
+                                  "to simply ignore the ones that do not have HMMs, run the same command wiht `--just-do-it` flag."
                                                     % (len(missing_hmms), len(genomes)))
 
     A = lambda x: args.__dict__[x] if x in args.__dict__ else None

--- a/anvio/cli/export_contigs.py
+++ b/anvio/cli/export_contigs.py
@@ -10,7 +10,6 @@ import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import ConfigError, FilesNPathsError
-import anvio.errors
 
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"

--- a/anvio/cli/filter_hmm_hits_table.py
+++ b/anvio/cli/filter_hmm_hits_table.py
@@ -8,7 +8,6 @@ is done using model and/or gene coverage
 import sys
 
 import anvio
-import anvio.data.hmm
 import anvio.terminal as terminal
 
 from anvio.tables.hmmhits import FilterHmmHitsTable

--- a/anvio/cli/gen_distribution_of_genes_in_a_bin.py
+++ b/anvio/cli/gen_distribution_of_genes_in_a_bin.py
@@ -74,7 +74,7 @@ def run_program():
                     "average detection is %.2f across all metagenomes, %.2f being the maximum. Well, you can take a look at the "
                     "anvi-summarize output if you would like to learn more. The bottom line is this: the metagenomes you have in this "
                     "project are not the best ones to investigate the occurrence of the genes in this genome in the environment. So. "
-                    "This program will give you quite useless output files, but anvi'o hopes that you will enjoy them anyway :(" %\
+                    "This program will give you quite useless output files, but anvi'o hopes that you will enjoy them anyway :(" %
                             (num_metagenomes, min_detection, average_detection_of_genome, max_detection_of_genome))
     else:
         not_enough_detection = False

--- a/anvio/cli/gen_pseudo_paired_reads_from_fastq.py
+++ b/anvio/cli/gen_pseudo_paired_reads_from_fastq.py
@@ -129,7 +129,7 @@ def get_args():
     parser = ArgumentParser(description=__description__)
 
     parser.add_argument('-f', '--fastq', required=True)
-    parser.add_argument(*anvio.A('output-file-prefix'), **anvio.K('output-file-prefix', {'help': \
+    parser.add_argument(*anvio.A('output-file-prefix'), **anvio.K('output-file-prefix', {'help':
                         'If you want final FASTQs with the format myfastq_1.fastq and myfastq_2.fastq, '
                         'then this parameter should be set to myfastq'}))
 

--- a/anvio/cli/gen_structure_database.py
+++ b/anvio/cli/gen_structure_database.py
@@ -50,7 +50,7 @@ def get_args():
 
     groupD = parser.add_argument_group('DATABASES', 'Declaring relevant anvi\'o databases. First things first.')
     groupD.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
-    groupD.add_argument("--pdb-db", type=str, default=None, help = \
+    groupD.add_argument("--pdb-db", type=str, default=None, help =
                         """By default, this program accesses the structure files it needs from an
                         internal anvi'o database that can be set up with anvi-setup-pdb-database. If
                         a required structure is not in this database, it will instead be
@@ -70,7 +70,7 @@ def get_args():
     groupI.add_argument(*anvio.A('external-structures'), **anvio.K('external-structures'))
 
     groupM = parser.add_argument_group('MODELLER PARAMS', 'Parameters for MODELLER\'s homology modeling.')
-    groupM.add_argument("--num-models", "-N", type=int, default=1, help = \
+    groupM.add_argument("--num-models", "-N", type=int, default=1, help =
                         """This parameter determines the number of predicted structures that are
                         solved for a given protein.  The original atomic positions for each model
                         are perturbed by an amount defined by --deviation, which leads to
@@ -80,14 +80,14 @@ def get_args():
                         should be kept in mind that the largest determinant of a model's accuracy is
                         determined by the protein templates used, so no need to go overboard with an
                         excessively large --num-models. The default is %(default)d.""")
-    groupM.add_argument("--deviation", "-d", type=float, default=4.0, help = \
+    groupM.add_argument("--deviation", "-d", type=float, default=4.0, help =
                         """Deviation (angstroms)""")
-    groupM.add_argument("--modeller-database", "-D", type=str, default="pdb_95", help = \
+    groupM.add_argument("--modeller-database", "-D", type=str, default="pdb_95", help =
                         """Which database do you want to search the structures of? Default is
                         "%(default)s". If you have your own database it must have either the extension
                         .bin or .pir. If you don't have a database or don't know what this
                         means, don't worry, we will both inform you and take care of you.""")
-    groupM.add_argument("--scoring-method", "-b", type=str, default="DOPE_score", help = \
+    groupM.add_argument("--scoring-method", "-b", type=str, default="DOPE_score", help =
                         """How should the best model be decided? The metric used could be any of
                         GA341_score, DOPE_score, and molpdf. GA341 is an absolute measure,
                         where a good model will have a score near 1.0, whereas anything below 0.6
@@ -96,23 +96,23 @@ def get_args():
                         distinguisher between good and bad models than molpdf. The default is %(default)s.
                         To learn more see the MODELLER tutorial:
                         https://salilab.org/modeller/tutorial/basic.html.""")
-    groupM.add_argument("--very-fast", action = 'store_true', help = \
+    groupM.add_argument("--very-fast", action = 'store_true', help =
                         """If provided, a very fast optimization is done for each model at the cost
                         of accuracy. It is recommended to use a --num-models of 1, since the
                         optimization is so crude that all models will likely converge to the same
                         solution.""")
-    groupM.add_argument("--percent-cutoff", "-p", type=float, default=30, help = \
+    groupM.add_argument("--percent-cutoff", "-p", type=float, default=30, help =
                         """If a protein in the database has a percent identity to the gene of
                         interest that is less than this parameter, then
                         it is not considered as a template. The default is %(default)f.""")
-    groupM.add_argument("--alignment-fraction-cutoff", "-a", type=float, default=0.80, help = \
+    groupM.add_argument("--alignment-fraction-cutoff", "-a", type=float, default=0.80, help =
                         """If a protein in the database aligns to a fraction of the gene of interest
                         that is less than this parameter, the template is not considered. For example,
                         if --alignment-cutoff is set to 0.90, and the fraction of the gene of interest
                         that is covered by a potential template is 0.80 in their alignment, the template
                         does not align to enough of the gene of interest to be considered. The default
                         is %(default)f.""")
-    groupM.add_argument("--max-number-templates", "-t", type=int, default=5, help = \
+    groupM.add_argument("--max-number-templates", "-t", type=int, default=5, help =
                         """Generally speaking it is best to use as many templates as possible given
                         that they have high proper percent identity to the gene of interest. Taken
                         from https://salilab.org/modeller/methenz/andras/node4.html: 'The use of
@@ -130,16 +130,16 @@ def get_args():
                         default is %(default)d.""")
 
     groupE = parser.add_argument_group('EXTRA', 'Everything else.')
-    groupE.add_argument("--skip-DSSP", action = "store_true", help = \
+    groupE.add_argument("--skip-DSSP", action = "store_true", help =
                         """Dictionary of Secondary Structure of Proteins (DSSP) is a program that takes
                         as its input a protein structure file and outputs predicted secondary
                         structure (alpha helix, beta strand, etc.), measures of solvent
                         accessibility, and hydrogen bonds for each residue in the protein. If for
                         some reason you don't want this, provide this flag.""")
-    groupE.add_argument("--modeller-executable", type=str, help = \
+    groupE.add_argument("--modeller-executable", type=str, help =
                         """The MODELLER program to use. For example, `mod9.19`. Anvi'o will try and find
                         it if not provided""")
-    groupE.add_argument("--offline-mode", action = "store_true", help = \
+    groupE.add_argument("--offline-mode", action = "store_true", help =
                         """Anvi'o first tries to obtain template structures from a database (see
                         --pdb-db for details). If the requested template does not exist in the
                         database, its structure will be downloaded from the RCSB PDB server.
@@ -151,7 +151,7 @@ def get_args():
 
     params = {
         'default': 25,
-        'help': anvio.K('write-buffer-size')['help'] + \
+        'help': anvio.K('write-buffer-size')['help'] +
                 ' If --num-threads is 1, this parameter is ignored because the DB is written to after each gene'
     }
     groupE.add_argument(*anvio.A('write-buffer-size'), **anvio.K('write-buffer-size', params))

--- a/anvio/cli/get_pn_ps_ratio.py
+++ b/anvio/cli/get_pn_ps_ratio.py
@@ -170,11 +170,11 @@ def get_args():
                                                       to generate variability table.'}))
 
     groupE = parser.add_argument_group('TUNABLES', "Successfully tune one or more of these parameters to unlock the badge 'Advanced anvian'.")
-    groupE.add_argument(*anvio.A('min-departure-from-consensus'), **anvio.K('min-departure-from-consensus', {'default': 0.0, 'help': \
+    groupE.add_argument(*anvio.A('min-departure-from-consensus'), **anvio.K('min-departure-from-consensus', {'default': 0.0, 'help':
                             'SCVs will be ignored if they have a departure from consensus less than this \
                             value. Note: Keep in mind you may have already supplied this parameter during anvi-gen-variability-profile.\
                             The default value is %(default).2f.'}))
-    groupE.add_argument(*anvio.A('min-departure-from-reference'), **anvio.K('min-departure-from-reference', {'default': 0.0, 'help': \
+    groupE.add_argument(*anvio.A('min-departure-from-reference'), **anvio.K('min-departure-from-reference', {'default': 0.0, 'help':
                             'SCVs will be ignored if they have a departure from reference less than this \
                             value. Note: Keep in mind you may have already supplied this parameter during anvi-gen-variability-profile.\
                             The default value is %(default).2f.'}))
@@ -188,7 +188,7 @@ def get_args():
 
     groupO = parser.add_argument_group('OUTPUT', 'The output of this program is a folder directory with several tables.')
     groupO.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir', {'required':True}))
-    groupO.add_argument('-p', '--pivot', action='store_true', help = \
+    groupO.add_argument('-p', '--pivot', action='store_true', help =
                             'By default the output is in long format, however you can \
                              choose the output to be in matrix form with this flag. If you\'re not sure which one is right for you, \
                              just try one and take a look at the output--there is no cost for making a mistake :)')

--- a/anvio/cli/get_short_reads_mapping_to_a_gene.py
+++ b/anvio/cli/get_short_reads_mapping_to_a_gene.py
@@ -74,7 +74,7 @@ def run_program():
                from the contigs database you are using. " % (len(missing_gene_caller_ids), len(genes_of_interest))
 
         if anvio.DEBUG:
-            raise ConfigError(msg + "Here are the list of gene caller IDs that's making anvi'o upset: %s" % \
+            raise ConfigError(msg + "Here are the list of gene caller IDs that's making anvi'o upset: %s" %
                                     (", ".join([str(g) for g in missing_gene_caller_ids])))
         else:
             error_msg = msg + "Since this can be a long list in some cases, anvi'o will not show you what\

--- a/anvio/cli/import_collection.py
+++ b/anvio/cli/import_collection.py
@@ -99,7 +99,7 @@ def run_program():
     if max(num_occurences_of_entries.values()) != 1:
         raise ConfigError("Some %(item)s names occur more than once in the input file. A %(item)s cannot belong in two "
                            "bins, and neither there should be the same bin assignment for a given %(item)s. Long story "
-                           "short, each name should appear only once in your input file, and it is not the case :/" \
+                           "short, each name should appear only once in your input file, and it is not the case :/"
                                                                         % {'item': 'contig' if args.contigs_mode else 'split'})
     #################################################################################################
     # </SANITY CHECKS>

--- a/anvio/cli/import_functions.py
+++ b/anvio/cli/import_functions.py
@@ -61,7 +61,7 @@ def get_functions_dict(args):
     if args.parser not in parser_modules['functions']:
         raise ConfigError("Anvi'o does not know what to do with '%s'. You must use one of the available parsers "
                            "to make sense of genes (well, open reading frames) found in your contigs (please see "
-                           "the documentation for a more detailed explanation): %s"\
+                           "the documentation for a more detailed explanation): %s"
                                                  % (args.parser, ', '.join(parser_modules['functions'])))
     if not args.input_files:
         raise ConfigError("You need to use '--input-files' parameter to list file(s) that is/are required the "
@@ -92,7 +92,7 @@ def get_args():
                                 %d parsers readily available: %s. IT IS OK if you do not select a parser if you\
                                 have a standard, TAB-delimited input file for funcitonal annotation of genes. If\
                                 this is not like 2018 and everything is already outdated, you should be able to\
-                                go to this address and learn everything you need like a boss: http://merenlab.org/2016/06/18/importing-functions/"\
+                                go to this address and learn everything you need like a boss: http://merenlab.org/2016/06/18/importing-functions/"
                                             % (len(parser_modules['functions']), list(parser_modules['functions'].keys())))
     parser.add_argument('-i', '--input-files', metavar = 'FILE(S)', nargs='+', default = None, required = True,
                         help = 'One or more input files should follow this parameter. The way these files will be handled\

--- a/anvio/cli/import_taxonomy_for_layers.py
+++ b/anvio/cli/import_taxonomy_for_layers.py
@@ -95,7 +95,7 @@ def run_program():
 
         if taxa_excluded_count:
             run.warning("A total of %d taxon names, which made up %.2f%% of the input data altogether were excluded "
-                        "from this import due to the min abundance criterion of %.1f%% for inclusion." % \
+                        "from this import due to the min abundance criterion of %.1f%% for inclusion." %
                                 (len(taxa_excluded), taxa_excluded_count * 100 / total_count, args.min_abundance))
 
 

--- a/anvio/cli/mcg_classifier.py
+++ b/anvio/cli/mcg_classifier.py
@@ -57,7 +57,7 @@ def run_program():
                                "actually in your collection: %s" % (args.collection_name, missing_bins, bin_names_in_collection))
     elif args.bin_id:
         if args.bin_id not in bin_names_in_collection:
-            raise ConfigError("The bin you declared, %s, does not appear to be in the collection %s." \
+            raise ConfigError("The bin you declared, %s, does not appear to be in the collection %s."
                               % (args.bin_id, args.collection_name))
         bin_names_of_interest = [args.bin_id]
     else:
@@ -66,8 +66,8 @@ def run_program():
     for bin_name in bin_names_of_interest:
         # This is where things are happening
         _bin = summarizer.Bin(summary, bin_name)
-        mcg.init(gene_level_coverage_stats_dict = _bin.gene_level_coverage_stats_dict, \
-                    split_coverage_values_per_nt_dict = _bin.split_coverage_values_per_nt_dict, \
+        mcg.init(gene_level_coverage_stats_dict = _bin.gene_level_coverage_stats_dict,
+                    split_coverage_values_per_nt_dict = _bin.split_coverage_values_per_nt_dict,
                     additional_description = bin_name)
         if not args.get_samples_stats_only:
             mcg.classify()

--- a/anvio/cli/predict_CPR_genomes.py
+++ b/anvio/cli/predict_CPR_genomes.py
@@ -59,7 +59,7 @@ def run_program():
 
     if args.output_file and ( not args.just_do_it and filesnpaths.is_file_exists(args.output_file, dont_raise=True) ):
         raise ConfigError("The output file '%s' already exists. Please either remove it, or provide a different name. "
-                          "Anvi'o does not like overwriting your stuff (well, only whenever it is convenient to do so)."\
+                          "Anvi'o does not like overwriting your stuff (well, only whenever it is convenient to do so)."
                                     % args.output_file)
 
     if args.profile_db and not args.collection_name:

--- a/anvio/cli/run_hmms.py
+++ b/anvio/cli/run_hmms.py
@@ -72,7 +72,7 @@ def run_program():
         sources = utils.get_HMM_sources_dictionary([args.hmm_profile_dir], check_for_ACC_lines_in_HMM=args.add_to_functions_table)
         run.info('HMM profiles', '%d source%s been loaded: %s' % (len(sources),
                                                           's' if len(sources) > 1 else '',
-                                                          ', '.join(['%s (%d genes)' % (s, len(sources[s]['genes']))\
+                                                          ', '.join(['%s (%d genes)' % (s, len(sources[s]['genes']))
                                                                                                     for s in sources])))
     elif args.installed_hmm_profile:
         args.installed_hmm_profile = [p.strip() for p in args.installed_hmm_profile.split(',') if p.strip()]

--- a/anvio/cli/run_ncbi_cogs.py
+++ b/anvio/cli/run_ncbi_cogs.py
@@ -69,7 +69,7 @@ def get_args():
 
     groupC.add_argument('--search-with', default=default_search_method, metavar="SEARCH_METHOD",
                         help="What program to use for database searching. The default search uses %(default)s.\
-                              All available options include: %(serach_methods)s." \
+                              All available options include: %(serach_methods)s."
                                         % {'serach_methods': ', '.join(available_search_methods),
                                            'default': default_search_method})
 

--- a/anvio/cli/update_structure_database.py
+++ b/anvio/cli/update_structure_database.py
@@ -56,17 +56,17 @@ def get_args():
     groupM.add_argument('--list-modeller-params', action='store_true', help='Since you are updating an existing DB, modeller params are set in '
                                                                             'place. You can have this program list them by providing this flag')
 
-    groupE.add_argument("--rerun-genes", action='store_true', help = \
+    groupE.add_argument("--rerun-genes", action='store_true', help =
                         """Supply if you would like to rerun structural modelling for your genes of
                         interest if they are already present in your DB""")
-    groupE.add_argument("--modeller-executable", type=str, help = \
+    groupE.add_argument("--modeller-executable", type=str, help =
                         """The MODELLER program to use. For example, `mod9.19`. Anvi'o will try and find
                         it if not provided.""")
 
     groupE.add_argument(*anvio.A('num-threads'), **anvio.K('num-threads'))
     params = {
         'default': 25,
-        'help': anvio.K('write-buffer-size')['help'] + \
+        'help': anvio.K('write-buffer-size')['help'] +
                 ' If --num-threads is 1, this parameter is ignored because the DB is written to after each gene'
     }
     groupE.add_argument(*anvio.A('write-buffer-size'), **anvio.K('write-buffer-size', params))

--- a/anvio/clustering.py
+++ b/anvio/clustering.py
@@ -20,9 +20,9 @@ with terminal.SuppressAllOutput():
     from ete3 import Tree
 
 
-distance_metrics = ['euclidean', 'cityblock', 'sqeuclidean', 'cosine', 'correlation', 'hamming',\
-                    'jaccard', 'chebyshev', 'canberra', 'braycurtis', 'yule', 'matching',\
-                    'dice', 'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',\
+distance_metrics = ['euclidean', 'cityblock', 'sqeuclidean', 'cosine', 'correlation', 'hamming',
+                    'jaccard', 'chebyshev', 'canberra', 'braycurtis', 'yule', 'matching',
+                    'dice', 'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',
                     'sokalsneath', 'minkowski']
 
 linkage_methods = ['single', 'complete', 'average', 'weighted', 'centroid', 'median', 'ward']

--- a/anvio/clusteringconfuguration.py
+++ b/anvio/clusteringconfuguration.py
@@ -144,7 +144,7 @@ class ClusteringConfiguration:
 
         # make sure all matrices have identical rows:
         if len(set([list(m['id_to_sample'].values()).__str__() for m in list(self.matrices_dict.values())])) > 1:
-            master_rows, master_matrix = sorted([(len(self.matrices_dict[m]['id_to_sample']), list(self.matrices_dict[m]['id_to_sample'].values()), m)\
+            master_rows, master_matrix = sorted([(len(self.matrices_dict[m]['id_to_sample']), list(self.matrices_dict[m]['id_to_sample'].values()), m)
                                                             for m in self.matrices_dict])[0][1:]
             self.master = master_matrix
             self.master_rows = master_rows
@@ -310,7 +310,7 @@ class ClusteringConfiguration:
 
                 if not len(table_rows):
                     raise ConfigError("It seems the table '%s' in the database it was requested from is empty. This "
-                                       "is not good. Here is the section that is not working for you: '%s' :/" \
+                                       "is not good. Here is the section that is not working for you: '%s' :/"
                                                                 % (table, section))
 
                 tmp_file_path = filesnpaths.get_temp_file_path()

--- a/anvio/cogs.py
+++ b/anvio/cogs.py
@@ -179,7 +179,7 @@ class COGs:
         if self.search_with not in self.available_search_methods:
             raise ConfigError("Let us start by making it clear that we probably like '%s' as much as you do, but it doesn't "
                               "seem to be available on your system OR recognized by the COGs class since anvi'o couldn't "
-                              "find it among the available search methods. You probably need to try something else :/" \
+                              "find it among the available search methods. You probably need to try something else :/"
                                                                                                     % self.search_with)
 
         if self.search_with not in self.available_db_search_program_targets:
@@ -395,7 +395,7 @@ class COGs:
                              "inspections before suggested that these hits are usually matching to very poorly described functions that "
                              "are not mature enough to warrant a new COG id, or to be associated with an existing one. While that is "
                              "our interpretation, we may be totally wrong, and we welcome you to double-check these. Here are the "
-                             "offending protein IDs if you would like to dig deeper: " % \
+                             "offending protein IDs if you would like to dig deeper: " %
                                         (hits_for_missing_ncbi_protein_ids, len(missing_ncbi_protein_ids_found)), lc='yellow')
 
             self.run.info_single(missing_ncbi_protein_ids_msg, nl_after=1, level=0, cut_after=0)
@@ -415,7 +415,7 @@ class COGs:
             self.run.warning("This is important. %s hits for your genes that appeared in the proteins FASTA file from the NCBI had protein "
                              "IDs that were not described in the CSV file from the NCBI that associates each protein ID with a COG function. "
                              "That's OK if you don't care. But if you would like to take a look, anvi'o stored a report "
-                             "file for you at %s" \
+                             "file for you at %s"
                         % (len(in_proteins_FASTA_not_in_cogs_CSV), report_output_file_path))
 
 
@@ -768,7 +768,7 @@ class COGsSetup:
             self.run.warning("%d of %d COG IDs that appear in the list of orthology domains file (which links protein IDs "
                              "to COG names), are missing from the COG names file (which links COG IDs to function names and "
                              "categories). Because clearly even the files that are distributed together should not be expected to "
-                             "be fully compatible. Anvi'o thanks everyone for their contributions." % \
+                             "be fully compatible. Anvi'o thanks everyone for their contributions." %
                                                         (len(missing_cog_ids), len(self.cogs_found_in_proteins_fasta)))
 
         dictio.write_serialized_object(missing_cog_ids, os.path.join(self.COG_data_dir, 'MISSING_COG_IDs.cPickle'))

--- a/anvio/completeness.py
+++ b/anvio/completeness.py
@@ -95,7 +95,7 @@ class Completeness:
                              "are not included when the anvi'o domain predictor was trained :/ Here is the list of domains that are making "
                              "us upset here: \"%s\". This means either you put a new HMM single-copy core gene collection to the anvi'o HMMs "
                              "directory, or gave it as a parameter, and run `anvi-run-hmms` without updating the classifier anvi'o uses to "
-                             "resolve domains for proper completion/redundancy estimates." % \
+                             "resolve domains for proper completion/redundancy estimates." %
                                            ('a domain' if num_domains_missing == 1 else '%s domains' % num_domains_missing,
                                             ', '.join(self.domains_missing_in_SCG_domain_predictor)))
             self.initialized_properly = False
@@ -133,7 +133,7 @@ class Completeness:
                                  "how they behave. That's all good and very exciting, but unfortunately anvi'o will not be able to predict domains "
                                  "due to this incompatibility here. Running `anvi-run-hmms` on this contigs database would've solved this problem "
                                  "but it is not an absolute necessity as anvi'o will continue running by not utilizing domain-specific HMMs for "
-                                 "completion/redundancy estimates, and report all the results all at once without prioritizing a single domain." % \
+                                 "completion/redundancy estimates, and report all the results all at once without prioritizing a single domain." %
                                                ('an HMM source' if num_sources_missing == 1 else '%s HMM sources' % num_sources_missing,
                                                 ', '.join(self.sources_missing_in_SCGs_run_for_contigs)))
             self.initialized_properly = False

--- a/anvio/constants.py
+++ b/anvio/constants.py
@@ -163,9 +163,9 @@ fetch_filters = {None                 : None,
                  'proper-pairs'       : lambda x: not x.mate_is_unmapped,
                  'double-forwards'    : lambda x: x.is_paired and not x.is_reverse and not x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name,
                  'double-reverses'    : lambda x: x.is_paired and x.is_reverse and x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name,
-                 'inversions'         : lambda x: (x.is_paired and not x.is_reverse and not x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name and (abs(x.tlen) < 2000)) or \
+                 'inversions'         : lambda x: (x.is_paired and not x.is_reverse and not x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name and (abs(x.tlen) < 2000)) or
                                                   (x.is_paired and x.is_reverse and x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name and (abs(x.tlen) < 2000)),
-                 'distant-inversions'  : lambda x: (x.is_paired and not x.is_reverse and not x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name) or \
+                 'distant-inversions'  : lambda x: (x.is_paired and not x.is_reverse and not x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name) or
                                                   (x.is_paired and x.is_reverse and x.mate_is_reverse and not x.mate_is_unmapped and x.reference_name == x.next_reference_name),
                  'single-mapped-reads': lambda x: x.mate_is_unmapped,
                  'distant-pairs-1K'   : lambda x: x.is_paired and not x.mate_is_unmapped and abs(x.tlen) > 1000}

--- a/anvio/data/SSMs/__init__.py
+++ b/anvio/data/SSMs/__init__.py
@@ -32,7 +32,7 @@ def get(engine, run=run):
         if sorted(matrix_columns) != sorted(matrix_rows):
             raise ConfigError("Anvi'o found a substitution scoring matrix named '%s'. However, it doesn't look like "
                               "a nicely done matrix. Substitution scoring matrices must contain the same row and column "
-                              "names (i.e., a square matrix that is equal to its transpose). Well. This one does not :/" \
+                              "names (i.e., a square matrix that is equal to its transpose). Well. This one does not :/"
                                                     % (os.path.basename(matrix_path)))
 
         if engine == 'AA':
@@ -46,7 +46,7 @@ def get(engine, run=run):
         if len(unexpected_items_in_matrix):
             raise ConfigError("It seems you have a poorly done substitution scoring matrix named '%s' in the data directory. "
                               "Anvi'o expects an %s substitution matrix to describe one or more of these %d guys: '%s'. But "
-                              "the matrix %s had stuff anvi'o is not familiar with: '%s'." % \
+                              "the matrix %s had stuff anvi'o is not familiar with: '%s'." %
                                             (matrix_id, engine, len(expected_items), ', '.join(expected_items),
                                              matrix_id, ', '.join(unexpected_items_in_matrix)))
 
@@ -54,7 +54,7 @@ def get(engine, run=run):
         data[matrix_id] = matrix_data
 
     if len(data):
-        run.warning('%d matri%s been loaded: "%s".' % \
+        run.warning('%d matri%s been loaded: "%s".' %
                                     (len(data),
                                      'ces have' if len(data) > 1 else 'x has',
                                      ', '.join(list(data.keys()))),

--- a/anvio/db.py
+++ b/anvio/db.py
@@ -626,13 +626,13 @@ class DB:
 
         if len(set(dataframe.columns)) != len(list(dataframe.columns)):
             raise ConfigError("insert_rows_from_dataframe :: There is at least one duplicate column "
-                              "name in the dataframe. Here is the list of columns: [{}].".\
+                              "name in the dataframe. Here is the list of columns: [{}].".
                                format(", ".join(list(dataframe.columns))))
 
         if set(dataframe.columns) != set(self.get_table_structure(table_name)):
             raise ConfigError("insert_rows_from_dataframe :: The columns in the dataframe "
                               "do not equal the columns of the requested table. "
-                              "The columns from each are respectively ({}); and ({}).".\
+                              "The columns from each are respectively ({}); and ({}).".
                                format(", ".join(list(dataframe.columns)),
                                       ", ".join(self.get_table_structure(table_name))))
 

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -720,7 +720,7 @@ class ContigsSuperclass(object):
                                   "contained %d split names. Note that if you have been using a `min_contig_length` cutoff "
                                   "that may have resulted in the removal of your splits from the primary dict of splits. "
                                   "Regardless, here is one of the split names that you requested and were missing: '%s'. "
-                                  "And here is one found in the splits basic info dict: '%s'." % \
+                                  "And here is one found in the splits basic info dict: '%s'." %
                                                 (len(missing_split_names), len(split_names_of_interest), len(self.splits_basic_info),
                                                  missing_split_names[0], list(self.splits_basic_info.keys())[0]))
 
@@ -955,7 +955,7 @@ class ContigsSuperclass(object):
             else:
                 self.progress.reset()
                 raise ConfigError("Some of the functional sources you requested are missing from the contigs database '%s'. Here "
-                                  "they are (or here it is, whatever): %s." % \
+                                  "they are (or here it is, whatever): %s." %
                                                  (self.contigs_db_path, ', '.join(["'%s'" % s for s in missing_sources])))
         else:
             # if we are here, we have all the sources present
@@ -1129,7 +1129,7 @@ class ContigsSuperclass(object):
                               "something must have gone very wrong somewhere in the code ..." % (gene_caller_id, contig_name))
 
         if not pos_in_contig >= gene_call['start'] or not pos_in_contig < gene_call['stop']:
-            raise ConfigError("get_corresponding_codon_order_in_gene :: position %d does not occur in gene call %d :(" \
+            raise ConfigError("get_corresponding_codon_order_in_gene :: position %d does not occur in gene call %d :("
                               % (pos_in_contig, gene_caller_id))
 
         start, stop = gene_call['start'], gene_call['stop']
@@ -2001,7 +2001,7 @@ class PanSuperclass(object):
 
         F = lambda x: '[YES]' if x else '[NO]'
         self.run.info('Pan DB', 'Initialized: %s (v. %s)' % (self.pan_db_path, anvio.__pan__version__))
-        self.run.info('Gene cluster homogeneity estimates', 'Functional: %s; Geometric: %s; Combined: %s' % \
+        self.run.info('Gene cluster homogeneity estimates', 'Functional: %s; Geometric: %s; Combined: %s' %
                          (F(self.functional_homogeneity_info_is_available), F(self.geometric_homogeneity_info_is_available),
                           F(self.combined_homogeneity_info_is_available)),
                       mc="cyan")
@@ -2072,7 +2072,7 @@ class PanSuperclass(object):
 
         if not self.genomes_storage_is_available:
             raise ConfigError("The pan anvi'o super class for is upset. You are attempting to get AA sequences for %s,\
-                               but there is not genomes storage is available to get it." \
+                               but there is not genomes storage is available to get it."
                                     % 'a gene cluster' if len(gene_cluster_names) > 1 else '%d gene_clusters' % len(gene_cluster_names))
 
         if gene_clusters_dict is None:
@@ -2083,7 +2083,7 @@ class PanSuperclass(object):
         missing_gene_cluster_names = [p for p in gene_cluster_names if p not in gene_clusters_dict]
         if len(missing_gene_cluster_names[0:5]):
             raise ConfigError("get_sequences_for_gene_clusters: %d of %d gene clusters are missing in your data. Not good :/ "
-                              "Here are some of the missing ones; %s" \
+                              "Here are some of the missing ones; %s"
                                         % (len(missing_gene_cluster_names), len(gene_cluster_names), ', '.join(missing_gene_cluster_names[0:5])))
 
         self.progress.new('Accessing gene cluster sequences', progress_total_items=len(gene_cluster_names))
@@ -2253,7 +2253,7 @@ class PanSuperclass(object):
             output_queue.put(indices_dict)
 
 
-    def write_sequences_in_gene_clusters_to_file(self, gene_clusters_dict=None, gene_cluster_names=set([]), \
+    def write_sequences_in_gene_clusters_to_file(self, gene_clusters_dict=None, gene_cluster_names=set([]),
                                                   skip_alignments=False, output_file_path=None, report_DNA_sequences=False):
         if output_file_path:
             filesnpaths.is_output_file_writable(output_file_path)
@@ -2288,8 +2288,8 @@ class PanSuperclass(object):
         self.run.info('Output FASTA file', output_file_path, mc='green', nl_after=1)
 
 
-    def write_sequences_in_gene_clusters_for_phylogenomics(self, gene_clusters_dict=None, skip_alignments=False, \
-                                                output_file_path=None, report_DNA_sequences=False, align_with=None, \
+    def write_sequences_in_gene_clusters_for_phylogenomics(self, gene_clusters_dict=None, skip_alignments=False,
+                                                output_file_path=None, report_DNA_sequences=False, align_with=None,
                                                 separator=None, partition_file_path=None):
         if output_file_path:
             filesnpaths.is_output_file_writable(output_file_path)
@@ -3029,7 +3029,7 @@ class PanSuperclass(object):
                                --max-geometric-homogeneity-index %(max_gh)f, --min-combined-homogeneity-index %(min_ch)f, and --max-combined-homogeneity-index %(max_ch)f. \
                                None of your %(all_gcs)d gene clusters in your %(all_gs)d genomes that were included this analysis matched to this combination \
                                (please note that number of genomes may be smaller than the actual number of genomes in the original pan genome \
-                               if other filters were applied to the gene clusters dictionary prior)." % \
+                               if other filters were applied to the gene clusters dictionary prior)." %
                                             {'min_oc': min_num_genomes_gene_cluster_occurs, 'max_oc': max_num_genomes_gene_cluster_occurs,
                                              'min_g': min_num_genes_from_each_genome, 'max_g': max_num_genes_from_each_genome,
                                              'min_fh': min_functional_homogeneity_index, 'max_fh': max_functional_homogeneity_index,
@@ -3102,7 +3102,7 @@ class PanSuperclass(object):
         if len(genomes_to_remove) == len(all_genomes):
             raise ConfigError("Bad news: using --max-num-gene-clusters-missing-from-genome paramter with '%d' removed all of your "
                               "%d genomes from the analysis. This means every genome you have in your pangenome misses at least %d "
-                              "of your %d gene clusters. Now you know :/" \
+                              "of your %d gene clusters. Now you know :/"
                                     % (max_num_gene_clusters_missing_from_genome,
                                        len(all_genomes),
                                        max_num_gene_clusters_missing_from_genome,
@@ -3153,7 +3153,7 @@ class PanSuperclass(object):
             gene_clusters_dict = copy.deepcopy(self.gene_clusters)
 
         if not isinstance(gene_clusters_dict, dict):
-            raise ConfigError("Houston, we have a problem. The gene clusters dict seems to be of type %s and not dict :/"\
+            raise ConfigError("Houston, we have a problem. The gene clusters dict seems to be of type %s and not dict :/"
                             % type(gene_clusters_dict))
 
         # let's see what the user wants.
@@ -3282,7 +3282,7 @@ class PanSuperclass(object):
         else:
             self.run.info_single("A short announcement for the curious: anvi'o found %d gene clusters in the database, attempted to "
                                  "initialize a gene clusters dictionary for %d of them as requested by the user or the programmer, and "
-                                 "managed to get back a gene clusters dictionary with %d items. We just hope all these make sense to you." \
+                                 "managed to get back a gene clusters dictionary with %d items. We just hope all these make sense to you."
                                 % (len(self.gene_cluster_names_in_db), len(gene_cluster_ids_to_focus), len(self.gene_clusters)), nl_after=1, nl_before=1)
 
         # gene cluster names were set when we first initialized the class, but if we are here, it means the user may have
@@ -3357,7 +3357,7 @@ class PanSuperclass(object):
 
         if not self.gene_clusters:
             raise ConfigError("init_collection_profile wants to initialize the collection profile for '%s', but the "
-                               "the gene clusters dict is kinda empty :/ Someone forgot to initialize something maybe?" \
+                               "the gene clusters dict is kinda empty :/ Someone forgot to initialize something maybe?"
                                         % collection_name)
 
         # get trimmed collection and bins_info dictionaries
@@ -3619,7 +3619,7 @@ class ProfileSuperclass(object):
         elif self.collection_name and not utils.is_blank_profile(self.profile_db_path):
             self.run.warning("ProfileSuperClass found a collection focus, which means it will be initialized using only "
                              "the splits in the profile database that are affiliated with the collection %s and "
-                             "%s it describes." % (self.collection_name, \
+                             "%s it describes." % (self.collection_name,
                                                    'bins "%s" ' % ', '.join(self.bin_names) if self.bin_names else 'all bins'))
             self.split_names_of_interest = ccolections.GetSplitNamesInBins(self.args).get_split_names_only()
 
@@ -4922,7 +4922,7 @@ class ContigsDatabase:
         if len(missing_gene_calls):
             raise ConfigError("Your contigs database has %d genes, but it's missing %d of %d gene calls "
                               "you want to remove from it :/ This doesn't make sense. Here is one of those "
-                              "gene calls that were not in your database: %d" % \
+                              "gene calls that were not in your database: %d" %
                                     (len(gene_calls_in_db), len(missing_gene_calls), len(gene_caller_ids_to_remove), gene_caller_ids_to_remove[-1]))
 
         self.run.warning('%d gene calls %d is being removed from your contigs '
@@ -5092,7 +5092,7 @@ class ContigsDatabase:
                 raise ConfigError("At least one of the deflines in your FASTA File does not comply with the 'simple deflines' "
                                   "requirement of anvi'o. You can either use the script `anvi-script-reformat-fasta` to take "
                                   "care of this issue, or read this section in the tutorial to understand the reason behind "
-                                  "this requirement (anvi'o is very upset for making you do this): %s" % \
+                                  "this requirement (anvi'o is very upset for making you do this): %s" %
                                        ('http://merenlab.org/2016/06/22/anvio-tutorial-v2/#take-a-look-at-your-fasta-file'))
 
             if len(fasta.seq) < kmer_size:
@@ -5343,8 +5343,8 @@ class ContigsDatabase:
         self.run.info('Gene calling step skipped', skip_gene_calling, quiet=self.quiet)
         self.run.info("Splits broke genes (non-mindful mode)", skip_mindful_splitting, quiet=self.quiet)
         self.run.info('Desired split length (what the user wanted)', split_length, quiet=self.quiet)
-        self.run.info("Average split length (what anvi'o gave back)", (int(round(numpy.mean(recovered_split_lengths)))) \
-                                                                        if recovered_split_lengths \
+        self.run.info("Average split length (what anvi'o gave back)", (int(round(numpy.mean(recovered_split_lengths))))
+                                                                        if recovered_split_lengths
                                                                             else "(Anvi'o did not create any splits)", quiet=self.quiet)
 
 
@@ -5612,7 +5612,7 @@ class AA_counts(ContigsSuperclass):
 
         if not self.collection_name in collections_info_table:
             valid_collections = ', '.join(list(collections_info_table.keys()))
-            raise ConfigError("'%s' is not a valid collection name. But %s: '%s'." \
+            raise ConfigError("'%s' is not a valid collection name. But %s: '%s'."
                                     % (self.collection_name,
                                        'these are' if len(valid_collections) > 1 else 'this is',
                                        valid_collections))
@@ -5625,7 +5625,7 @@ class AA_counts(ContigsSuperclass):
 
             missing_bins = [b for b in bin_names_of_interest if b not in bin_names_in_collection]
             if len(missing_bins):
-                raise ConfigError("Some bin names you declared do not appear to be in the collection %s." \
+                raise ConfigError("Some bin names you declared do not appear to be in the collection %s."
                                             % self.collection_name)
         else:
             bin_names_of_interest = bin_names_in_collection
@@ -5741,7 +5741,7 @@ def update_description_in_db(anvio_db_path, description, run=run):
                     "and %d characters." % (db_type, len(description.split()), len(description)))
 
 
-def do_hierarchical_clustering_of_items(anvio_db_path, clustering_configs, split_names=[], database_paths={}, input_directory=None, default_clustering_config=None, \
+def do_hierarchical_clustering_of_items(anvio_db_path, clustering_configs, split_names=[], database_paths={}, input_directory=None, default_clustering_config=None,
                                 distance=constants.distance_metric_default, linkage=constants.linkage_method_default, run=run, progress=progress):
     """This is just an orphan function that computes hierarchical clustering w results
        and calls the `add_items_order_to_db` function with correct input.

--- a/anvio/drivers/MODELLER.py
+++ b/anvio/drivers/MODELLER.py
@@ -537,7 +537,7 @@ class MODELLER:
         # Find best match for align fraction and pident
         code_chain_id_of_best = tuple(search_df.iloc[search_df['proper_pident'].argmax()][['code', 'chain']].values)
         best_hit = search_df.loc[
-            (search_df['code'] == code_chain_id_of_best[0]) & \
+            (search_df['code'] == code_chain_id_of_best[0]) &
             (search_df['chain'] == code_chain_id_of_best[1]), ['pident', 'align_fraction']
         ].iloc[0]
 
@@ -555,7 +555,7 @@ class MODELLER:
         if not matches_after_filter:
             self.run.warning("Gene {} did not have a search result with percent identicalness above or equal "
                              "to {}% and alignment fraction above {}%. The best match was chain {} of https://www.rcsb.org/structure/{}, which had a "
-                             "percent identicalness of {:.2f}% and an alignment fraction of {:.3f}. No structure will be modelled.".\
+                             "percent identicalness of {:.2f}% and an alignment fraction of {:.3f}. No structure will be modelled.".
                               format(self.corresponding_gene_call,
                                      self.percent_cutoff,
                                      self.alignment_fraction_cutoff,
@@ -811,7 +811,7 @@ class MODELLER:
                 self.out["structure_exists"] = False
 
             raise ModellerScriptError("The MODELLER script {} did not execute properly. Hopefully it is clear "
-                                      "from the above error message. No structure is going to be modelled."\
+                                      "from the above error message. No structure is going to be modelled."
                                        .format(script_name))
 
         # If we made it this far, the MODELLER script ran to completion. Now check outputs exist

--- a/anvio/drivers/__init__.py
+++ b/anvio/drivers/__init__.py
@@ -62,7 +62,7 @@ class Aligners:
 
         if not quiet:
           self.run.warning("The workflow you are using will likely use '%s' by %s (%s) to align your sequences. "
-                           "If you publish your findings, please do not forget to properly credit this tool." \
+                           "If you publish your findings, please do not forget to properly credit this tool."
                                 % (aligner, _aligner().citation, _aligner().web), lc='yellow', header="CITATION")
 
         return self.aligners[aligner]

--- a/anvio/drivers/emapper.py
+++ b/anvio/drivers/emapper.py
@@ -121,13 +121,13 @@ class EggNOGMapper:
 
         if version_to_use not in self.available_parsers:
             if self.annotation:
-                raise ConfigError("Anvi'o does not know about the version you requested. Here are the ones available: %s" % \
+                raise ConfigError("Anvi'o does not know about the version you requested. Here are the ones available: %s" %
                                                         (', '.join(list(self.available_parsers.keys()))))
             else:
                 raise ConfigError("Bad news :( This version of anvi'o does not have a parser for the eggnog-mapper installed "
                                    "on your system. This is the version you have on your system (if this looks totally alien "
                                    "to you it may indicate another problem, in which case consider writing to anvi'o developers): "
-                                   "%s. For your reference, these are the versions anvi'o knows what to do with: %s" % \
+                                   "%s. For your reference, these are the versions anvi'o knows what to do with: %s" %
                                                         (version_to_use, ', '.join(list(self.available_parsers.keys()))))
 
         self.version_to_use = version_to_use
@@ -154,7 +154,7 @@ class EggNOGMapper:
             gene_callers_id = int(fields[0][len(self.gene_caller_id_prefix):])
         except:
             raise ConfigError("At least one gene caller id in this annotation file (%s) does not look like how anvi'o likes its gene calls. "
-                              "Hint: what should remain after removing gene caller id prefix (%s) should be an integer value." %\
+                              "Hint: what should remain after removing gene caller id prefix (%s) should be an integer value." %
                                                 (fields[0], self.gene_caller_id_prefix))
 
         return gene_callers_id

--- a/anvio/drivers/pyani.py
+++ b/anvio/drivers/pyani.py
@@ -71,7 +71,7 @@ class PyANI:
             raise ConfigError("PyANI returned with non-zero exit code, there may be some errors. "
                              "please check the log file for details.")
 
-        output_matrix_names = ['alignment_coverage', 'alignment_lengths', 'hadamard', \
+        output_matrix_names = ['alignment_coverage', 'alignment_lengths', 'hadamard',
                                'percentage_identity', 'similarity_errors', 'correlations']
 
         full_matrix_path = lambda name: os.path.join(input_path, 'output', self.method + '_' + name + '.tab')
@@ -88,7 +88,7 @@ class PyANI:
 
         if not self.quiet:
             self.run.info_single("Output matrices for the following items are stored in the output "
-                                 "directory: %s <success kid meme.png>." % \
+                                 "directory: %s <success kid meme.png>." %
                                             (', '.join(["'%s'" % m.replace('_', ' ') for m in matrices])), nl_before=1, mc='green')
 
         # restore old working directory

--- a/anvio/drivers/trnscan_se.py
+++ b/anvio/drivers/trnscan_se.py
@@ -94,7 +94,7 @@ class tRNAScanSE:
                              "with. Anvi'o will continue to try to run everything as if this didn't happen. If you see this warning "
                              "but everything works fine, let us know so we can include this version number into the list of 'tested' "
                              "version numbers. If you see an unexpected error, please consider installing one of these versions "
-                             "of tRNAScan-SE (and again please let us know anyway so we can address it for later): '%s'" % \
+                             "of tRNAScan-SE (and again please let us know anyway so we can address it for later): '%s'" %
                                            (self.program_name, version_found, ', '.join(list(self.tested_versions))))
 
         self.installed_version = version_found
@@ -143,7 +143,7 @@ class tRNAScanSE:
                 if not len(fields) == 10:
                     raise ConfigError("The expected output of tRNAScan-SE includes exactly 10 columns. However, the output "
                                       "anvi'o is working contains at least one line with %d columns :/ This doesn't look "
-                                      "good. Here is the list of columns data of that line for your reference: '%s'." \
+                                      "good. Here is the list of columns data of that line for your reference: '%s'."
                                                             % (len(fields), fields))
 
                 d[entry_no] = {'contig_name': fields[0],

--- a/anvio/fastalib.py
+++ b/anvio/fastalib.py
@@ -125,7 +125,7 @@ class SequenceSource():
                                                'seq': self.seq,
                                                'count': 1}
 
-        self.unique_hash_list = [i[1] for i in sorted([(self.unique_hash_dict[hash]['count'], hash)\
+        self.unique_hash_list = [i[1] for i in sorted([(self.unique_hash_dict[hash]['count'], hash)
                         for hash in self.unique_hash_dict], reverse=True)]
 
 

--- a/anvio/filesnpaths.py
+++ b/anvio/filesnpaths.py
@@ -491,7 +491,7 @@ def gen_output_directory(output_directory, progress=Progress(verbose=False), run
             os.makedirs(output_directory)
         except:
             progress.end()
-            raise FilesNPathsError("Output directory does not exist (attempt to create one failed as well): '%s'" % \
+            raise FilesNPathsError("Output directory does not exist (attempt to create one failed as well): '%s'" %
                                                             (output_directory))
     if not os.access(output_directory, os.W_OK):
         progress.end()
@@ -631,10 +631,10 @@ class AppendableFile:
 
         import anvio.utils as utils
         if is_file_empty(self.path):
-            utils.store_dict_as_TAB_delimited_file(dict_to_append, None, headers=self.headers, file_obj=file_handle, \
-                                                    key_header=self.key_header, keys_order=self.keys_order, \
-                                                    header_item_conversion_dict=self.header_item_conversion_dict, \
-                                                    do_not_close_file_obj=True, do_not_write_key_column=self.do_not_write_key_column, \
+            utils.store_dict_as_TAB_delimited_file(dict_to_append, None, headers=self.headers, file_obj=file_handle,
+                                                    key_header=self.key_header, keys_order=self.keys_order,
+                                                    header_item_conversion_dict=self.header_item_conversion_dict,
+                                                    do_not_close_file_obj=True, do_not_write_key_column=self.do_not_write_key_column,
                                                     none_value=self.none_value)
         else:
             # if dictionary is empty, just return

--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -277,7 +277,7 @@ class GenomeDescriptions(object):
                              "identical to each other). But since you have instructed anvi'o to ignore that "
                              "it is now continuing with the flow (even though %d hashes for your internal "
                              "genomes and %d) hashes for your external genomes appeared more than once). "
-                             "See below the genome names with identical hashes:" \
+                             "See below the genome names with identical hashes:"
                                      % (len(self.internal_genomes_with_identical_hashes),
                                         len(self.external_genomes_with_identical_hashes)),
                                         overwrite_verbose=True)
@@ -407,7 +407,7 @@ class GenomeDescriptions(object):
                 self.run.warning("Some of your genomes (%d of the %d, to be precise) seem to have no functional annotation. Since this workflow "
                                  "can only use matching functional annotations across all genomes involved, having even one genome without "
                                  "any functions means that there will be no matching function across all. Things will continue to work, but "
-                                 "you will have no functions at the end for your gene clusters." % \
+                                 "you will have no functions at the end for your gene clusters." %
                                                 (len(genomes_with_no_functional_annotation), len(self.genomes)))
 
             # make sure it is clear.
@@ -434,7 +434,7 @@ class GenomeDescriptions(object):
                 # none of the functions are common
                 self.run.warning("Although some of your genomes had some functional annotations, none of them were common to all genomes :/ "
                                  "Anvi'o will continue working with them, but you will have no functions available to you downstream. Just "
-                                 "so you know, these are the annotation sources observed at least once in at least one of your genomes: '%s'" % \
+                                 "so you know, these are the annotation sources observed at least once in at least one of your genomes: '%s'" %
                                                                     (', '.join(all_function_annotation_sources_observed)))
                 self.functions_are_available = False
             else:
@@ -448,7 +448,7 @@ class GenomeDescriptions(object):
                                      "functional annotation sources that are common to all of your genomes, and they will be used whenever "
                                      "it will be appropriate. Here they are: '%s'. The bad news is you had more function annotation sources, "
                                      "but they were not common to all genomes. Here they are so you can say your goodbyes to them (because "
-                                     "they will not be used): '%s'" % \
+                                     "they will not be used): '%s'" %
                                             (', '.join(self.function_annotation_sources), ', '.join(self.function_annotation_sources_some_genomes_miss)))
                 else:
                     # every function ever observed is common to all genomes.
@@ -661,7 +661,7 @@ class GenomeDescriptions(object):
             info = []
             for genome_name in genomes_with_non_reported_gene_calls_from_other_gene_callers:
                 info.append('%s (%s)' % (genome_name,
-                                         ', '.join(['%d gene calls by "%s"' % (tpl[1], tpl[0]) for \
+                                         ', '.join(['%d gene calls by "%s"' % (tpl[1], tpl[0]) for
                                                          tpl in self.genomes[genome_name]['gene_calls_from_other_gene_callers'].items()])))
 
             gene_caller = list(self.genomes.values())[0]['gene_caller']
@@ -671,13 +671,13 @@ class GenomeDescriptions(object):
                                  "the gene caller anvi'o used, which was set to '%s' either by default, or because you asked for it. "
                                  "The following genomes contained genes that were not processed (this may be exactly what you expect "
                                  "to happen, but if was not, you may need to use the `--gene-caller` flag to make sure anvi'o is using "
-                                 "the gene caller it should be using): %s." % \
+                                 "the gene caller it should be using): %s." %
                                                 (gene_caller, ', '.join(info)), header="PLEASE READ CAREFULLY", lc='green')
             else:
                 self.progress.reset()
                 self.run.warning("Some of your genomes had gene calls identified by gene callers other than "
                                  "the anvi'o default, '%s', and will not be processed. Use the `--debug` flag "
-                                 "if this sounds important and you would like to see more of this message." % \
+                                 "if this sounds important and you would like to see more of this message." %
                                                 (gene_caller), header="JUST FYI", lc='green')
 
         # check whether every genome has at least one gene call.

--- a/anvio/genomesimilarity.py
+++ b/anvio/genomesimilarity.py
@@ -188,7 +188,7 @@ class Dereplicate:
 
         if self.similarity_threshold < 0 or self.similarity_threshold > 1:
             raise ConfigError("When anvi'o collapses %s's output into a similarity matrix, all values are reported as "
-                             "similaritys between 0 and 1. %.2f can't be used to determine redundant genomes"\
+                             "similaritys between 0 and 1. %.2f can't be used to determine redundant genomes"
                               % (self.program_name, self.similarity_threshold))
 
         if self.representative_method == "Qscore" and not (self.external_genomes or self.internal_genomes):
@@ -964,7 +964,7 @@ class ANI(GenomeSimilarity):
                             "and was below your threshold, and so the ANI scores will be ignored (set to 0) for all downstream "
                             "reports you will find in anvi'o tables and visualizations. %sAnvi'o kindly invites you "
                             "to carefully think about potential implications of discarding hits based on an arbitrary alignment "
-                            "fraction, but does not judge you because it is not perfect either." % \
+                            "fraction, but does not judge you because it is not perfect either." %
                                                     (self.min_alignment_fraction,
                                                      num_anvio_wants_to_remove_via_alignment_fraction,
                                                      len(d), g1, float(self.results['percentage_identity'][g1][g2]), g2, g1, g2,
@@ -976,7 +976,7 @@ class ANI(GenomeSimilarity):
                              "than '%.2f'). Anvi'o found %d such instances between the pairwise "
                              "comparisons of your %d genomes, but the --significant-alignment-length parameter "
                              "saved them all, because each one of them were longer than %d nts. So your filters kinda cancelled "
-                             "each other out. Just so you know." % \
+                             "each other out. Just so you know." %
                                                     (self.min_alignment_fraction,
                                                      num_anvio_wants_to_remove_via_alignment_fraction, len(d),
                                                      self.significant_alignment_length))

--- a/anvio/genomestorage.py
+++ b/anvio/genomestorage.py
@@ -172,8 +172,8 @@ class GenomeStorage(object):
                 raise ConfigError("%d of %d genome names you wanted to focus are missing from the genomes sotrage. "
                                 "Although this may not be a show-stopper, anvi'o likes to be explicit, so here we "
                                 "are. Not going anywhere until you fix this. For instance this is one of the missing "
-                                "genome names: '%s', and this is one random genome name from the database: '%s'" % \
-                                         (len(genome_names_to_focus_missing_from_db), len(self.genome_names_to_focus),\
+                                "genome names: '%s', and this is one random genome name from the database: '%s'" %
+                                         (len(genome_names_to_focus_missing_from_db), len(self.genome_names_to_focus),
                                          genome_names_to_focus_missing_from_db[0], ', '.join(self.genome_names_in_db)))
 
             self.genome_names = self.genome_names_to_focus

--- a/anvio/hmmops.py
+++ b/anvio/hmmops.py
@@ -219,15 +219,15 @@ class SequencesForHMMHits:
 
         self.progress.update('Recovering contig seqs for %d genes' % (len(gene_caller_ids_of_interest)))
         where_clause_for_contigs = "contig in (%s)" % ', '.join(['"%s"' % s for s in contig_names_of_interest])
-        self.contig_sequences = contigs_db.get_some_rows_from_table_as_dict(t.contig_sequences_table_name, \
-                                                                            string_the_key=True, \
+        self.contig_sequences = contigs_db.get_some_rows_from_table_as_dict(t.contig_sequences_table_name,
+                                                                            string_the_key=True,
                                                                             where_clause=where_clause_for_contigs)
 
         self.progress.update('Recovering amino acid seqs for %d genes' % (len(gene_caller_ids_of_interest)))
-        self.aa_sequences = contigs_db.get_some_rows_from_table_as_dict(t.gene_amino_acid_sequences_table_name, \
+        self.aa_sequences = contigs_db.get_some_rows_from_table_as_dict(t.gene_amino_acid_sequences_table_name,
                                                                         where_clause=where_clause_for_genes)
 
-        self.genes_in_contigs = contigs_db.get_some_rows_from_table_as_dict(t.genes_in_contigs_table_name, \
+        self.genes_in_contigs = contigs_db.get_some_rows_from_table_as_dict(t.genes_in_contigs_table_name,
                                                                             where_clause=where_clause_for_genes)
 
         self.splits_in_contigs = list(split_names_of_interest)
@@ -372,7 +372,7 @@ class SequencesForHMMHits:
             source    = entry['source']
             gene_name = entry['gene_name'].strip()
 
-            if source in sources and (not dont_include_models_with_multiple_domain_hits or (source not in models_to_remove) or \
+            if source in sources and (not dont_include_models_with_multiple_domain_hits or (source not in models_to_remove) or
                                                     gene_name not in models_to_remove[source]):
                 gene_hit_counts[source][gene_name] += 1
 
@@ -524,7 +524,7 @@ class SequencesForHMMHits:
 
         for gene_callers_id in hits_per_gene_caller_id:
             if len(hits_per_gene_caller_id[gene_callers_id]) > 1:
-                hit_ids_to_remove = [tpl[1] for tpl in sorted([(hmm_sequences_dict_for_splits[hit]['e_value'], hit) \
+                hit_ids_to_remove = [tpl[1] for tpl in sorted([(hmm_sequences_dict_for_splits[hit]['e_value'], hit)
                                                                     for hit in hits_per_gene_caller_id[gene_callers_id]])[1:]]
                 for hit_id_to_remove in hit_ids_to_remove:
                     hmm_sequences_dict_for_splits.pop(hit_id_to_remove)
@@ -756,7 +756,7 @@ class SequencesForHMMHits:
         self.run.info_single("Hi! The anvi'o function that was supposed to remove genes that were occurring in "
                              "less than X number of bins due to the use of `--min-num-bins-gene-occurs` is "
                              "speaking. What follows is a report of what happened after anvi'o tried to remove "
-                             "genes that were occurring in at least %d of the %d bins you had at this point." \
+                             "genes that were occurring in at least %d of the %d bins you had at this point."
                                     % (min_num_bins_gene_occurs, len(all_bins)), nl_before=1, nl_after=1)
 
         self.run.info('All genes (%d)' % len(all_genes), ', '.join(all_genes), nl_after=1)
@@ -922,7 +922,7 @@ class SequencesForHMMHits:
                 raise ConfigError("One or more gene names in the genes order list does seem to appear among the genes described "
                                   "by the HMM sources (which translates to 'terrible news'). Here are the genes that cause this "
                                   "issue if you want to fix this: '%s' (and here are the HMM sources you have been using for this "
-                                  "operation in case it helps: '%s')." \
+                                  "operation in case it helps: '%s')."
                                               % (', '.join(genes_in_genes_order_but_missing_in_hmm_source), ', '.join(self.sources)))
             gene_names = genes_order
         else:
@@ -953,8 +953,8 @@ class SequencesForHMMHits:
         for i in range(0, num_genes):
             gene_name = all_gene_names[i]
             self.progress.update('working on %s (%d of %d) ...' % (gene_name, i + 1, num_genes))
-            genes_list = [(bin_name, genes_in_bins_dict[gene_name][bin_name]) \
-                                                        for bin_name in genes_in_bins_dict[gene_name] \
+            genes_list = [(bin_name, genes_in_bins_dict[gene_name][bin_name])
+                                                        for bin_name in genes_in_bins_dict[gene_name]
                                                                            if bin_name in genes_in_bins_dict[gene_name]]
             genes_in_bins_dict[gene_name] = aligner(run=terminal.Run(verbose=False)).run_default(genes_list, debug=anvio.DEBUG)
             gene_lengths[gene_name] = len(list(genes_in_bins_dict[gene_name].values())[0])
@@ -992,7 +992,7 @@ class SequencesForHMMHits:
             run.warning("You asked for some genes that were missing from all bins this class had in the "
            "HMM hits dictionary (here is a list of them: '%s'). Not knowing what to do with this werid "
            "situation, anvi'o put gap characters for all of them and retained your order. Here are those "
-           "genes that missed the party: '%s'" % \
+           "genes that missed the party: '%s'" %
                 (', '.join(bin_names_in_dict), ', '.join(set(gene_names_missing_from_everywhere))))
 
         f.close()

--- a/anvio/homogeneityindex.py
+++ b/anvio/homogeneityindex.py
@@ -52,7 +52,7 @@ class HomogeneityCalculator(object):
 
                     if amino_acid_residue_1 != "-" and amino_acid_residue_2 != "-":
                         max_score += 3
-                        if amino_acid_residue_1 == amino_acid_residue_2 and (amino_acid_residue_1 != 'X' and amino_acid_residue_1 != 'J' \
+                        if amino_acid_residue_1 == amino_acid_residue_2 and (amino_acid_residue_1 != 'X' and amino_acid_residue_1 != 'J'
                                                                             and amino_acid_residue_1 != 'B' and amino_acid_residue_1 != 'Z'):
                             similarity_score += 3
                         elif utils.is_amino_acid_functionally_conserved(amino_acid_residue_1,amino_acid_residue_2):

--- a/anvio/interacdome.py
+++ b/anvio/interacdome.py
@@ -526,7 +526,7 @@ class InteracDomeTableData(object):
         }
 
         if kind not in self.files:
-            raise ConfigError("Unknown kind '%s' of InteracDome data. Known kinds: %s" \
+            raise ConfigError("Unknown kind '%s' of InteracDome data. Known kinds: %s"
                               % (kind, ','.join(list(self.files.keys()))))
 
         self.filepath = self.files[self.kind]

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -535,8 +535,8 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
         contig_name_to_splits_dict = utils.get_contig_name_to_splits_dict(self.contigs_db_path)
 
         # get a list of contig names based on their lengths
-        contig_names_sorted_by_length = [tpl[0] \
-                for tpl in sorted([(k, self.contigs_basic_info[k]['length']) \
+        contig_names_sorted_by_length = [tpl[0]
+                for tpl in sorted([(k, self.contigs_basic_info[k]['length'])
                 for k in self.contigs_basic_info], key = lambda x: x[1], reverse=True)]
 
         split_names = set(self.displayed_item_names_ordered)
@@ -1762,7 +1762,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
                              "this step. Another way to do it is the good ol' way of ignoring these warnings as you usually "
                              "do. If you do the latter, you will probably be fine. But we wanted to keep you in the loop "
                              "just in case you are not fine and the code does not realize that yet. The sources for gene "
-                             "calls that will not be included in your gene view include these ones: '%s'." % \
+                             "calls that will not be included in your gene view include these ones: '%s'." %
                                     (len(gene_caller_ids_missing_in_gene_level_cov_stats_dict),
                                      ', '.join(gene_caller_sources_for_missing_gene_caller_ids_in_gene_level_cov_stats_dict)))
 
@@ -1922,7 +1922,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
             raise ConfigError("There are some split names in your additional view data file ('%s') that are missing from "
                                "split names characterized in the database. There are in fact %d of them. For instance, "
                                "here is a random split name that is in your additional view data, yet not in the database: "
-                               "'%s'. This is not going to work for anvi'o :/" \
+                               "'%s'. This is not going to work for anvi'o :/"
                                     % (self.additional_view_path, len(splits_in_additional_view_but_not_in_tree), splits_in_additional_view_but_not_in_tree.pop()))
 
         if splits_in_tree_but_not_in_view_data:
@@ -1935,7 +1935,7 @@ class Interactive(ProfileSuperclass, PanSuperclass, ContigsSuperclass):
 
         if splits_in_tree_but_not_in_database:
             raise ConfigError('Some split names found in your tree are missing from your database. Hard to '
-                               'know why is this the case, but here is a couple of them: %s'\
+                               'know why is this the case, but here is a couple of them: %s'
                                     % ', '.join(list(splits_in_tree_but_not_in_database)[0:5]))
 
         if self.additional_layers_path:

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -335,7 +335,7 @@ class Inversions:
             # extend start and stop positions of merged stretches to ENSURE we are not
             # missing important information because bioinformatics.
             coverage_stretches_in_contigs[contig_name] = [(0 if (e[0] - self.num_nts_to_pad_a_stretch< 0) else e[0] - self.num_nts_to_pad_a_stretch,
-                                                           contig_length if (e[1] + self.num_nts_to_pad_a_stretch) > contig_length else e[1] + self.num_nts_to_pad_a_stretch) \
+                                                           contig_length if (e[1] + self.num_nts_to_pad_a_stretch) > contig_length else e[1] + self.num_nts_to_pad_a_stretch)
                                                                 for e in coverage_stretches_in_contigs[contig_name]]
 
         ################################################################################

--- a/anvio/kgmlnetworkops.py
+++ b/anvio/kgmlnetworkops.py
@@ -1010,16 +1010,16 @@ class KGMLNetworkWalker:
                         kgml_compound_entries=current_chain.kgml_compound_entries.copy(),
                         is_consumed=is_explore_consumption,
                         kgml_reactions=current_chain.kgml_reactions + [kgml_reaction],
-                        kgml_reaction_directions=\
+                        kgml_reaction_directions=
                             current_chain.kgml_reaction_directions + [is_forward],
                         gaps=current_chain.gaps + [is_gap] if self.network else [],
-                        aliased_modelseed_compounds=\
-                            current_chain.aliased_modelseed_compounds.copy() \
+                        aliased_modelseed_compounds=
+                            current_chain.aliased_modelseed_compounds.copy()
                                 if self.network else [],
-                        network_kos=current_chain.network_kos + [tuple(network_kos)] \
+                        network_kos=current_chain.network_kos + [tuple(network_kos)]
                             if self.network else [],
-                        aliased_modelseed_reactions=\
-                            current_chain.aliased_modelseed_reactions + \
+                        aliased_modelseed_reactions=
+                            current_chain.aliased_modelseed_reactions +
                                 [tuple(modelseed_reactions)] if self.network else []
                     )
                     candidate_terminal_chain: Chain = \

--- a/anvio/mcgclassifier.py
+++ b/anvio/mcgclassifier.py
@@ -311,7 +311,7 @@ class MetagenomeCentricGeneClassifier:
             fig.suptitle("%s - histogram of non-outliers" % sample)
             # adding the mean and std of the non-outliers as text to the plot
             text_for_hist = u'$\mu = %d$\n $\sigma = %d$' %\
-                                (self.samples_coverage_stats_dicts['non_outlier_mean_coverage'][sample],\
+                                (self.samples_coverage_stats_dicts['non_outlier_mean_coverage'][sample],
                                  self.samples_coverage_stats_dicts['non_outlier_coverage_std'][sample])
             ax.text(0.8, 0.9, text_for_hist, ha='center', va='center', transform=ax.transAxes)
             plt.savefig(pdf_output_file, format='pdf')
@@ -505,7 +505,7 @@ class MetagenomeCentricGeneClassifier:
         # the results of the classifier per sample
 
         for sample in self.samples_detection_information:
-            TSC = [g for g in self.gene_class_df.index if (self.gene_class_df.loc[g,'coverage_consistency'] and \
+            TSC = [g for g in self.gene_class_df.index if (self.gene_class_df.loc[g,'coverage_consistency'] and
                                                             self.gene_class_df.loc[g,'core'])]
             self.samples_detection_information['number_of_taxon_specific_core_detected'] = len(TSC)
 
@@ -618,11 +618,11 @@ def get_non_outliers_information(v, MAD_threshold=2.5, zeros_are_outliers=False)
     return non_outlier_indices, d
 
 # The order of the strings is very important since it is used in get_class_string
-class_short_names = ['NNA', 'SNA', 'NCA',\
-                     'SCA', 'NNC', 'SNC',\
+class_short_names = ['NNA', 'SNA', 'NCA',
+                     'SCA', 'NNC', 'SNC',
                      'NCC', 'SCC']
-class_long_names = ['Non-specific_Non-consistent_Accessory', 'Specific_Non-consistent_Accessory', 'Non-specific_Consistent_Accessory',\
-                    'Specific_Consistent_Accessory', 'Non-specific_Non-consistent_Core', 'Specific_Non-consistent_Core',\
+class_long_names = ['Non-specific_Non-consistent_Accessory', 'Specific_Non-consistent_Accessory', 'Non-specific_Consistent_Accessory',
+                    'Specific_Consistent_Accessory', 'Non-specific_Non-consistent_Core', 'Specific_Non-consistent_Core',
                     'Non-specific_Consistent_Core', 'Specific_Consistent_Core']
 class_short_name_long_name_dict = dict(zip(class_short_names,class_long_names))
 

--- a/anvio/merger.py
+++ b/anvio/merger.py
@@ -113,7 +113,7 @@ class MultipleRuns:
                              "all of them were single, non-blank anvi'o profiles. Anvi'o removed %d of them, and will merge "
                              "only the remaining %d. At the end of this warning you will find a list of paths to those databases "
                              "anvi'o excluded from merging. If you are not happy with that, please carefully examine what went wrong. "
-                             "Here are all the paths for excluded databases: %s." \
+                             "Here are all the paths for excluded databases: %s."
                                             % (len(self.input_profile_db_paths), len(improper), len(proper), ', '.join(["'%s'" % p for p in improper])))
 
         # replace input profile database paths with proper paths:
@@ -124,7 +124,7 @@ class MultipleRuns:
         if data_group_names:
             self.run.warning("Anvi'o found %d data groups for taxonomy (%s), and will do its best to make sure they "
                              "get worked into the merged profile database. A moment of zero promises but crossed "
-                             "fingers (which is the best way to avoid most computational poopsies)." % \
+                             "fingers (which is the best way to avoid most computational poopsies)." %
                                                 (len(data_group_names), ', '.join(data_group_names)),
                               header="GOOD NEWS",
                               lc="green")
@@ -455,13 +455,13 @@ class MultipleRuns:
                              "(which becomes the center tree in all anvi'o displays). If you want a hierarchical "
                              "clustering to be done anyway, please see the flag `--enforce-hierarchical-clustering`. "
                              "But more importantly, please take a look at the anvi'o tutorial to make sure you know "
-                             "your better options to analyze large metagenomic datasets with anvi'o." \
+                             "your better options to analyze large metagenomic datasets with anvi'o."
                                                                 % pp(self.max_num_splits_for_hierarchical_clustering))
             self.skip_hierarchical_clustering = True
 
         if self.num_splits > self.max_num_splits_for_hierarchical_clustering and self.enforce_hierarchical_clustering:
             self.run.warning("Because you have used the flag `--enforce-hierarchical-clustering`, anvi'o will attempt "
-                             "to create a hierarchical clustering of your %s splits. It may take a bit of time..." \
+                             "to create a hierarchical clustering of your %s splits. It may take a bit of time..."
                                                                 % pp(self.num_splits))
 
         self.total_reads_mapped_per_sample = dict([(s, self.layer_additional_data_dict['default'][s]['total_reads_mapped']) for s in self.layer_additional_data_dict['default']])
@@ -610,7 +610,7 @@ class MultipleRuns:
                              "available in the merged profile, clustering of some of the essential data "
                              "failed. It is likely not a very big deal, but you shall be the judge of it. "
                              "Anvi'o now proceeds to store layers order information for those view items "
-                             "the clustering in fact worked. Here is the list of stuff that failed: '%s'"\
+                             "the clustering in fact worked. Here is the list of stuff that failed: '%s'"
                               % (', '.join(failed_attempts)))
 
         # add the layer orders quietly
@@ -684,6 +684,6 @@ class MultipleRuns:
         self.run.info_single("Anvi'o hierarchical clustering of contigs...", nl_before=1, nl_after=1, mc="blue")
 
         if not self.skip_hierarchical_clustering:
-            dbops.do_hierarchical_clustering_of_items(self.merged_profile_db_path, self.clustering_configs, self.split_names, self.database_paths, \
-                                                      input_directory=self.output_directory, default_clustering_config=constants.merged_default, \
+            dbops.do_hierarchical_clustering_of_items(self.merged_profile_db_path, self.clustering_configs, self.split_names, self.database_paths,
+                                                      input_directory=self.output_directory, default_clustering_config=constants.merged_default,
                                                       distance=self.distance, linkage=self.linkage, run=self.run, progress=self.progress)

--- a/anvio/metabolicexchanges.py
+++ b/anvio/metabolicexchanges.py
@@ -1427,7 +1427,7 @@ class ExchangePredictorMulti(ExchangePredictorArgs):
             self.run.info_single(f"Child process is starting prediction with an ExchangePredictorSingle class using {args_single.num_threads} threads."
                                  f"If this value is one less than the number provided to the --num-threads parameter, everything is fine. The child "
                                  f"process itself is using 1 thread so we don't let it spawn more than N-1 additional processes.")
-        data_dicts_for_one_pair, failed_maps_list = ExchangePredictorSingle(args_single, progress=progress_quiet, run=run_quiet \
+        data_dicts_for_one_pair, failed_maps_list = ExchangePredictorSingle(args_single, progress=progress_quiet, run=run_quiet
                                                             ).predict_exchanges(output_files_dictionary=self.output_file_dict,
                                                             return_data_dicts=True)
 

--- a/anvio/metabolism/estimate.py
+++ b/anvio/metabolism/estimate.py
@@ -1647,8 +1647,8 @@ class KeggMetabolismEstimator(KeggEstimatorArgs, KeggDataLoader, KeggEstimationA
                                   "for the %s output mode. Something is terribly wrong, and it is probably a developer's fault. :("
                                   % (mode))
             if self.available_modes[mode]["data_dict"] == 'modules':
-                output_dict = self.generate_output_dict_for_modules(module_superdict_for_list_of_splits, headers_to_include=header_list, \
-                                                                    only_complete_modules=self.only_complete, \
+                output_dict = self.generate_output_dict_for_modules(module_superdict_for_list_of_splits, headers_to_include=header_list,
+                                                                    only_complete_modules=self.only_complete,
                                                                     exclude_zero_completeness=self.exclude_zero_modules)
             elif self.available_modes[mode]["data_dict"] == 'kofams':
                 output_dict = self.generate_output_dict_for_kofams(ko_superdict_for_list_of_splits, headers_to_include=header_list)
@@ -1683,8 +1683,8 @@ class KeggMetabolismEstimator(KeggEstimatorArgs, KeggDataLoader, KeggEstimationA
                                   "for the %s output mode. Something is terribly wrong, and it is probably a developer's fault. :("
                                   % (mode))
             if self.available_modes[mode]["data_dict"] == 'modules':
-                output_dict = self.generate_output_dict_for_modules(module_superdict, headers_to_include=header_list, \
-                                                                    only_complete_modules=self.only_complete, \
+                output_dict = self.generate_output_dict_for_modules(module_superdict, headers_to_include=header_list,
+                                                                    only_complete_modules=self.only_complete,
                                                                     exclude_zero_completeness=self.exclude_zero_modules)
             elif self.available_modes[mode]["data_dict"] == 'kofams':
                 output_dict = self.generate_output_dict_for_kofams(ko_superdict, headers_to_include=header_list)
@@ -2105,12 +2105,12 @@ class KeggMetabolismEstimatorMulti(KeggEstimatorArgs, KeggDataLoader):
             if not self.matrix_format:
                 KeggMetabolismEstimator(args, progress=progress_quiet, run=run_quiet).estimate_metabolism(output_files_dictionary=files_dict)
             else:
-                metabolism_super_dict[metagenome_name], ko_hits_super_dict[metagenome_name], module_steps_super_dict[metagenome_name] = KeggMetabolismEstimator(args, \
-                                                                                                    progress=progress_quiet, \
-                                                                                                    run=run_quiet).estimate_metabolism(skip_storing_data=True, \
-                                                                                                    return_subset_for_matrix_format=True, \
-                                                                                                    all_modules_in_db=self.all_modules_in_db, \
-                                                                                                    all_kos_in_db=self.all_kos_in_db, \
+                metabolism_super_dict[metagenome_name], ko_hits_super_dict[metagenome_name], module_steps_super_dict[metagenome_name] = KeggMetabolismEstimator(args,
+                                                                                                    progress=progress_quiet,
+                                                                                                    run=run_quiet).estimate_metabolism(skip_storing_data=True,
+                                                                                                    return_subset_for_matrix_format=True,
+                                                                                                    all_modules_in_db=self.all_modules_in_db,
+                                                                                                    all_kos_in_db=self.all_kos_in_db,
                                                                                                     module_paths_dict=self.module_paths_dict)
 
             self.progress.increment()
@@ -2316,22 +2316,22 @@ class KeggMetabolismEstimatorMulti(KeggEstimatorArgs, KeggDataLoader):
         module_list.sort()
 
         for stat, key in module_matrix_stats.items():
-            self.write_stat_to_matrix(stat_name=stat, stat_header='module', stat_key=key, stat_dict=module_superdict_multi, \
-                                      item_list=module_list, stat_metadata_headers=MODULE_METADATA_HEADERS, \
+            self.write_stat_to_matrix(stat_name=stat, stat_header='module', stat_key=key, stat_dict=module_superdict_multi,
+                                      item_list=module_list, stat_metadata_headers=MODULE_METADATA_HEADERS,
                                       write_rows_with_all_zeros=include_zeros)
 
         module_step_list = list(steps_superdict_multi[first_sample][first_bin].keys())
         module_step_list.sort()
         for stat, key in module_step_matrix_stats.items():
-            self.write_stat_to_matrix(stat_name=stat, stat_header='module_step', stat_key=key, stat_dict=steps_superdict_multi, \
-                                      item_list=module_step_list, stat_metadata_headers=STEP_METADATA_HEADERS, \
+            self.write_stat_to_matrix(stat_name=stat, stat_header='module_step', stat_key=key, stat_dict=steps_superdict_multi,
+                                      item_list=module_step_list, stat_metadata_headers=STEP_METADATA_HEADERS,
                                       write_rows_with_all_zeros=include_zeros)
 
         # now we make a KO hit count matrix
         ko_list = list(self.ko_dict.keys())
         ko_list.sort()
-        self.write_stat_to_matrix(stat_name='enzyme_hits', stat_header='enzyme', stat_key='num_hits', stat_dict=ko_superdict_multi, \
-                                  item_list=ko_list, stat_metadata_headers=KO_METADATA_HEADERS, \
+        self.write_stat_to_matrix(stat_name='enzyme_hits', stat_header='enzyme', stat_key='num_hits', stat_dict=ko_superdict_multi,
+                                  item_list=ko_list, stat_metadata_headers=KO_METADATA_HEADERS,
                                   write_rows_with_all_zeros=include_zeros)
 
         # if necessary, make module specific KO matrices
@@ -2385,8 +2385,8 @@ class KeggMetabolismEstimatorMulti(KeggEstimatorArgs, KeggDataLoader):
                     step_comments = None
 
                 stat = f"{mod}_enzyme_hits"
-                self.write_stat_to_matrix(stat_name=stat, stat_header="enzyme", stat_key='num_hits', stat_dict=ko_superdict_multi, \
-                                          item_list=kos_in_mod, stat_metadata_headers=KO_METADATA_HEADERS, \
+                self.write_stat_to_matrix(stat_name=stat, stat_header="enzyme", stat_key='num_hits', stat_dict=ko_superdict_multi,
+                                          item_list=kos_in_mod, stat_metadata_headers=KO_METADATA_HEADERS,
                                           write_rows_with_all_zeros=True, comment_dictionary=step_comments)
 
             if skipped_mods:

--- a/anvio/migrations/contigs/v14_to_v15.py
+++ b/anvio/migrations/contigs/v14_to_v15.py
@@ -59,7 +59,7 @@ def migrate(db_path):
 
     progress.end()
     run.info_single("The contigs database is now %s. This upgrade added two more table to your contigs database "
-                    "so it can store data annotations at the nucleotide and amino acid levels" \
+                    "so it can store data annotations at the nucleotide and amino acid levels"
                     % (next_version), nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/contigs/v16_to_v17.py
+++ b/anvio/migrations/contigs/v16_to_v17.py
@@ -88,7 +88,7 @@ def migrate(db_path):
     contigs_db.disconnect()
 
     run.info_single("Your contigs db is now %s. This update carried one more issue into the graveyard "
-                    "of bad design decisions we've made years ago by altering %d tables in your database." \
+                    "of bad design decisions we've made years ago by altering %d tables in your database."
                             % (next_version, len(tables)), nl_after=1, nl_before=1, mc='green')
 
 if __name__ == '__main__':

--- a/anvio/migrations/contigs/v17_to_v18.py
+++ b/anvio/migrations/contigs/v17_to_v18.py
@@ -42,7 +42,7 @@ def migrate(db_path):
 
     progress.end()
     run.info_single("The contigs database is now %s. We just updated the self table of the contigs database with a small "
-                    "bit of information to be able to track SCG taxonomy version changes more accurately going forward" % \
+                    "bit of information to be able to track SCG taxonomy version changes more accurately going forward" %
                                     (next_version), nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/contigs/v7_to_v8.py
+++ b/anvio/migrations/contigs/v7_to_v8.py
@@ -48,7 +48,7 @@ def migrate(db_path):
     # bye
     progress.end()
     run.info_single("The contigs database is now %s! The only thing this upgrade did was to reset your "
-                    "functional annotations :/ But you know, `anvi-run-ncbi-cogs` is pretty fast!" \
+                    "functional annotations :/ But you know, `anvi-run-ncbi-cogs` is pretty fast!"
                                         % (next_version), nl_after=1, nl_before=1, mc='green')
 
 if __name__ == '__main__':

--- a/anvio/migrations/contigs/v8_to_v9.py
+++ b/anvio/migrations/contigs/v8_to_v9.py
@@ -55,7 +55,7 @@ def migrate(db_path):
     dbops.update_description_in_db(db_path, 'No description is given')
 
     run.info_single("The contigs database is now %s! All this upgrade did was to associate your contigs db with a "
-                    "project name (which happened to be 'NO_NAME', because anvi'o likes you very much)" \
+                    "project name (which happened to be 'NO_NAME', because anvi'o likes you very much)"
                                             % (next_version), nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/pan/v6_to_v7.py
+++ b/anvio/migrations/pan/v6_to_v7.py
@@ -108,7 +108,7 @@ class TableForItemAdditionalData(Table):
                 predicted_key_type = type_class.__name__ if type_class else None
 
             key_types[key] = predicted_key_type
-            self.run.info('Key "%s"' % key, 'Predicted type: %s' % (key_types[key]), \
+            self.run.info('Key "%s"' % key, 'Predicted type: %s' % (key_types[key]),
                                             nl_after = 1 if key == keys_list[-1] else 0)
 
         db_entries = []

--- a/anvio/migrations/pan/v7_to_v8.py
+++ b/anvio/migrations/pan/v7_to_v8.py
@@ -186,7 +186,7 @@ class AdditionalAndOrderDataBaseClass(Table, object):
 
         if not len(data_keys):
             raise ConfigError("There is something wrong with the additional data file for %s at %s. "
-                              "It does not seem to have any additional keys for data :/" \
+                              "It does not seem to have any additional keys for data :/"
                                             % (self.target, additional_data_file_path))
 
         if self.target == 'layer_orders':
@@ -295,7 +295,7 @@ def check_samples_db_status():
                           "between either sides of '='). If you have a samples database, you can tell anvi'o the location of it "
                           "using the same environmental variable: 'ANVIO_SAMPLES_DB=YOUR_SAMPLES_DB_PATH anvi-migrate "
                           "YOUR_PAN_DB_PATH'. If you are curious, this was necessary because there may be multiple samples "
-                          "databases for a given project, or a samples database may be at any location and may have any name." \
+                          "databases for a given project, or a samples database may be at any location and may have any name."
                             % current_version)
 
     if os.environ['ANVIO_SAMPLES_DB'] == 'SKIP':
@@ -379,7 +379,7 @@ def migrate(db_path):
     if fully_upgraded:
         shutil.move(samples_db_path, samples_db_path + '.OBSOLETE')
         run.info_single("Your pan db is now version %s. You no longer need your old samples database (which is now "
-                        "renamed to something ugly so you can see it." \
+                        "renamed to something ugly so you can see it."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
     elif samples_db_path:
         run.info_single("Your pan db is now version %s. BUT THERE WAS THIS: the actual purpose of this script was to "
@@ -387,7 +387,7 @@ def migrate(db_path):
                         "has failed. Probably everything is still alright, but you may have to do that step manually. The "
                         "Error messsage should be somewhere above." % next_version, nl_after=1, nl_before=1, mc='green')
     else:
-        run.info_single("Your pan db is now version %s. BUT WITHOUT the samples database incorporation as you wished."\
+        run.info_single("Your pan db is now version %s. BUT WITHOUT the samples database incorporation as you wished."
                                                     % next_version, nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/profile/v21_to_v22.py
+++ b/anvio/migrations/profile/v21_to_v22.py
@@ -106,13 +106,13 @@ def migrate(db_path):
 
     if fully_upgraded:
         run.info_single("Your profile db is now version %s. Anvi'o just created a new, up-to-date auxiliary data file (which ends with "
-                        "extension .db), and deleted the old one (the one that ended with the extension .h5))" \
+                        "extension .db), and deleted the old one (the one that ended with the extension .h5))"
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. BUT THERE WAS THIS: the actual purpose of this script was to upgrade your "
                         "AUXILIARY-DATA.h5 file, but it was not where it was supposed to be. Anvi'o upgraded your profile.db alone, "
                         "but as a consequence you will not be able to use its auxiliary data with this profile database. If you care "
-                        "about it, you should find the old profile database, and upgrade it along with its auxiliary data" \
+                        "about it, you should find the old profile database, and upgrade it along with its auxiliary data"
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/profile/v22_to_v23.py
+++ b/anvio/migrations/profile/v22_to_v23.py
@@ -166,7 +166,7 @@ class AdditionalAndOrderDataBaseClass(Table, object):
 
         if not len(data_keys):
             raise ConfigError("There is something wrong with the additional data file for %s at %s. "
-                              "It does not seem to have any additional keys for data :/" \
+                              "It does not seem to have any additional keys for data :/"
                                             % (self.target, additional_data_file_path))
 
         if self.target == 'layer_orders':
@@ -348,7 +348,7 @@ def migrate(db_path):
     if fully_upgraded:
         shutil.move(samples_db_path, samples_db_path + '.OBSOLETE')
         run.info_single("Your profile db is now version %s. You no longer need your old samples database (which is now "
-                        "renamed to something ugly so you can see it." \
+                        "renamed to something ugly so you can see it."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
     elif samples_db_path:
         run.info_single("Your profile db is now version %s. BUT THERE WAS THIS: the actual purpose of this script was to "
@@ -356,7 +356,7 @@ def migrate(db_path):
                         "has failed. Probably everything is still alright, but you may have to do that step manually. The "
                         "Error messsage should be somewhere above." % next_version, nl_after=1, nl_before=1, mc='green')
     else:
-        run.info_single("Your profile db is now version %s. BUT WITHOUT the samples database incorporation as you wished."\
+        run.info_single("Your profile db is now version %s. BUT WITHOUT the samples database incorporation as you wished."
                                                     % next_version, nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/profile/v23_to_v24.py
+++ b/anvio/migrations/profile/v23_to_v24.py
@@ -159,11 +159,11 @@ def migrate(db_path):
 
     if full_upgrade:
         run.info_single("Your profile db is now version %s. You can learn more about what happened here "
-                        "by taking a look at this issue: https://github.com/merenlab/anvio/issues/800" \
+                        "by taking a look at this issue: https://github.com/merenlab/anvio/issues/800"
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. But essentially nothing really happened to your "
-                        "database since it was a blank profile (which is OK, move along)." \
+                        "database since it was a blank profile (which is OK, move along)."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/profile/v24_to_v25.py
+++ b/anvio/migrations/profile/v24_to_v25.py
@@ -79,11 +79,11 @@ def migrate(db_path):
         run.info_single("Your profile db is now version %s. If you had amino acids profiled for this database,\
                          you just lost all of that content :( The only option is to re-profile all your databases\
                          and merge them again. We are very sorry about the inconvenience. If you don't know what\
-                         this message is talking about, then you have nothing to worry about." \
+                         this message is talking about, then you have nothing to worry about."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. But essentially nothing really happened to your "
-                        "database since it was a blank profile (which is OK, move along)." \
+                        "database since it was a blank profile (which is OK, move along)."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
 
 

--- a/anvio/migrations/profile/v30_to_v31.py
+++ b/anvio/migrations/profile/v30_to_v31.py
@@ -46,7 +46,7 @@ def migrate(db_path):
         run.info_single("Your profile db is now %s (WRONG .. anvi'o never takes breaks)." % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. But essentially nothing really happened to your "
-                        "database since it was a blank profile (which is OK, move along)." \
+                        "database since it was a blank profile (which is OK, move along)."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
 
 if __name__ == '__main__':

--- a/anvio/migrations/profile/v31_to_v32.py
+++ b/anvio/migrations/profile/v31_to_v32.py
@@ -60,7 +60,7 @@ def migrate(db_path):
                         "of your database. All good now." % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. But essentially nothing really happened to your "
-                        "database since it was a blank profile (which is OK, move along)." \
+                        "database since it was a blank profile (which is OK, move along)."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
 
 if __name__ == '__main__':

--- a/anvio/migrations/profile/v32_to_v33.py
+++ b/anvio/migrations/profile/v32_to_v33.py
@@ -56,7 +56,7 @@ def migrate(db_path):
                         "`in_complete_gene_call` has become `in_complete_gene_call`" % next_version, nl_after=1, nl_before=1, mc='green')
     else:
         run.info_single("Your profile db is now version %s. But essentially nothing really happened to your "
-                        "database since it was a blank profile (which is OK, move along)." \
+                        "database since it was a blank profile (which is OK, move along)."
                                                             % next_version, nl_after=1, nl_before=1, mc='green')
 
 if __name__ == '__main__':

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -620,8 +620,8 @@ class Pangenome(object):
             self.run.warning("%s did not retun search results for %d of %d the amino acid sequences in your input FASTA file. "
                              "Anvi'o will do some heuristic magic to complete the missing data in the search output to recover "
                              "from this. But since you are a scientist, here are the amino acid sequence IDs for which %s "
-                             "failed to report self search results: %s." \
-                                                    % (search_tool, len(ids_without_self_search), len(all_ids), \
+                             "failed to report self search results: %s."
+                                                    % (search_tool, len(ids_without_self_search), len(all_ids),
                                                        search_tool, ', '.join(ids_without_self_search)))
 
         # HEURISTICS TO ADD MISSING SELF SEARCH RESULTS
@@ -768,7 +768,7 @@ class Pangenome(object):
                 self.run.warning("It seems you have %s gene clusters in your pangenome. This exceeds the soft limit "
                                  "of %s for anvi'o to attempt to create a hierarchical clustering of your gene clusters "
                                  "(which becomes the center tree in all anvi'o displays). If you want a hierarchical "
-                                 "clustering to be done anyway, please see the flag `--enforce-hierarchical-clustering`." \
+                                 "clustering to be done anyway, please see the flag `--enforce-hierarchical-clustering`."
                                             % (pp(len(gene_clusters_dict)), pp(self.max_num_gene_clusters_for_hierarchical_clustering)))
                 self.skip_hierarchical_clustering = True
 
@@ -983,7 +983,7 @@ class Pangenome(object):
             raise ConfigError("self.genomes must be a dict. Anvi'o needs an adult :(")
 
         if len(self.genomes) < 2:
-            raise ConfigError("There must be at least two genomes for this workflow to work. You have like '%d' of them :/" \
+            raise ConfigError("There must be at least two genomes for this workflow to work. You have like '%d' of them :/"
                     % len(self.genomes))
 
         if len(self.genomes) > 100:
@@ -1005,7 +1005,7 @@ class Pangenome(object):
             raise ConfigError("You are asking anvi'o to skip aligning sequences within your gene clusters, and then you "
                               "are also asking it to use '%s' for aligning sequences within your gene clusters. It is easy "
                               "to ignore this and skip the alignment, but anvi'o gets nervous when it realizes her users are "
-                              "being inconsistent. Please make up your mind, and come back as the explicit person you are" \
+                              "being inconsistent. Please make up your mind, and come back as the explicit person you are"
                                                                             % self.align_with)
 
         self.check_params()

--- a/anvio/parsers/__init__.py
+++ b/anvio/parsers/__init__.py
@@ -41,7 +41,7 @@ def get_parser_names(module):
 def get_parser_module(module):
     if module not in parser_modules:
         raise ConfigError("Anvi'o parser modules do not recognize any module called '%s'. But it has "
-                          "these in case your honour would change their minds: '%s'." % \
+                          "these in case your honour would change their minds: '%s'." %
                                 (module, ', '.join(list(parser_modules.keys()))))
 
     return parser_modules[module]
@@ -52,7 +52,7 @@ def get_parser_obj(module, parser):
 
     if parser not in parser_module:
         raise ConfigError("Parser modules speaking: the parser module '%s' does exist (yay),\
-                           but there is no parser '%s' in it (boo). It has these instad: '%s'."\
+                           but there is no parser '%s' in it (boo). It has these instad: '%s'."
                                 % (module, parser, ', '.join(list(parser_module.keys()))))
 
     return parser_modules[module][parser]

--- a/anvio/parsers/base.py
+++ b/anvio/parsers/base.py
@@ -51,7 +51,7 @@ class Parser(object):
                                    "don't know how to generate them" % (self.annotation_source,
                                                                         ', '.join(list(self.files_expected.values()))))
 
-            raise ConfigError("%s parser requires %d files (%s). %s missing from your input: %s"\
+            raise ConfigError("%s parser requires %d files (%s). %s missing from your input: %s"
                                      % (self.annotation_source,
                                         len(self.files_expected),
                                         ', '.join(list(self.files_expected.values())),
@@ -99,7 +99,7 @@ class Parser(object):
                                 "even know what file it is. But in general this error occurs when the mapping function "
                                 "does not find what its looking for in a line. For instance, a value that was supposed to "
                                 "be an integer ends up being actually a piece of text or something. Well. Here are the "
-                                "line numbers if you care and can make sense of this information: %s" % \
+                                "line numbers if you care and can make sense of this information: %s" %
                                                         (self.annotation_source, len(failed_lines), failed_lines_text))
 
 

--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -1024,7 +1024,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
 
         if A('contigs_of_interest'):
             filesnpaths.is_file_exists(args.contigs_of_interest)
-            self.contig_names_of_interest = set([c.strip() for c in open(args.contigs_of_interest).readlines()\
+            self.contig_names_of_interest = set([c.strip() for c in open(args.contigs_of_interest).readlines()
                                                                            if c.strip() and not c.startswith('#')])
         else:
             self.contig_names_of_interest = set([])
@@ -1323,7 +1323,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
 
         self.run.warning("Your minimum contig length is set to %s base pairs. So anvi'o will not take into "
                          "consideration anything below that. If you need to kill this an restart your "
-                         "analysis with another minimum contig length value, feel free to press CTRL+C." \
+                         "analysis with another minimum contig length value, feel free to press CTRL+C."
                                                 % (pp(self.min_contig_length)))
 
         if self.max_contig_length < sys.maxsize:
@@ -1723,7 +1723,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
             self.run.warning('According to the data generated in the contigs database, there %s in your BAM file '
                              'with 0 gene calls. Which may not be unusual if (a) some of your contigs are very short, '
                              'or (b) your the gene caller was not capable of dealing with the type of data you had. '
-                             'If you would like to take a look yourself, here is one contig that is missing any genes: %s"' %\
+                             'If you would like to take a look yourself, here is one contig that is missing any genes: %s"' %
                                       (P(len(contigs_without_any_gene_calls)), random.choice(contigs_without_any_gene_calls)))
 
 
@@ -1764,7 +1764,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
             raise ConfigError("Anvi'o applied your min/max length criteria for contigs to filter out the bad ones "
                               "and has bad news: not a single contig in your contigs database was greater than %s "
                               "and smaller than %s nts :( So this profiling attempt did not really go anywhere. "
-                              "Please remove your half-baked output directory if it is still there: '%s'." \
+                              "Please remove your half-baked output directory if it is still there: '%s'."
                                         % (pp(self.min_contig_length), pp(self.max_contig_length), self.output_directory))
         else:
             self.contig_names = [self.contig_names[i] for i in contigs_with_good_lengths]
@@ -1853,7 +1853,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
                                    "and this is another one found in your contigs database: '%s'. You may be using an "
                                    "contigs database for profiling that has nothing to do with the BAM file you are "
                                    "trying to profile, or you may have failed to fix your contig names in your FASTA file "
-                                   "prior to mapping, which is described here: %s"\
+                                   "prior to mapping, which is described here: %s"
                                         % (contig_name, self.contig_names_in_contigs_db.pop(), 'http://goo.gl/Q9ChpS'))
 
         self.run.info('Number of contigs to be conisdered (after -M)', self.num_contigs, display_only=True)
@@ -2409,8 +2409,8 @@ class BAMProfiler(dbops.ContigsSuperclass):
     def cluster_contigs(self):
         default_clustering_config = constants.blank_default if self.blank else constants.single_default
 
-        dbops.do_hierarchical_clustering_of_items(self.profile_db_path, self.clustering_configs, self.split_names, self.database_paths, \
-                                                  input_directory=self.output_directory, default_clustering_config=default_clustering_config, \
+        dbops.do_hierarchical_clustering_of_items(self.profile_db_path, self.clustering_configs, self.split_names, self.database_paths,
+                                                  input_directory=self.output_directory, default_clustering_config=default_clustering_config,
                                                   distance=self.distance, linkage=self.linkage, run=self.run, progress=self.progress)
 
 

--- a/anvio/programs.py
+++ b/anvio/programs.py
@@ -402,7 +402,7 @@ class AnvioPrograms(AnvioAuthors):
         self.run.info_single("Of %d programs found, %d did not contain PROVIDES AND/OR REQUIRES "
                              "statements :/ This may be normal for some programs, but here is the "
                              "complete list of those that are missing __provides__ and __requires__ "
-                             "tags in their code in case you see something you can complete: '%s'." % \
+                             "tags in their code in case you see something you can complete: '%s'." %
                                         (len(self.program_names_and_paths),
                                          len(programs_without_provides_requires_info),
                                          ', '.join(programs_without_provides_requires_info)),
@@ -413,7 +413,7 @@ class AnvioPrograms(AnvioAuthors):
                              "help by adding usage information for programs by creating markdown "
                              "formatted files under the directory '%s'. Please see examples in anvi'o "
                              "codebase: https://github.com/merenlab/anvio/tree/master/anvio/docs. "
-                             "Here is a complete list of programs that are missing usage statements: %s " % \
+                             "Here is a complete list of programs that are missing usage statements: %s " %
                                         (len(self.program_names_and_paths),
                                          len(programs_without_provides_requires_info),
                                          anvio.DOCS_PATH,
@@ -712,7 +712,7 @@ class AnvioWorkflows:
         if len(workflows_without_descriptions):
             self.run.info_single("Of %d workflows found, %d did not contain any DESCRIPTION. If you would like to "
                                  "see examples and add new descriptions, please see the directory '%s'. Here is the "
-                                 "full list of workflows that are not yet explained: %s." \
+                                 "full list of workflows that are not yet explained: %s."
                                         % (len(ANVIO_WORKFLOWS),
                                            len(workflows_without_descriptions),
                                            anvio.DOCS_PATH,
@@ -792,7 +792,7 @@ class AnvioArtifacts:
         if len(artifacts_without_descriptions):
             self.run.info_single("Of %d artifacts found, %d did not contain any DESCRIPTION. If you would like to "
                                  "see examples and add new descriptions, please see the directory '%s'. Here is the "
-                                 "full list of artifacts that are not yet explained: %s." \
+                                 "full list of artifacts that are not yet explained: %s."
                                         % (len(ANVIO_ARTIFACTS),
                                            len(artifacts_without_descriptions),
                                            anvio.DOCS_PATH,
@@ -863,7 +863,7 @@ class AnvioDocs(AnvioPrograms, AnvioArtifacts, AnvioWorkflows):
             raise ConfigError("Some artifacts do not have matching images. If you just added a new artifact type, you "
                               "also need to add a corresponding PNG icon for the type under the directory '%s'. See "
                               "examples in that directory, and if they are not enough, get in touch with a developer. "
-                              "Regardless. These are the artifact types missing images: %s." \
+                              "Regardless. These are the artifact types missing images: %s."
                                                                 % (os.path.join(self.images_source_directory, 'icons'),
                                                                    ', '.join(missing_images_for_artifact_types)))
 

--- a/anvio/programsearch.py
+++ b/anvio/programsearch.py
@@ -91,7 +91,7 @@ class ProgramSearch:
             self.headers_to_report = ['Program'] + self.report.split(',')
             for header in self.headers_to_report:
                 if header not in self.headers:
-                    raise ConfigError('%s isn\'t a valid option for --report. Here are your options (comma separate them): %s' \
+                    raise ConfigError('%s isn\'t a valid option for --report. Here are your options (comma separate them): %s'
                                            % (header, ', '.join(self.headers)))
         else:
             self.get_headers_to_report()

--- a/anvio/samplesops.py
+++ b/anvio/samplesops.py
@@ -180,8 +180,8 @@ class SamplesInformation:
             except:
                 return v
 
-        for sample_attribute_tuples in [[(F(self.samples_information_dict[sample][attribute]), sample, attribute) \
-                                            for sample in self.samples_information_dict] \
+        for sample_attribute_tuples in [[(F(self.samples_information_dict[sample][attribute]), sample, attribute)
+                                            for sample in self.samples_information_dict]
                                             for attribute in self.aliases_to_attributes_dict]:
             # skip bar charts:
             if ';' in str(sample_attribute_tuples[0][0]):
@@ -221,7 +221,7 @@ class SamplesInformation:
             if sorted(self.sample_names_in_samples_information_file) != sorted(self.sample_names_in_samples_order_file):
                 raise SamplesError('OK. Samples described in the information file and order file are not identical :/ '
                                     'Here are the %d sample names in the information file: "%s", versus the %d sample '
-                                    'names in the orders file: "%s". And here is the difference: "%s".'\
+                                    'names in the orders file: "%s". And here is the difference: "%s".'
                                                             % (len(self.sample_names_in_samples_information_file),
                                                                self.sample_names_in_samples_information_file,
                                                                len(self.sample_names_in_samples_order_file),

--- a/anvio/scgdomainclassifier.py
+++ b/anvio/scgdomainclassifier.py
@@ -167,7 +167,7 @@ class Train(SCGDomainClassifier):
                 self.run.warning("The number of contigs databases found for the domain '%s' is %d. You should consider "
                             "increasing the number of genomes you include for this domain. A robust classifier "
                             "will require similar number of genomes for each domain that capture the diversity "
-                            "of the domain they represent. Say, at least 20 genomes per domain is a good start." \
+                            "of the domain they represent. Say, at least 20 genomes per domain is a good start."
                                     % (domain, len(self.contigs_dbs[domain])))
 
             self.progress.update("Making sure contigs dbs are contigs dbs")
@@ -243,7 +243,7 @@ class Predict(SCGDomainClassifier):
             raise ConfigError("The classifier on your disk is missing some of the mandatory information in it :/ For instance, the "
                               "following SCG domains are not defined in it: '%s'. One way to fix this could be re-training the "
                               "random forest with `anvi-script-gen-scg-domain-classifier` with a reasonable set of genomes. Don't "
-                              "forget to store the resulting classifier at the default anvi'o path of /blah/blah/anvio/data/%s." \
+                              "forget to store the resulting classifier at the default anvi'o path of /blah/blah/anvio/data/%s."
                                         % (', '.join(missing_classes), self.input_classifier_path))
 
 

--- a/anvio/sge.py
+++ b/anvio/sge.py
@@ -246,7 +246,7 @@ class SGE:
                             found = True
                             info_dict[s] += 1
                     if not found:
-                        raise ConfigError("Unknown state for qstat: '%s' (known states: '%s')"\
+                        raise ConfigError("Unknown state for qstat: '%s' (known states: '%s')"
                                  % (state, ', '.join(list(info_dict.keys()))))
 
                 line_no += 1

--- a/anvio/splitter.py
+++ b/anvio/splitter.py
@@ -243,14 +243,14 @@ class XSplitter(object):
                              "(which becomes the center tree in all anvi'o displays). If you want a hierarchical "
                              "clustering to be done anyway, you can re-run the splitting process only for this bin "
                              "by adding these parameters to your run: '--bin-id %s --enforce-hierarchical-clustering'. "
-                             "If you feel like you are lost, don't hesitate to get in touch with anvi'o developers." \
+                             "If you feel like you are lost, don't hesitate to get in touch with anvi'o developers."
                                                         % (pp(self.max_num_splits_for_hierarchical_clustering), self.bin_id))
             skip_hierarchical_clustering = True
 
         if self.num_splits > self.max_num_splits_for_hierarchical_clustering and self.enforce_hierarchical_clustering:
             self.run.warning("Becasue you have used the flag `--enforce-hierarchical-clustering`, anvi'o will attempt "
                              "to create a hierarchical clustering of your %s splits for this bin. It may take a bit of "
-                             "time, and it is not even anvi'o's fault, you know  :/" \
+                             "time, and it is not even anvi'o's fault, you know  :/"
                                                         % pp(self.max_num_splits_for_hierarchical_clustering))
 
         return skip_hierarchical_clustering
@@ -679,9 +679,9 @@ class BinSplitter(summarizer.Bin, XSplitter):
         self.progress.end()
 
         if not self.skip_hierarchical_clustering:
-            dbops.do_hierarchical_clustering_of_items(self.bin_profile_db_path, constants.clustering_configs['merged' if merged else 'single'], self.split_names, \
-                                                      self.database_paths, input_directory=self.bin_output_directory, \
-                                                      default_clustering_config=constants.merged_default, distance=self.distance, \
+            dbops.do_hierarchical_clustering_of_items(self.bin_profile_db_path, constants.clustering_configs['merged' if merged else 'single'], self.split_names,
+                                                      self.database_paths, input_directory=self.bin_output_directory,
+                                                      default_clustering_config=constants.merged_default, distance=self.distance,
                                                       linkage=self.linkage, run=terminal.Run(verbose=False), progress=self.progress)
 
         # add a collection

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -560,7 +560,7 @@ class StructureSuperclass(object):
         # Check for genes that do not appear in the contigs database
         bad_gene_caller_ids = [g for g in genes_of_interest if g not in genes_in_contigs_database]
         if bad_gene_caller_ids:
-            raise ConfigError(("This gene caller id you provided is" if len(bad_gene_caller_ids) == 1 else \
+            raise ConfigError(("This gene caller id you provided is" if len(bad_gene_caller_ids) == 1 else
                                "These gene caller ids you provided are") + " not known to this contigs database: {}.\
                                You have only 2 lives left. 2 more mistakes, and anvi'o will automatically uninstall \
                                itself. Yes, seriously :(".format(", ".join([str(x) for x in bad_gene_caller_ids])))
@@ -1172,14 +1172,14 @@ class DSSPClass(object):
         except Exception:
             raise ConfigError('Your executable of DSSP, `{}`, doesn\'t appear to be working. For information on how to test '
                               'that your version is working correctly, please visit '
-                              'http://merenlab.org/2016/06/18/installing-third-party-software/#dssp'\
+                              'http://merenlab.org/2016/06/18/installing-third-party-software/#dssp'
                                .format(self.executable))
 
         if not len(test_residue_annotation.keys()):
             raise ConfigError("Your executable of DSSP, `{}`, exists but didn't return any meaningful output. This "
                               "is a known issue with certain distributions of DSSP. For information on how to test "
                               "that your version is working correctly, please visit "
-                              "http://merenlab.org/2016/06/18/installing-third-party-software/#dssp"\
+                              "http://merenlab.org/2016/06/18/installing-third-party-software/#dssp"
                                .format(self.executable))
 
         try:
@@ -1650,7 +1650,7 @@ class PDBDatabase(object):
 
         self.run.warning("You want to --reset the database (size %s), which seems potentially rash. "
                          "Anvi'o is putting you in time out for 20 seconds before deleting. Press "
-                         "CTRL+C at any time during your time out to cancel the deletion." \
+                         "CTRL+C at any time during your time out to cancel the deletion."
                             % self.size_of_database())
         time.sleep(20)
         os.remove(self.db_path)

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -407,14 +407,14 @@ class PanSummarizer(PanSuperclass, SummarizerSuperClass):
         if not values_that_are_not_none:
             raise ConfigError("The variable '%s' contains only values of type None,\
                                this is probably a mistake, surely you didn't mean to provide an empty category.\
-                               Do you think this is a mistake on our part? Let us know." % \
+                               Do you think this is a mistake on our part? Let us know." %
                                                                     category_variable)
 
         type_category_variable = type(values_that_are_not_none[0][category_variable])
         if type_category_variable != str:
             raise ConfigError("The variable '%s' does not seem to resemble anything that could be a category. "
                               "Anvi'o expects these variables to be of type string, yet yours is type %s :/ "
-                              "Do you think this is a mistake on our part? Let us know." % \
+                              "Do you think this is a mistake on our part? Let us know." %
                                                                     (category_variable, type_category_variable))
 
         gene_clusters_functions_summary_dict = self.get_gene_clusters_functions_summary_dict(functional_annotation_source)
@@ -445,7 +445,7 @@ class PanSummarizer(PanSuperclass, SummarizerSuperClass):
         functions_in_categories = occurrence_of_functions_in_pangenome_dataframe.groupby('category').sum()
 
         # unique names of categories
-        categories = set([str(categories_dict[g][category_variable]) for g in categories_dict.keys() if\
+        categories = set([str(categories_dict[g][category_variable]) for g in categories_dict.keys() if
                             (categories_dict[g][category_variable] is not None or include_ungrouped)])
 
         categories_to_genomes_dict = {}
@@ -542,7 +542,7 @@ class PanSummarizer(PanSuperclass, SummarizerSuperClass):
         genome_names = ', '.join(list(self.gene_clusters.values())[0].keys())
 
         # set up the initial summary dictionary
-        self.summary['meta'] = { \
+        self.summary['meta'] = {
                 'quick': self.quick,
                 'cog_functions_are_called': self.cog_functions_are_called,
                 'cog_categories_are_called': self.cog_categories_are_called,
@@ -562,7 +562,7 @@ class PanSummarizer(PanSuperclass, SummarizerSuperClass):
         }
 
         # I am not sure whether this is the best place to do this,
-        self.summary['basics_pretty'] = { \
+        self.summary['basics_pretty'] = {
                 'pan': [('Created on', self.p_meta['creation_date']),
                         ('Version', anvio.__pan__version__),
                         ('Number of genes', pretty(int(self.p_meta['num_genes_in_gene_clusters']))),
@@ -1040,9 +1040,9 @@ class ContigSummarizer(SummarizerSuperClass):
             run.info_single('PLEASE READ CAREFULLY. Contigs db info summary will not include %d gene calls that were '
                             'not identified by "%s", the default gene caller. Other gene calls found in this contigs '
                             'database include, %s. If you are more interested in gene calls in any of those, you should '
-                            'indicate that through the `--gene-caller` parameter in your program.' \
-                                                                % (sum(gene_calls_from_other_gene_callers.values()), \
-                                                                   gene_caller_to_use, \
+                            'indicate that through the `--gene-caller` parameter in your program.'
+                                                                % (sum(gene_calls_from_other_gene_callers.values()),
+                                                                   gene_caller_to_use,
                                                                    ', '.join(['%d gene calls by %s' % (tpl[1], tpl[0]) for tpl in gene_calls_from_other_gene_callers.items()])))
 
         if len(impossible_gene_calls_missing_from_contigs_db):
@@ -1325,7 +1325,7 @@ class Bin:
                              'any sense, you may need make sure everything is in order. The thing is, '
                              'sometimes external clustering results that are added to the contigs via '
                              '`anvi-populate-collections-table` may include split names that are not used '
-                             'while the contigs database was generated.'\
+                             'while the contigs database was generated.'
                                                 % (len(missing_ids), bin_id, self.summary.collection_name))
 
 

--- a/anvio/synteny.py
+++ b/anvio/synteny.py
@@ -193,7 +193,7 @@ class NGram(object):
             num_genes = len(gene_caller_ids)
 
             if self.window_range[1] > num_genes:
-                raise ConfigError("The largest window size you requested (%d) is larger than the number of genes found on this genome: %s" % \
+                raise ConfigError("The largest window size you requested (%d) is larger than the number of genes found on this genome: %s" %
                     (self.window_range[1], contigs_db_name))
 
 

--- a/anvio/tables/collections.py
+++ b/anvio/tables/collections.py
@@ -53,7 +53,7 @@ class TablesForCollections(Table):
             database._exec('''DELETE FROM %s WHERE collection_name = "%s" AND \
                                                    bin_name = "%s"''' % (table_name, collection_name, bin_name))
 
-        self.run.warning('All previous entries for "%s" of "%s" is being removed from "%s"'\
+        self.run.warning('All previous entries for "%s" of "%s" is being removed from "%s"'
                     % (bin_name,collection_name, ', '.join(tables_to_clear)))
 
         database.disconnect()
@@ -152,7 +152,7 @@ class TablesForCollections(Table):
 
             if len(splits_only_in_db):
                 self.run.warning('%d of %d items found in the database were missing from the "%s" results. If this '
-                                         'does not make any sense, please make sure you know why before going any further.'\
+                                         'does not make any sense, please make sure you know why before going any further.'
                                                 % (len(splits_only_in_db), len(self.splits_info), collection_name))
 
             # then populate contigs table.

--- a/anvio/tables/genecalls.py
+++ b/anvio/tables/genecalls.py
@@ -541,7 +541,7 @@ class TablesForGeneCalls(Table):
 
                 if gene_caller_ids_for_source:
                     for table_name in [t.genes_in_contigs_table_name, t.genes_in_splits_table_name]:
-                        database._exec('''DELETE FROM %s WHERE gene_callers_id IN (%s)''' % \
+                        database._exec('''DELETE FROM %s WHERE gene_callers_id IN (%s)''' %
                                                     (table_name, ','.join([str(g) for g in gene_caller_ids_for_source])))
 
         self.progress.new('Processing')

--- a/anvio/tables/genelevelcoverages.py
+++ b/anvio/tables/genelevelcoverages.py
@@ -76,7 +76,7 @@ class TableForGeneLevelCoverages(Table):
                 raise ConfigError("Bad news of the day: You have a genes database for the collection %s and bin %s. But "
                                   "clearly the parameters you used to generate these gene-level coverage data has little "
                                   "to do with the parameters you are using now. For instance, parameter '%s' was not even "
-                                  "stored in the database :/" % \
+                                  "stored in the database :/" %
                                         (self.collection_name, self.bin_name , str(parameter)))
 
             parameter_user_set = self.parameters[parameter]
@@ -96,7 +96,7 @@ class TableForGeneLevelCoverages(Table):
                               "matching the matching parameters you are using now. For instance, the database "
                               "has %s for %s, but the same parameter is currently set to %s in your workflow. "
                               "The best solution to this is to remove this database (which is at '%s'), and let "
-                              "anvi'o generate another one for you." % \
+                              "anvi'o generate another one for you." %
                                     (self.collection_name, self.bin_name, len(non_matching_parameters), str(e[1]),
                                     e[0], str(e[2]), self.db_path))
 
@@ -130,7 +130,7 @@ class TableForGeneLevelCoverages(Table):
                                   "who is creative. But what we know is that this genes database at '%s' is not one that you "
                                   "can use anymore. The easy solution is this: remove this database, and let anvi'o generate "
                                   "another one for you. Alternatively you can run the same exact command you run right before "
-                                  "you get this error. Sometimes that works too." % \
+                                  "you get this error. Sometimes that works too." %
                                         (self.collection_name, self.bin_name, self.db_path))
 
 

--- a/anvio/tables/hmmhits.py
+++ b/anvio/tables/hmmhits.py
@@ -213,7 +213,7 @@ class TablesForHMMHits(Table):
 
         # now we know our sequences
         self.run.info('Target sequences determined',
-                      '; '.join([f"{pp(utils.get_num_sequences_in_fasta(file_path))} sequences for {target}" \
+                      '; '.join([f"{pp(utils.get_num_sequences_in_fasta(file_path))} sequences for {target}"
                                     for target, file_path in target_files_dict.items()]))
 
         if have_hmm_sources_with_non_RNA_contig_context:
@@ -425,7 +425,7 @@ class TablesForHMMHits(Table):
 
             database.disconnect()
 
-            run.warning("%d gene caller ids that were added via the HMM source have been removed from \"%s\"" \
+            run.warning("%d gene caller ids that were added via the HMM source have been removed from \"%s\""
                         % (len(gene_caller_ids_to_remove), ', '.join(tables_with_gene_callers_id)))
 
 

--- a/anvio/tables/miscdata.py
+++ b/anvio/tables/miscdata.py
@@ -144,12 +144,12 @@ class AdditionalAndOrderDataBaseClass(Table, object):
             raise ConfigError("Some of the keys in your input file contain white characters at the beginning "
                               "or at the end. This is your lucky day, because anvi'o caught it, and you will "
                               "fix it before continuing, and those weird data keys will not cause any headaches "
-                              "in the future. Thank you and you are welcome. Here are the offending keys: %s." % \
+                              "in the future. Thank you and you are welcome. Here are the offending keys: %s." %
                                         (', '.join(['"%s"' % k for k in bad_keys])))
 
         if not len(data_keys):
             raise ConfigError("There is something wrong with the additional data file for %s at %s. "
-                              "It does not seem to have any additional keys for data :/" \
+                              "It does not seem to have any additional keys for data :/"
                                             % (self.target_table, additional_data_file_path))
 
         self.progress.end()
@@ -257,7 +257,7 @@ class AdditionalAndOrderDataBaseClass(Table, object):
                     self.run.warning("You are exporting data from the additional data table '%s' for the "
                                      "data group '%s'. Great. Just remember that there are %d more data "
                                      "groups in your database, and you are not exporting anything from them "
-                                     "at this point (they know you're the boss, so they're not upset)." \
+                                     "at this point (they know you're the boss, so they're not upset)."
                                         % (self.target_table, self.target_data_group, len(self.available_group_names) - 1),
                                       header="FRIENDLY REMINDER", lc='yellow')
 
@@ -281,7 +281,7 @@ class AdditionalAndOrderDataBaseClass(Table, object):
     def list_data_keys(self):
         database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
 
-        NOPE = lambda: self.run.info_single("There are no additional data for '%s' in this database :/" \
+        NOPE = lambda: self.run.info_single("There are no additional data for '%s' in this database :/"
                                                 % (self.target_table), nl_before=1, nl_after=1, mc='red')
 
         additional_data_keys = {}
@@ -301,9 +301,9 @@ class AdditionalAndOrderDataBaseClass(Table, object):
             group_names = [self.target_data_group] if self.target_data_group_set_by_user else self.available_group_names
 
             for group_name in group_names:
-                data_keys_in_group = database.get_single_column_from_table(self.table_name, \
-                                                                           'data_key', \
-                                                                           unique=True, \
+                data_keys_in_group = database.get_single_column_from_table(self.table_name,
+                                                                           'data_key',
+                                                                           unique=True,
                                                                            where_clause="data_group='%s'" % group_name)
                 additional_data_keys[group_name] = sorted(data_keys_in_group)
 
@@ -311,7 +311,7 @@ class AdditionalAndOrderDataBaseClass(Table, object):
             data_keys = sorted(database.get_single_column_from_table(self.table_name, 'data_key', unique=True))
 
             if not len(data_keys):
-                self.run.info_single("There are no additional data for '%s' in this database :/" \
+                self.run.info_single("There are no additional data for '%s' in this database :/"
                                                     % (self.target_table), nl_before=1, nl_after=1, mc='red')
                 database.disconnect()
                 return
@@ -344,7 +344,7 @@ class AdditionalAndOrderDataBaseClass(Table, object):
 
             num_keys_not_displayed = num_keys - num_keys_to_display
             if num_keys_not_displayed > 0:
-                self.run.info_single('(... %d more; use `--debug` to list all ...)' % \
+                self.run.info_single('(... %d more; use `--debug` to list all ...)' %
                                                                 (num_keys_not_displayed), nl_after = 1, mc='cyan', level=3)
 
         database.disconnect()
@@ -537,7 +537,7 @@ class OrderDataBaseClass(AdditionalAndOrderDataBaseClass, object):
             predicted_key_type = data_dict[key]['data_type']
 
             data_key_types[key] = predicted_key_type
-            self.run.info('Data key "%s"' % key, 'Type: %s' % (data_key_types[key]), \
+            self.run.info('Data key "%s"' % key, 'Type: %s' % (data_key_types[key]),
                                             nl_after = 1 if key == data_keys_list[-1] else 0)
 
         # we be responsible here.
@@ -588,7 +588,7 @@ class OrderDataBaseClass(AdditionalAndOrderDataBaseClass, object):
                     layer_names[data_key] = [s.strip() for s in data_dict[data_key]['data_value'].split(',')]
             except:
                 raise ConfigError("Parsing the %s data for %s failed :/ We don't know why, because we are lazy. Please "
-                                  "take a loook at your input data and figure out :(" \
+                                  "take a loook at your input data and figure out :("
                                                                     % (data_dict[data_key]['data_type'], data_key))
 
         return layer_names
@@ -628,7 +628,7 @@ class AdditionalDataBaseClass(AdditionalAndOrderDataBaseClass, object):
                               "here because the last command you run was something like 'show me all the data in misc' "
                               "data tables, then you may try to be more specific by explicitly defining your target "
                               "data table. If you think you have already been as sepecific as you could be, then anvi'o "
-                              "is as frustrated as you are right now :(" % \
+                              "is as frustrated as you are right now :(" %
                                     (self.target_table, self.target_data_group, ', '.join(['"%s"' % d for d in self.available_group_names])))
 
 
@@ -643,7 +643,7 @@ class AdditionalDataBaseClass(AdditionalAndOrderDataBaseClass, object):
         self.progress.update('...')
 
         database = db.DB(self.db_path, utils.get_required_version_for_db(self.db_path))
-        additional_data_keys_in_db = database.get_single_column_from_table(self.table_name, 'data_key', unique=True, \
+        additional_data_keys_in_db = database.get_single_column_from_table(self.table_name, 'data_key', unique=True,
                         where_clause="""data_group LIKE '%s'""" % self.target_data_group)
         database.disconnect()
 
@@ -693,7 +693,7 @@ class AdditionalDataBaseClass(AdditionalAndOrderDataBaseClass, object):
                                   "would not have resulted in an exception, and anvi'o would simply returned an empty data "
                                   "dictionary. But since you are requested to get a specific list of keys ('%s'), we are raising "
                                   "an exception and break the flow just to make sure you are aware of the fact that we don't "
-                                  "see the stuff you're requesting :(" \
+                                  "see the stuff you're requesting :("
                                         % (self.db_type, self.db_path, self.target_table, ' ,'.join(additional_data_keys_requested)))
 
             if set(additional_data_keys_requested) - set(additional_data_keys_in_db):
@@ -815,7 +815,7 @@ class AdditionalDataBaseClass(AdditionalAndOrderDataBaseClass, object):
                 predicted_key_type = type_class.__name__ if type_class else None
 
             key_types[key] = predicted_key_type
-            self.run.info('Data key "%s"' % key, 'Predicted type: %s' % (key_types[key]), \
+            self.run.info('Data key "%s"' % key, 'Predicted type: %s' % (key_types[key]),
                                             nl_after = 1 if key == data_keys_list[-1] else 0)
 
         # we be responsible here.
@@ -841,7 +841,7 @@ class AdditionalDataBaseClass(AdditionalAndOrderDataBaseClass, object):
         if len(keys_already_in_db):
             if self.just_do_it:
                 self.run.warning('The following keys in your data dict will replace the ones that are already '
-                                 'in your %s database %s table and %s data group: %s.' \
+                                 'in your %s database %s table and %s data group: %s.'
                                                 % (self.db_type, self.target_table,
                                                    self.target_data_group, ', '.join(keys_already_in_db)))
 
@@ -1079,14 +1079,14 @@ class TableForLayerAdditionalData(AdditionalDataBaseClass):
                               "continue, and hopes that you will try again. In case you want to see a random layer name "
                               "that is only in your data, here is one: %s. In comparison, here is a random layer name "
                               "from your database: %s. If you don't want to deal with this, you could use the flag "
-                              "`--just-do-it`, and anvi'o would do something." \
-                                    % (len(layers_in_data_but_not_in_db), len(layers_in_data), self.db_type, \
+                              "`--just-do-it`, and anvi'o would do something."
+                                    % (len(layers_in_data_but_not_in_db), len(layers_in_data), self.db_type,
                                        layers_in_data_but_not_in_db.pop(), layers_in_db.pop()))
         elif len(layers_in_data_but_not_in_db) and self.just_do_it:
             self.run.warning("Listen up! %d of %d layers in your additional data were *only* in your data (which "
                              "means they are not in the %s database you are working with). But since you asked anvi'o to "
                              "keep its mouth shut, it removed the ones that were not in your database from your input "
-                             "data, hoping that the rest of your probably very dubious operation will go just fine :/" \
+                             "data, hoping that the rest of your probably very dubious operation will go just fine :/"
                                    % (len(layers_in_data_but_not_in_db), len(layers_in_data), self.db_type))
             for layer_name in layers_in_data_but_not_in_db:
                 data_dict.pop(layer_name)
@@ -1094,7 +1094,7 @@ class TableForLayerAdditionalData(AdditionalDataBaseClass):
         layers_in_db_but_not_in_data = layers_in_db.difference(layers_in_data)
         if len(layers_in_db_but_not_in_data):
             self.run.warning("Your input contains additional data for only %d of %d total number of layers in your %s "
-                             "database. Just wanted to make sure you know what's up, but we cool." \
+                             "database. Just wanted to make sure you know what's up, but we cool."
                                 % (len(layers_in_db) - len(layers_in_db_but_not_in_data), len(layers_in_db), self.db_type))
 
 
@@ -1185,7 +1185,7 @@ class TableForNucleotideAdditionalData(AdditionalDataBaseClass):
             elif pos < 0 or pos >= contig_lengths[contig]:
                 raise ConfigError("The data key '%s' (entry #%d) is not properly formatted. The contig "
                                   "'%s' exists in the database, but the position %d falls outside of "
-                                  "the contig, which has a length of %d." % \
+                                  "the contig, which has a length of %d." %
                                   (data_key, i+1, contig, pos, contig_lengths[contig]))
 
         if len(not_in_db):
@@ -1407,12 +1407,12 @@ class TableForAminoAcidAdditionalData(AdditionalDataBaseClass):
 
             if gene_callers_id not in gene_lengths:
                 raise ConfigError("There is a problem with data key '%s' (entry #%d). It specifies gene callers "
-                                  "ID %d, which does not exist." % \
+                                  "ID %d, which does not exist." %
                                   (data_key, i+1, gene_callers_id))
 
             if codon_order_in_gene < 0 or codon_order_in_gene >= gene_lengths[gene_callers_id]:
                 raise ConfigError("There is a problem with data key '%s' (entry #%d). It specifies codon_order_in_gene "
-                                  "%d, which falls outside of gene %d (its length is %d)." % \
+                                  "%d, which falls outside of gene %d (its length is %d)." %
                                   (data_key, i+1, codon_order_in_gene, gene_callers_id, gene_lengths[gene_callers_id]))
 
         database.disconnect()
@@ -1440,7 +1440,7 @@ class MiscDataTableFactory(TableForItemAdditionalData, TableForLayerAdditionalDa
             table_classes[target_data_table].__init__(self, args, r=self.run, p=self.progress)
         except KeyError:
             raise ConfigError("MiscDataTableFactory does not know about target data tables for '%s' :( "
-                              "You can go to the online documentation, or you can try any of %s" % \
+                              "You can go to the online documentation, or you can try any of %s" %
                               (target_data_table, ', '.join(["'%s'" % table for table in table_classes])))
 
 

--- a/anvio/tables/taxonomy.py
+++ b/anvio/tables/taxonomy.py
@@ -144,7 +144,7 @@ class TablesForGeneLevelTaxonomy(Table, TaxonNamesTable):
                                "with `anvi-get-dna-sequences-for-gene-calls` or `anvi-get-aa-sequences-for-gene-calls` programs "
                                "to get the data to annotate. For instance one of the gene caller ids you have in your "
                                "input data that does not appear in the database is this one: '%s'. Anvi'o hopes it makes "
-                               "sense to you, because it definitely does not make any sense to anvi'o :("\
+                               "sense to you, because it definitely does not make any sense to anvi'o :("
                                                         % (len(gene_caller_ids_missing_in_db), str(gene_caller_ids_missing_in_db.pop())))
 
         # check whether input matrix dict
@@ -154,7 +154,7 @@ class TablesForGeneLevelTaxonomy(Table, TaxonNamesTable):
             raise ConfigError("Anvi'o is trying to get ready to create tables for taxonomy, but there is something "
                                "wrong :( The taxonomy names dict (one of the required input dictionaries to the class "
                                "seems to be missing a one or more keys that are necessary to finish the job. Here is "
-                               "a list of missing keys: %s. The complete list of input keys should contain these: %s."\
+                               "a list of missing keys: %s. The complete list of input keys should contain these: %s."
                                         % (', '.join(missing_keys), ', '.join(t.taxon_names_table_structure[1:])))
 
         if not len(self.taxon_names_dict):
@@ -223,6 +223,6 @@ class TablesForGeneLevelTaxonomy(Table, TaxonNamesTable):
         # disconnect
         database.disconnect()
 
-        self.run.info('Splits taxonomy', 'Input data from "%s" annotated %d of %d splits (%.1f%%) with taxonomy.'\
+        self.run.info('Splits taxonomy', 'Input data from "%s" annotated %d of %d splits (%.1f%%) with taxonomy.'
                                             % (self.source, num_splits_with_taxonomy, num_splits_processed,
                                                num_splits_with_taxonomy * 100.0 / num_splits_processed))

--- a/anvio/tables/views.py
+++ b/anvio/tables/views.py
@@ -100,7 +100,7 @@ class TablesForViews(Table):
         if not append_mode:
             if view_name and view_name in views_in_db:
                 raise ConfigError("TablesForViews speaking: Yo yo yo. You already have a view in the db '%s' called '%s'. "
-                                   "You can't create another one before you get rid of the existing one, because rules."\
+                                   "You can't create another one before you get rid of the existing one, because rules."
                                                                             % (self.db_path, view_name))
 
             # first create the data table:

--- a/anvio/taxonomyops/__init__.py
+++ b/anvio/taxonomyops/__init__.py
@@ -268,9 +268,9 @@ class TaxonomyEstimatorSingle(TerminologyHelper):
 
         if self.metagenome_mode or anvio.DEBUG:
             self.run.info_single(f"A total of %s {self._SOURCE_DATA}s with taxonomic affiliations were successfully initialized "
-                                 f"from the contigs database 🎉 Following shows the frequency of these {self._ITEMS}: %s." % \
+                                 f"from the contigs database 🎉 Following shows the frequency of these {self._ITEMS}: %s." %
                                             (pp(len(self.gene_callers_id_to_item_taxonomy_dict)),
-                                             ', '.join(["%s (%d)" % (g, self.frequency_of_items_with_taxonomy[g]) \
+                                             ', '.join(["%s (%d)" % (g, self.frequency_of_items_with_taxonomy[g])
                                                                 for g in self.frequency_of_items_with_taxonomy])), nl_before=1)
 
 
@@ -1306,7 +1306,7 @@ class PopulateContigsDatabaseWithTaxonomy(TerminologyHelper):
                 num_finished_processes += 1
 
                 self.progress.increment(increment_to=num_finished_processes)
-                self.progress.update(f"%s of %s {self._ITEMS} are finished in %s processes with %s threads." \
+                self.progress.update(f"%s of %s {self._ITEMS} are finished in %s processes with %s threads."
                                         % (num_finished_processes, total_num_processes, int(self.num_parallel_processes), self.num_threads))
 
             except KeyboardInterrupt:

--- a/anvio/taxonomyops/scg.py
+++ b/anvio/taxonomyops/scg.py
@@ -240,7 +240,7 @@ class SanityCheck(object):
                 if self.scg_name_for_metagenome_mode and self.scg_name_for_metagenome_mode not in self.ctx.SCGs:
                     raise ConfigError("We understand that you wish to work with '%s' to study the taxonomic make up of your contigs "
                                       "database in metagenome mode. But then this gene is not one of those anvi'o recognizes as "
-                                      "suitable SCGs to do that. Here is a list for you to choose from: '%s'." \
+                                      "suitable SCGs to do that. Here is a list for you to choose from: '%s'."
                                                             % (self.scg_name_for_metagenome_mode, ', '.join(self.ctx.SCGs.keys())))
 
                 if self.compute_scg_coverages and not self.profile_db_path:
@@ -404,14 +404,14 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
                              "to compare different versions of the database, and if you would like to ensure consistency, you can re-run "
                              "`anvi-run-scg-taxonomy` on contigs databases that have a different version than what is installed on your "
                              "system, which is '%s' (if you run `anvi-db-info` on any contigs database you can learn the SCG database "
-                             "version of it). Anvi'o found these versions across your genomes: '%s'." % \
+                             "version of it). Anvi'o found these versions across your genomes: '%s'." %
                                         (self.ctx.scg_taxonomy_database_version, ', '.join(list(set(scg_taxonomy_database_versions_in_genomes)))))
         elif scg_taxonomy_database_versions_in_genomes[0] != self.ctx.scg_taxonomy_database_version:
             self.progress.reset()
             self.run.warning("While all of your genomes agree with each other and have the SCG taxonomy database version of %s, "
                               "this version differs from what is installed on your system, which is %s. If you don't do anything, "
                               "things will continue to work. But if you would like to get rid of this warning you will need to "
-                              "re-run the program `anvi-run-scg-taxonomy` on each one of them 😬" % \
+                              "re-run the program `anvi-run-scg-taxonomy` on each one of them 😬" %
                                         (scg_taxonomy_database_versions_in_genomes[0], self.ctx.scg_taxonomy_database_version))
 
         # we keep these attribute names the same as for metagenomes so that we don't have to duplicate every function later
@@ -456,14 +456,14 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
                              "to compare different versions of the database, and if you would like to ensure consistency, you can re-run "
                              "`anvi-run-scg-taxonomy` on contigs databases that have a different version than what is installed on your "
                              "system, which is '%s' (if you run `anvi-db-info` on any contigs database you can learn the SCG database "
-                             "version of it). Anvi'o found these versions across your metagenomes: '%s'." % \
+                             "version of it). Anvi'o found these versions across your metagenomes: '%s'." %
                                         (self.ctx.scg_taxonomy_database_version, ', '.join(list(set(scg_taxonomy_database_versions_in_metagenomes)))))
         elif scg_taxonomy_database_versions_in_metagenomes[0] != self.ctx.scg_taxonomy_database_version:
             self.progress.reset()
             self.run.warning("While all of your metagenomes agree with each other and have the SCG taxonomy database version of %s, "
                               "this version differs from what is installed on your system, which is %s. If you don't do anything, "
                               "things will continue to work. But if you would like to get rid of this warning you will need to "
-                              "re-run the program `anvi-run-scg-taxonomy` on each one of them 😬" % \
+                              "re-run the program `anvi-run-scg-taxonomy` on each one of them 😬" %
                                         (scg_taxonomy_database_versions_in_metagenomes[0], self.ctx.scg_taxonomy_database_version))
 
         self.metagenomes = copy.deepcopy(g.metagenomes)
@@ -545,7 +545,7 @@ class SCGTaxonomyEstimatorMulti(SCGTaxonomyArgs, SanityCheck):
                              "is nothing more than some heuristic for your convenience, and we strongly advice you to "
                              "run this program with the parameter `--report-scg-frequencies` and examine the output "
                              "to see if there is a better choice. As you can imagine, the most frequent SCG may not be "
-                             "the one that is more common across all genomes or metagenomes you are interested." % \
+                             "the one that is more common across all genomes or metagenomes you are interested." %
                                                 (self.scg_name_for_metagenome_mode, len(self.metagenomes)))
 
             self.run.info("SCG [determined by anvi'o]", self.scg_name_for_metagenome_mode, nl_after=1, mc="green")

--- a/anvio/taxonomyops/trna.py
+++ b/anvio/taxonomyops/trna.py
@@ -233,7 +233,7 @@ class SanityCheck(object):
 
                 if self.anticodon_for_metagenome_mode and self.anticodon_for_metagenome_mode not in self.ctx.anticodons:
                     raise ConfigError("We understand that you wish to work with '%s' to study the taxonomic make up of your contigs "
-                                      "database in metagenome mode. But then anvi'o doesn't recognize this. Here is a list for you to choose from: '%s'." \
+                                      "database in metagenome mode. But then anvi'o doesn't recognize this. Here is a list for you to choose from: '%s'."
                                                             % (self.anticodon_for_metagenome_mode, ', '.join(self.ctx.anticodons.keys())))
 
                 if self.compute_anticodon_coverages and not self.profile_db_path:

--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -257,16 +257,16 @@ class Progress:
 
                 # see a full list of color codes: https://gitlab.com/dslackw/colored
                 if p_length >= break_point:
-                    sys.stderr.write(Back.CYAN + Fore.BLACK + c[:break_point] + \
-                                     Back.GREY_30 + Fore.WHITE + c[break_point:end_point] + \
-                                     Back.CYAN + Fore.CYAN + c[end_point] + \
-                                     Back.GREY_50 + Fore.LIGHT_CYAN + c[end_point:] + \
+                    sys.stderr.write(Back.CYAN + Fore.BLACK + c[:break_point] +
+                                     Back.GREY_30 + Fore.WHITE + c[break_point:end_point] +
+                                     Back.CYAN + Fore.CYAN + c[end_point] +
+                                     Back.GREY_50 + Fore.LIGHT_CYAN + c[end_point:] +
                                      Style.RESET)
                 else:
-                    sys.stderr.write(Back.CYAN + Fore.BLACK + c[:break_point - p_length] + \
-                                     Back.SALMON_1 + Fore.BLACK + p_text + \
-                                     Back.GREY_30 + Fore.WHITE + c[break_point:end_point] + \
-                                     Back.GREY_50 + Fore.LIGHT_CYAN + c[end_point:] + \
+                    sys.stderr.write(Back.CYAN + Fore.BLACK + c[:break_point - p_length] +
+                                     Back.SALMON_1 + Fore.BLACK + p_text +
+                                     Back.GREY_30 + Fore.WHITE + c[break_point:end_point] +
+                                     Back.GREY_50 + Fore.LIGHT_CYAN + c[end_point:] +
                                      Style.RESET)
                 sys.stderr.flush()
             else:
@@ -753,7 +753,7 @@ class Timer:
 
         for unit in format_order:
             if unit not in unit_hierarchy:
-                raise TerminalError('Timer.format_time :: \'%s\' is not a valid unit. Use any of %s.'\
+                raise TerminalError('Timer.format_time :: \'%s\' is not a valid unit. Use any of %s.'
                                      % (unit, ', '.join(unit_hierarchy)))
 
         # calculate the value for each unit (e.g. 'seconds', 'days', etc) found in fmt

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -444,7 +444,7 @@ def is_program_exists(program, dont_raise=False):
 
     raise ConfigError("An anvi'o function needs '%s' to be installed on your system, but it doesn't seem to appear "
                        "in your path :/ If you are certain you have it on your system (for instance you can run it "
-                       "by typing '%s' in your terminal window), you may want to send a detailed bug report. Sorry!"\
+                       "by typing '%s' in your terminal window), you may want to send a detailed bug report. Sorry!"
                         % (program, program))
 
 
@@ -584,8 +584,8 @@ def run_command(cmdline, log_file_path, first_line_of_log_is_cmdline=True, remov
 
     if anvio.DEBUG:
         Progress().reset()
-        Run().info("[DEBUG] `run_command` is running", \
-                   ' '.join(['%s' % (('"%s"' % str(x)) if ' ' in str(x) else ('%s' % str(x))) for x in cmdline]), \
+        Run().info("[DEBUG] `run_command` is running",
+                   ' '.join(['%s' % (('"%s"' % str(x)) if ' ' in str(x) else ('%s' % str(x))) for x in cmdline]),
                    nl_before=1, nl_after=1, mc='red', lc='yellow')
 
     filesnpaths.is_output_file_writable(log_file_path)
@@ -3061,7 +3061,7 @@ def is_amino_acid_functionally_conserved(amino_acid_residue_1, amino_acid_residu
 
     if group == 'Polar and Nonpolar':
         #they fall in more than one group, multiple tests needed
-        if amino_acid_residue_1 == 'H' and (amino_acid_residue_2 in constants.conserved_amino_acid_groups['Nonpolar'] \
+        if amino_acid_residue_1 == 'H' and (amino_acid_residue_2 in constants.conserved_amino_acid_groups['Nonpolar']
                                             or amino_acid_residue_2 in constants.conserved_amino_acid_groups['Bases']):
             return True
 
@@ -3168,7 +3168,7 @@ def check_contig_names(contig_names, dont_raise=False):
                            "digits. Names can also contain underscore ('_'), dash ('-') and dot ('.') "
                            "characters. anvio knows how much work this may require for you to go back and "
                            "re-generate your BAM files and is very sorry for asking you to do that, however, "
-                           "it is critical for later steps in the analysis." \
+                           "it is critical for later steps in the analysis."
                                 % ("contains multiple characters" if len(characters_anvio_doesnt_like) > 1 else "contains a character",
                                    ", ".join(['"%s"' % c for c in characters_anvio_doesnt_like])))
 
@@ -3487,13 +3487,13 @@ def export_sequences_from_contigs_db(contigs_db_path, output_file_path, seq_name
           if just_do_it:
               run.warning("Not all the sequences you requested are %s in this CONTIGS.db. %d names are contigs, "
                           "%d are splits, and %d are neither. BUT you're in just-do-it mode and we know you're in charge, so we'll "
-                          "proceed using any appropriate names." % \
+                          "proceed using any appropriate names." %
                           (mode, len(contig_names), len(split_names), len(missing_names),))
               seq_names_to_export = appropriate_seq_names
           else:
               raise ConfigError("Not all the sequences you requested are %s in this CONTIGS.db. %d names are contigs, "
                                 "%d are splits, and %d are neither. If you want to live on the edge and try to "
-                                "proceed using any appropriate names, try out the `--just-do-it` flag." % \
+                                "proceed using any appropriate names, try out the `--just-do-it` flag." %
                                 (mode, len(contig_names), len(split_names), len(missing_names)))
 
     for seq_name in seq_names_to_export:
@@ -3594,7 +3594,7 @@ def gen_gexf_network_file(units, samples_dict, output_file, sample_mapping_dict=
         output.write('''        <viz:size value="%d"/>\n''' % sample_size)
 
         if sample_mapping_dict and 'colors' in sample_mapping_dict[sample]:
-            output.write('''        <viz:color r="%d" g="%d" b="%d" a="1"/>\n''' %\
+            output.write('''        <viz:color r="%d" g="%d" b="%d" a="1"/>\n''' %
                                              HTMLColorToRGB(sample_mapping_dict[sample]['colors'], scaled=False))
 
         if sample_mapping_categories:
@@ -3893,9 +3893,9 @@ def to_jsonable(obj):
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
-def get_TAB_delimited_file_as_dictionary(file_path, expected_fields=None, dict_to_append=None, column_names=None,\
-                                        column_mapping=None, indexing_field=0, separator='\t', no_header=False,\
-                                        ascii_only=False, only_expected_fields=False, assign_none_for_missing=False,\
+def get_TAB_delimited_file_as_dictionary(file_path, expected_fields=None, dict_to_append=None, column_names=None,
+                                        column_mapping=None, indexing_field=0, separator='\t', no_header=False,
+                                        ascii_only=False, only_expected_fields=False, assign_none_for_missing=False,
                                         none_value=None, empty_header_columns_are_OK=False, return_failed_lines=False,
                                         ignore_duplicated_keys=False, key_prefix=None):
     """Takes a file path, returns a dictionary.
@@ -4260,7 +4260,7 @@ def get_HMM_sources_dictionary(source_dirs=[], check_for_ACC_lines_in_HMM=False)
                               "counfusion around these parts of the code. Anvi'o could set some defualts for you, "
                               "but it would be much better if you set your own defaults explicitly. You're not "
                               "sure what would make a good default for your HMM collection? Reach out to "
-                              "a developer, and they will help you! Here are the files that are empty: %s." % \
+                              "a developer, and they will help you! Here are the files that are empty: %s." %
                                     (os.path.basename(source), ', '.join(empty_files)))
 
         ref = R('reference.txt')
@@ -4344,7 +4344,7 @@ def check_misc_data_keys_for_format(data_keys_list):
         raise ConfigError("Oh no :( We recently changed the description of the stacked bar data type, and your input data "
                           "file still has the older version. Here is the list of those that are violating the new format: "
                           "%s. To avoid this issue and to turn them into the new format, you could take '%s', and present "
-                          "it as %d separate TAB-delimited entries that look like this: %s. Sorry!" % \
+                          "it as %d separate TAB-delimited entries that look like this: %s. Sorry!" %
                                             (', '.join(['"%s"' % k for k in obsolete_stackedbar_keys]),
                                              key_violates_new_rule,
                                              len(new_rule_compatible_data_keys),
@@ -4658,7 +4658,7 @@ def is_structure_db_and_contigs_db_compatible(structure_db_path, contigs_db_path
     if cdb.hash != sdb.hash:
         raise ConfigError('The contigs and structure databases do not seem compatible. '
                           'More specifically, the contigs database is not the one that '
-                          'was used when the structure database was created (%s != %s).'\
+                          'was used when the structure database was created (%s != %s).'
                                % (cdb.hash, sdb.hash))
 
     return True

--- a/anvio/variability.py
+++ b/anvio/variability.py
@@ -105,11 +105,11 @@ class ProcessAlleleCounts:
                                    has %d positions, but sequence has %d." % (key, len(self.d[key]), len(sequence)))
 
         if len(sequence) != allele_counts.shape[1]:
-            raise ConfigError("ProcessAlleleCounts :: allele_counts has %d positions, but sequence has %d." \
+            raise ConfigError("ProcessAlleleCounts :: allele_counts has %d positions, but sequence has %d."
                               % (len(sequence), allele_counts.shape[1]))
 
         if len(allele_to_array_index) != allele_counts.shape[0]:
-            raise ConfigError("ProcessAlleleCounts :: allele_counts has %d rows, but the allele_to_array_index dictionary has %d." \
+            raise ConfigError("ProcessAlleleCounts :: allele_counts has %d rows, but the allele_to_array_index dictionary has %d."
                               % (allele_counts.shape[0], len(allele_to_array_index)))
 
         self.min_coverage_for_variability = min_coverage_for_variability

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -373,7 +373,7 @@ class VariabilityFilter:
             has_default = True if params_inspection[param].default is not inspect._empty else False
             if not has_default and param not in kwargs.keys():
                 raise ConfigError("`%s` was passed to filter_data. All its arguments without defaults must "
-                                  "also be passed, but `%s` was not. Do so with \"%s = ...\"" \
+                                  "also be passed, but `%s` was not. Do so with \"%s = ...\""
                                        % (self.passed_function, param, param))
             else:
                 self.append_info_log("`%s` of `%s` was passed or has default" % (param, self.passed_function), True)
@@ -381,7 +381,7 @@ class VariabilityFilter:
         bad_args = [arg for arg in kwargs.keys() if arg not in params_inspection]
         if bad_args:
             raise ConfigError("VariabilityFilter :: The args [%s] were passed to filter_data,\
-                               but are not args of `%s`. Available args for this function are [%s]" \
+                               but are not args of `%s`. Available args for this function are [%s]"
                                % (", ".join(bad_args), self.passed_function, ", ".join(params_inspection)))
         for kwarg in kwargs:
             self.append_info_log("filter argument: `%s`" % (kwarg), "valid argument for `%s`" % (self.passed_function))
@@ -421,7 +421,7 @@ class VariabilityFilter:
 
         if not callable(self.passed_function):
             self.append_info_log("function is callable", False)
-            raise ConfigError("Function %s, which was passed to filter_data, is not callable" \
+            raise ConfigError("Function %s, which was passed to filter_data, is not callable"
                                    % (self.passed_function))
         else:
             self.append_info_log("function is callable", True)
@@ -433,7 +433,7 @@ class VariabilityFilter:
         except AttributeError:
             self.append_info_log("%s is an object" % self.name, False)
             raise ConfigError("VariabilityFilter :: You tried to filter the object `%s` which is "
-                              "not an attribute of VariabilitySuper or its parent classes." \
+                              "not an attribute of VariabilitySuper or its parent classes."
                                    % (self.name))
         self.append_info_log("%s is an object" % self.name, True)
 
@@ -442,7 +442,7 @@ class VariabilityFilter:
         if type(self.df) != pd.core.frame.DataFrame:
             self.append_info_log("name points to a valid dataframe", False)
             raise ConfigError("VariabilityFilter :: You tried to filter the object `%s` which is "
-                              "of type `%s`. You can only filter pandas dataframes." \
+                              "of type `%s`. You can only filter pandas dataframes."
                                    % (self.name, type(self.df)))
         self.append_info_log("name points to a valid dataframe", True)
 
@@ -970,7 +970,7 @@ class VariabilitySuper(VariabilityFilter, object):
                 self.progress.end()
                 some_to_report = bad_gene_caller_ids[:5] if len(bad_gene_caller_ids) <= 5 else bad_gene_caller_ids
                 raise ConfigError("{} of the gene caller ids you provided {} not {}. {}: {}. You only have 2 lives left. "
-                                  "2 more mistakes, and anvi'o will automatically uninstall itself. Yes, seriously :(".\
+                                  "2 more mistakes, and anvi'o will automatically uninstall itself. Yes, seriously :(".
                                    format(len(bad_gene_caller_ids),
                                           "is" if len(bad_gene_caller_ids) == 1 else "are",
                                           "in this variability table" if self.table_provided else "known to this contigs database",
@@ -1066,7 +1066,7 @@ class VariabilitySuper(VariabilityFilter, object):
           as `variable_nucleotides` does). This prevents us fom SQL-querying by splits of interest.
         """
 
-        R = lambda x, y: self.run.info("%s that variability data will be fetched for" % \
+        R = lambda x, y: self.run.info("%s that variability data will be fetched for" %
                          (x.capitalize() if len(y)<200 else "Num of "+x), ", ".join([str(z) for z in y]) if len(y)<200 else len(y))
 
         conditions = {}
@@ -1207,7 +1207,7 @@ class VariabilitySuper(VariabilityFilter, object):
             self.progress.end()
             raise ConfigError("There is no overlap between genes that have structures and genes that have variability. "
                               "Consider changing things upstream in your workflow or do not provide the structure db. "
-                              "Here are the genes in your structure database: {}".\
+                              "Here are the genes in your structure database: {}".
                                format(", ".join([str(x) for x in self.genes_with_structure])))
 
         if self.only_if_structure:
@@ -1284,7 +1284,7 @@ class VariabilitySuper(VariabilityFilter, object):
 
 
     def apply_preliminary_filters(self):
-        self.run.info('Variability data', '%s entries in %s splits across %s samples'\
+        self.run.info('Variability data', '%s entries in %s splits across %s samples'
                 % (pp(len(self.data)), pp(len(self.splits_basic_info)), pp(len(self.available_sample_ids))))
 
         self.filter_data(criterion = "sample_id",
@@ -3059,7 +3059,7 @@ class VariabilityNetwork:
                 raise ConfigError("The sample names you provided in the samples information data is not a subset of "
                                    "sample names found in the variable positions data :/ Essentially, every sample name "
                                    "appears in the variability data must be present in the samples information data, "
-                                   "however, you are missing these ones from your samples information: %s."\
+                                   "however, you are missing these ones from your samples information: %s."
                                                 % (', '.join(samples_missing_in_information_dict)))
 
         if self.include_competing_NTs:
@@ -3129,7 +3129,7 @@ class VariabilityData(NucleotidesEngine, CodonsEngine, AminoAcidsEngine):
         inferred_engine = utils.get_variability_table_engine_type(self.variability_table_path)
         if self.engine and self.engine != inferred_engine:
             raise ConfigError("The engine you requested is {0}, but the engine inferred from {1} is {2}. "
-                              "Explicitly declare the inferred engine type (--engine {2})".\
+                              "Explicitly declare the inferred engine type (--engine {2})".
                                format(self.engine, self.variability_table_path, inferred_engine))
         self.engine = inferred_engine
 

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -321,7 +321,7 @@ class WorkflowSuperClass:
 
         self.progress.new('Bleep bloop')
         self.progress.update('Quick dry run for an initial sanity check ...')
-        args = ['snakemake', '--snakefile', get_workflow_snake_file_path(self.name), \
+        args = ['snakemake', '--snakefile', get_workflow_snake_file_path(self.name),
                 '--configfile', self.config_file, '--dryrun', '--quiet']
 
         # if any conda yaml is provided for a rule, then add '--use-conda' to the snakemake command:
@@ -657,15 +657,15 @@ class WorkflowSuperClass:
 
 # The config file contains many essential configurations for the workflow
 # Setting the names of all directories
-dirs_dict = {"LOGS_DIR"     : "00_LOGS"         ,\
-             "QC_DIR"       : "01_QC"           ,\
-             "FASTA_DIR"    : "02_FASTA"     ,\
-             "CONTIGS_DIR"  : "03_CONTIGS"      ,\
-             "MAPPING_DIR"  : "04_MAPPING"      ,\
-             "PROFILE_DIR"  : "05_ANVIO_PROFILE",\
-             "MERGE_DIR"    : "06_MERGED"       ,\
-             "PAN_DIR"      : "07_PAN"          ,\
-             "LOCI_DIR"     : "04_LOCI_FASTAS"   \
+dirs_dict = {"LOGS_DIR"     : "00_LOGS"         ,
+             "QC_DIR"       : "01_QC"           ,
+             "FASTA_DIR"    : "02_FASTA"     ,
+             "CONTIGS_DIR"  : "03_CONTIGS"      ,
+             "MAPPING_DIR"  : "04_MAPPING"      ,
+             "PROFILE_DIR"  : "05_ANVIO_PROFILE",
+             "MERGE_DIR"    : "06_MERGED"       ,
+             "PAN_DIR"      : "07_PAN"          ,
+             "LOCI_DIR"     : "04_LOCI_FASTAS"
 }
 
 
@@ -726,8 +726,8 @@ def get_dir_names(config, dont_raise=False):
         # renaming folders according to the config file, if the user specified.
         if d not in DICT and not dont_raise:
             # making sure the user is asking to rename an existing folder.
-            raise ConfigError("You define a name for the directory '%s' in your "\
-                              "config file, but the only available folders are: "\
+            raise ConfigError("You define a name for the directory '%s' in your "
+                              "config file, but the only available folders are: "
                               "%s" % (d, DICT))
 
         DICT[d] = A(d,config["output_dirs"])

--- a/anvio/workflows/contigs/__init__.py
+++ b/anvio/workflows/contigs/__init__.py
@@ -84,11 +84,11 @@ class ContigsDBWorkflow(WorkflowSuperClass):
                     ['run', '--keep-ids', '--exclude-ids', '--min-len', '--max-len', "--prefix", "--simplify-names", "--seq-type"]
 
 
-        gen_contigs_params = ['--description', '--skip-gene-calling',\
-                              '--ignore-internal-stop-codons', '--skip-mindful-splitting',\
-                              '--contigs-fasta', '--project-name',\
-                              '--description', '--split-length', '--kmer-size',\
-                              '--skip-mindful-splitting', '--skip-gene-calling',\
+        gen_contigs_params = ['--description', '--skip-gene-calling',
+                              '--ignore-internal-stop-codons', '--skip-mindful-splitting',
+                              '--contigs-fasta', '--project-name',
+                              '--description', '--split-length', '--kmer-size',
+                              '--skip-mindful-splitting', '--skip-gene-calling',
                               '--ignore-internal-stop-codons', '--skip-predict-frame', '--prodigal-translation-table']
 
         self.rule_acceptable_params_dict['anvi_gen_contigs_database'] = gen_contigs_params
@@ -135,8 +135,8 @@ class ContigsDBWorkflow(WorkflowSuperClass):
         # sanity check for centrifuge db
         if run_taxonomy_with_centrifuge:
             if not self.get_param_value_from_config(["centrifuge", "db"]):
-                raise ConfigError("If you plan to run centrifuge, then you must "\
-                                  "provide a path for the centrifuge db in the "\
+                raise ConfigError("If you plan to run centrifuge, then you must "
+                                  "provide a path for the centrifuge db in the "
                                   "config file. See documentation for more details.")
 
         if run_taxonomy_with_centrifuge:
@@ -170,8 +170,8 @@ class ContigsDBWorkflow(WorkflowSuperClass):
 
         # import external functions if provided
         import_external_functions_flags = [os.path.join(self.dirs_dict["CONTIGS_DIR"],
-                                           group + "-steps", "external_functions_imported.done")\
-                                           for group in self.contigs_information \
+                                           group + "-steps", "external_functions_imported.done")
+                                           for group in self.contigs_information
                                            if self.contigs_information[group].get('gene_functional_annotation')]
         if import_external_functions_flags:
             optional_targets.extend(import_external_functions_flags)
@@ -306,11 +306,11 @@ class ContigsDBWorkflow(WorkflowSuperClass):
             raise ConfigError("Your fasta_txt file contains columns that are "
                               "not familiar to us. These are the only columns "
                               "that we accept: '%s'. These are the columns that "
-                              "we don't like in your file: '%s'." % (", ".join(w.get_fields_for_fasta_information()), \
+                              "we don't like in your file: '%s'." % (", ".join(w.get_fields_for_fasta_information()),
                                                                    ", ".join(bad_columns)))
 
         contigs_with_external_functions_and_no_external_gene_calls = \
-                [c for c in self.contigs_information \
+                [c for c in self.contigs_information
                     if self.contigs_information[c].get('gene_functional_annotation')
                     and not self.contigs_information[c].get('external_gene_calls')]
         if contigs_with_external_functions_and_no_external_gene_calls:

--- a/anvio/workflows/ecophylo/scripts/subset_external_gene_calls_file.py
+++ b/anvio/workflows/ecophylo/scripts/subset_external_gene_calls_file.py
@@ -5,12 +5,12 @@ import pandas as pd
 
 # Import tables
 #--------------
-external_gene_calls_all = pd.read_csv(snakemake.params.external_gene_calls_all, \
-                                      delim_whitespace=True, \
+external_gene_calls_all = pd.read_csv(snakemake.params.external_gene_calls_all,
+                                      delim_whitespace=True,
                                       index_col=False)
 
-headers = pd.read_csv(snakemake.input.headers, \
-                      sep="\t", \
+headers = pd.read_csv(snakemake.input.headers,
+                      sep="\t",
                       index_col=False,
                       names=["contig"])
 
@@ -24,7 +24,7 @@ external_gene_calls_subset['gene_callers_id'] = external_gene_calls_subset.index
 
 # Write file
 #-------------
-external_gene_calls_subset.to_csv(snakemake.output.external_gene_calls_subset, \
-                           sep="\t", \
-                           index=False, \
+external_gene_calls_subset.to_csv(snakemake.output.external_gene_calls_subset,
+                           sep="\t",
+                           index=False,
                            header=True)

--- a/anvio/workflows/metagenomics/__init__.py
+++ b/anvio/workflows/metagenomics/__init__.py
@@ -53,15 +53,15 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         # initialize the base class
         ContigsDBWorkflow.__init__(self)
 
-        self.rules.extend(['iu_gen_configs', 'iu_filter_quality_minoche', 'gen_qc_report', 'gzip_fastqs',\
-                     'merge_fastqs_for_co_assembly', 'megahit', 'merge_fastas_for_co_assembly',\
-                     'bowtie_build', 'bowtie', 'samtools_view', 'anvi_init_bam', 'idba_ud',\
-                     'anvi_profile', 'anvi_merge', 'import_percent_of_reads_mapped', 'anvi_cluster_contigs',\
-                     'krakenuniq', 'krakenuniq_mpa_report', 'import_krakenuniq_taxonomy', 'metaspades',\
-                     'flye', 'minimap2_index', 'minimap2',\
+        self.rules.extend(['iu_gen_configs', 'iu_filter_quality_minoche', 'gen_qc_report', 'gzip_fastqs',
+                     'merge_fastqs_for_co_assembly', 'megahit', 'merge_fastas_for_co_assembly',
+                     'bowtie_build', 'bowtie', 'samtools_view', 'anvi_init_bam', 'idba_ud',
+                     'anvi_profile', 'anvi_merge', 'import_percent_of_reads_mapped', 'anvi_cluster_contigs',
+                     'krakenuniq', 'krakenuniq_mpa_report', 'import_krakenuniq_taxonomy', 'metaspades',
+                     'flye', 'minimap2_index', 'minimap2',
                      'remove_short_reads_based_on_references', 'anvi_summarize', 'anvi_split'])
 
-        self.general_params.extend(['samples_txt', "references_mode", "all_against_all",\
+        self.general_params.extend(['samples_txt', "references_mode", "all_against_all",
                                     "kraken_txt", "collections_txt", "read_type_suffix"])
 
         rule_acceptable_params_dict = {}
@@ -119,8 +119,8 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         rule_acceptable_params_dict['import_percent_of_reads_mapped'] = ["run"]
         rule_acceptable_params_dict['krakenuniq'] = ["additional_params", "run", "--db", "--gzip-compressed"]
         rule_acceptable_params_dict['import_krakenuniq_taxonomy'] = ["--min-abundance"]
-        rule_acceptable_params_dict['remove_short_reads_based_on_references'] = ["dont_remove_just_map", \
-                                                                                 "references_for_removal_txt", \
+        rule_acceptable_params_dict['remove_short_reads_based_on_references'] = ["dont_remove_just_map",
+                                                                                 "references_for_removal_txt",
                                                                                  "delimiter-for-iu-remove-ids-from-fastq"]
 
         self.rule_acceptable_params_dict.update(rule_acceptable_params_dict)
@@ -236,7 +236,7 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         if len(self.sample_names) < 1:
             raise ConfigError("No samples found in samples.txt")
 
-        self.references_for_removal_txt = self.get_param_value_from_config(['remove_short_reads_based_on_references',\
+        self.references_for_removal_txt = self.get_param_value_from_config(['remove_short_reads_based_on_references',
                                                                             'references_for_removal_txt'])
         if self.references_for_removal_txt:
             self.load_references_for_removal()
@@ -284,12 +284,12 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
         target_files.extend(list(self.profile_databases.values()))
 
         # for groups of size 1 we create a message file
-        message_file_for_groups_of_size_1 = [os.path.join(self.dirs_dict["MERGE_DIR"], g, "README.txt") \
+        message_file_for_groups_of_size_1 = [os.path.join(self.dirs_dict["MERGE_DIR"], g, "README.txt")
                             for g in self.group_names if self.group_sizes[g] == 1]
         target_files.extend(message_file_for_groups_of_size_1)
 
 
-        contigs_annotated = [os.path.join(self.dirs_dict["CONTIGS_DIR"],\
+        contigs_annotated = [os.path.join(self.dirs_dict["CONTIGS_DIR"],
                              g + "-steps", "annotate_contigs_database.done") for g in self.group_names]
         target_files.extend(contigs_annotated)
 
@@ -310,8 +310,8 @@ class MetagenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
             target_files.extend(summary)
 
         if self.run_split:
-            split = [os.path.join(self.dirs_dict["SPLIT_PROFILES_DIR"],\
-                                  g + "-split.done")\
+            split = [os.path.join(self.dirs_dict["SPLIT_PROFILES_DIR"],
+                                  g + "-split.done")
                                   for g in self.collections.keys() if not 'default_collection' in self.collections[g]]
             target_files.extend(split)
 

--- a/anvio/workflows/pangenomics/__init__.py
+++ b/anvio/workflows/pangenomics/__init__.py
@@ -58,11 +58,11 @@ class PangenomicsWorkflow(PhylogenomicsWorkflow, ContigsDBWorkflow, WorkflowSupe
                                     "import_phylogenetic_tree_to_pangenome": {'tree_name': 'phylogeny'},
                                     "anvi_compute_genome_similarity": {"run": False}})
 
-        pan_params = ["--project-name", "--genome-names", "--skip-alignments",\
-                     "--align-with", "--exclude-partial-gene-calls", "--use-ncbi-blast",\
-                     "--minbit", "--mcl-inflation", "--min-occurrence",\
-                     "--min-percent-identity", "--description",\
-                     "--overwrite-output-destinations", "--skip-hierarchical-clustering",\
+        pan_params = ["--project-name", "--genome-names", "--skip-alignments",
+                     "--align-with", "--exclude-partial-gene-calls", "--use-ncbi-blast",
+                     "--minbit", "--mcl-inflation", "--min-occurrence",
+                     "--min-percent-identity", "--description",
+                     "--overwrite-output-destinations", "--skip-hierarchical-clustering",
                      "--enforce-hierarchical-clustering", "--distance", "--linkage", "--I-know-this-is-not-a-good-idea"]
         self.rule_acceptable_params_dict['anvi_pan_genome'] = pan_params
 
@@ -138,7 +138,7 @@ class PangenomicsWorkflow(PhylogenomicsWorkflow, ContigsDBWorkflow, WorkflowSupe
         if self.sequence_source_for_phylogeny:
             if self.sequence_source_for_phylogeny not in self.valid_sequence_sources_for_phylogeny:
                 raise ConfigError('%s is not a valid sequence_source_for_phylogeny. '
-                                  'We only know: %s' % (self.sequence_source_for_phylogeny,\
+                                  'We only know: %s' % (self.sequence_source_for_phylogeny,
                                    ', '.join(self.valid_sequence_sources_for_phylogeny)))
 
 

--- a/anvio/workflows/phylogenomics/__init__.py
+++ b/anvio/workflows/phylogenomics/__init__.py
@@ -52,9 +52,9 @@ class PhylogenomicsWorkflow(ContigsDBWorkflow, WorkflowSuperClass):
                                     'trimal': {'-gt': 0.5},
                                     'iqtree': {'threads': 8, '-m': 'WAG', '-bb': 1000}})
 
-        get_sequences_params = ['--return-best-hit', \
-                                '--separator', '--align-with', '--min-num-bins-gene-occurs', \
-                                '--max-num-genes-missing-from-bin', '--concatenate-genes', \
+        get_sequences_params = ['--return-best-hit',
+                                '--separator', '--align-with', '--min-num-bins-gene-occurs',
+                                '--max-num-genes-missing-from-bin', '--concatenate-genes',
                                 '--get-aa-sequences', '--gene-names', '--hmm-sources']
         self.rule_acceptable_params_dict['anvi_get_sequences_for_hmm_hits'] = get_sequences_params
         self.rule_acceptable_params_dict['trimal'] = ['-gt', 'additional_params']


### PR DESCRIPTION
This PR removes all redundant backslash characters from the codebase. Explicit line joins using a backslash are redundant between Python brackets, and considered bad practice. SO WE OBLIGE.