### PR TITLE
--use-auto-reference-as-is for anvi-reorient-genomes

### DIFF
--- a/anvio/cli/reorient_genomes.py
+++ b/anvio/cli/reorient_genomes.py
@@ -44,12 +44,22 @@ def get_args():
                         help="Two-column TAB-delimited file with genome name and FASTA file path.")
     groupA.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir', {'required': True}))
 
-    groupRef = parser.add_argument_group('SELECTION OF REFERENCE',
+    groupRef = parser.add_argument_group('SELECTION & PROCESSING OF REFERENCE',
                                          "If you do not set --reference, the program will auto-select a reference by "
                                          "choosing the genome with the fewest contigs; ties are broken by the largest "
                                          "total length. This mirrors how anvi'o tools often prioritize more complete assemblies.")
     groupRef.add_argument('--reference', required=False,
                           help="Genome name in fasta-txt to use as the reference orientation. If omitted, auto-selection applies.")
+    groupRef.add_argument('--use-auto-reference-as-is', action='store_true',
+                          help="When anvi'o selects the reference genome automatically (i.e., when `--reference` parameter is not "
+                               "used) it first chooses the genome with the fewest contigs and then longest among those that have "
+                               "the same number of contigs, and THEN, it rotates this auto-picked reference to a reasonable start "
+                               "point by taking into consideration all the genomes. Using this flag, you can ask anvi'o to not "
+                               "tinker with the auto-picked reference orientation. This is most useful when the collection of "
+                               "genomes (or contigs) all start with an evolutionarily meaningful positions, and all you want to "
+                               "do is to reverse complement those that need it so all genomes (or contigs) have the same "
+                               "orientation. This flag is obviously not compatible with `--reference` and "
+                               "`--use-dnaa-for-reference-orientation`.")
     groupRef.add_argument('--use-dnaa-for-reference-orientation', action='store_true',
                           help="Use DnaA gene location to orient the reference genome. The program will identify the DnaA "
                                "gene using an HMM profile (Bac_DnaA_C from Pfam), and rotate the reference to start near "

--- a/anvio/docs/programs/anvi-reorient-genomes.md
+++ b/anvio/docs/programs/anvi-reorient-genomes.md
@@ -37,6 +37,16 @@ Please note that when a reference genome is chosen automatically, the program wi
 
 If you have a reference genome that you trust (downloaded from a reliable source or manually circularized), you can ask the program to use that as a reference. In which case the program will not be tinkering with the reference, and do its best to match every other genome to it.
 
+If you want anvi'o to still auto-select the reference (fewest contigs, longest total length) but use it **without any rotation**, you can use `--use-auto-reference-as-is`:
+
+{{ codestart }}
+anvi-reorient-genomes --fasta-txt %(fasta-txt)s \
+                      --use-auto-reference-as-is \
+                      --output-dir REORIENTED-FASTA-FILES/
+{{ codestop }}
+
+This flag is incompatible with `--reference` (you cannot specify a reference and also ask for auto-selection) and with `--use-dnaa-for-reference-orientation` (which would rotate the reference, defeating the purpose of using it as-is).
+
 ### Using DnaA gene for biologically meaningful reference orientation
 
 {:.notice}
@@ -124,6 +134,7 @@ Here is a more detailed description of what is going on behind the scenes when y
    - **DnaA-based orientation** (if `--use-dnaa-for-reference-orientation` is set): Calls genes with `prodigal`, searches for the DnaA gene using `hmmsearch` with the Bac_DnaA_C HMM profile, and rotates the reference to start at the DnaA gene position. This provides biologically meaningful orientation for bacterial genomes.
    - **De novo optimal position** (if reference is auto-selected without DnaA flag): Aligns each genome to the reference using minimap2 with `--secondary=yes -N 100 -p 0.5` to capture **all possible good alignments** (not just the best one). Builds a coverage map using 1,000 bp bins showing which positions are covered by alignments from each genome. Identifies the position with maximum coverage across all genomes (stopping early if it finds 100%% coverage). The reference is then rotated to start at this optimal position, ensuring all genomes will start at a conserved region that is genuinely shared across the dataset.
    - **User-specified reference** (if `--reference` is set): Uses the reference genome as-is without rotation.
+   - **Auto-selected reference used as-is** (if `--use-auto-reference-as-is` is set): Auto-selects the reference (fewest contigs, longest total length) but skips any rotation, treating the auto-chosen genome exactly like a user-specified one.
 
 **For circular genomes (single-contig):**
 
@@ -164,7 +175,7 @@ Here is a more detailed description of what is going on behind the scenes when y
 
 * **Scaffolding fragmented genomes**: By default, fragmented genomes are written with contigs as separate sequences (ordered and oriented). Use `--scaffold-fragmented` to concatenate them into a single sequence with N-padding representing gaps. While this maximizes gene synteny for comparative analyses, **do not submit N-scaffolded MAGs as complete genomes** to public databases. The scaffolding is reference-based and may not represent the true genomic structure.
 
-* **Auto-selected reference and optimal start**: When you don't specify `--reference`, the program picks the genome with the fewest contigs (ties broken by longest total length), preferring complete circular genomes over fragmented ones. It then rotates the reference to a conserved position across your dataset using secondary alignments to capture all conserved regions (not just the single best alignment). This is especially useful for sets of closely related genomes where you want them all to start at a biologically meaningful position. For bacterial genomes, consider using `--use-dnaa-for-reference-orientation` for even more consistent results based on the replication origin. If you want a specific genome or starting position, use `--reference` to override this behavior.
+* **Auto-selected reference and optimal start**: When you don't specify `--reference`, the program picks the genome with the fewest contigs (ties broken by longest total length), preferring complete circular genomes over fragmented ones. It then rotates the reference to a conserved position across your dataset using secondary alignments to capture all conserved regions (not just the single best alignment). This is especially useful for sets of closely related genomes where you want them all to start at a biologically meaningful position. For bacterial genomes, consider using `--use-dnaa-for-reference-orientation` for even more consistent results based on the replication origin. If you want a specific genome or starting position, use `--reference` to override this behavior. If you want anvi'o to auto-select the reference but skip the rotation step (i.e., keep it exactly as it appears in the input FASTA), use `--use-auto-reference-as-is`.
 
 * **DnaA-based orientation benefits**: When working with bacterial genomes, the `--use-dnaa-for-reference-orientation` flag typically produces highly consistent alignments (e.g., all genomes starting within a few base pairs of each other) because it uses biological knowledge (the replication origin) rather than purely sequence-based heuristics. This can be particularly valuable for downstream synteny analyses or when comparing gene order across closely related strains.
 

--- a/anvio/genomereorientation.py
+++ b/anvio/genomereorientation.py
@@ -82,6 +82,7 @@ class GenomeReorienter:
         self.minimap2_preset = A('minimap2_preset') or "asm5"
         self.near_start_bp = A('near_start_bp') or 10000
         self.use_dnaa_for_reference_orientation = A('use_dnaa_for_reference_orientation') or False
+        self.use_auto_reference_as_is = A('use_auto_reference_as_is') or False
         self.scaffold_fragmented = A('scaffold_fragmented') or False
         self.min_contig_length = A('min_contig_length') or 1000
 
@@ -131,7 +132,7 @@ class GenomeReorienter:
                 self.run.info("Reference rotation", "Not needed (DnaA gene is already at position 0 .. yes, that happened o_O)", nl_after=1)
 
         # If reference was auto-selected and not using DnaA, find the optimal starting position
-        elif not reference_was_user_specified:
+        elif not reference_was_user_specified and not self.use_auto_reference_as_is:
             result = self._find_optimal_reference_start()
             if result:
                 optimal_position, genomes_covering, total_genomes = result
@@ -164,7 +165,7 @@ class GenomeReorienter:
         rotation_msg = "Copied reference genome without reorientation."
         if self.use_dnaa_for_reference_orientation:
             rotation_msg = "Reference genome (rotated to DnaA gene position)."
-        elif not reference_was_user_specified:
+        elif not reference_was_user_specified and not self.use_auto_reference_as_is:
             rotation_msg = "Reference genome (possibly rotated to optimal start position)."
 
         results = [ReorientationResult(self.reference_name, "reference",
@@ -268,6 +269,15 @@ class GenomeReorienter:
             num_sequences = utils.get_num_sequences_in_fasta(genome_path)
             self.genomes[genome_name]['num_contigs'] = num_sequences
             self.genomes[genome_name]['path'] = genome_path
+
+        if self.use_auto_reference_as_is and self.reference_name:
+            raise ConfigError("9 9 9. You can't use `--reference` with `--use-auto-reference-as-is`. You have to "
+                              "choose one of them :/")
+
+        if self.use_auto_reference_as_is and self.use_dnaa_for_reference_orientation:
+            raise ConfigError("Well .. `--use-auto-reference-as-is` and `--use-dnaa-for-reference-orientation` are "
+                              "not compatible with one another. The former keeps the auto-selected reference untouched. "
+                              "The latter rotates it. Incompatible stuff.")
 
         # Validate reference is single-contig if user-specified
         if self.reference_name:


### PR DESCRIPTION
When `anvi-reorient-genomes` is used without `--reference`, anvi'o selects the reference genome automatically (it first chooses the genome with the fewest contigs, and then chooses the longest one among all those that have the same number of contigs).

THEN, it rotates this auto-picked reference to a reasonable start point by taking into consideration all the genomes. This is very smart since even the best reference might start from a location that has no representation in other genomes. But then, if the user has sequences (say genomic islands coming from `anvi-export-locus` or another similar program) that all start from the same evolutionarily meaningful position, this becomes an issue if all user wants is to reverse complement those that need to be reverse complemented.

This PR introduces a new flag that allows the user to ask anvi'o to _not_ tinker with the auto-picked reference orientation.