### PR TITLE
anvi-export-functions += --include-contig-info

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,6 +182,25 @@ All exception classes inherit from `AnvioError` and automatically format with co
 - `TerminalError` — terminal/progress object misuse
 - `GenesDBError`, `TRNAIdentifierError`, etc. — domain-specific
 
+### Warnings vs. Errors
+
+`run.warning(...)` is for genuinely advisory information where the program can still proceed correctly and the user's intent is unambiguous. It is **not** a way to paper over bad input.
+
+**Conflicting or nonsensical flag combinations must always raise a `ConfigError`**, never issue a warning and silently ignore one of the flags. If a user passes two flags that are mutually exclusive or where one makes the other meaningless, they made a mistake — tell them clearly and stop:
+
+```python
+# correct
+if args.include_contig_info and args.matrix_format:
+    raise ConfigError("--include-contig-info has no effect with --matrix-format. "
+                      f"Please remove one of these flags and try again.")
+
+# wrong — silently discarding a flag the user explicitly passed
+if args.include_contig_info and args.matrix_format:
+    run.warning("--include-contig-info has no effect with --matrix-format and will be ignored.")
+```
+
+The same rule applies to any situation where a flag, parameter, or input value would be silently ignored. Silently ignoring user intent is always worse than stopping with a clear error.
+
 ### Global Flags from sys.argv
 
 Set at import time in `anvio/__init__.py` by inspecting `sys.argv` directly:

--- a/anvio/cli/export_functions.py
+++ b/anvio/cli/export_functions.py
@@ -59,7 +59,7 @@ def export_functions_in_matrix_format(functions_dict, sources_to_include, output
     run.info('Output file', output_file)
 
 
-CONTIG_INFO_FIELDS = ['contig', 'start', 'stop', 'direction', 'partial', 'contig_length', 'contig_gc_content']
+CONTIG_INFO_FIELDS = ['contig_name', 'start', 'stop', 'direction', 'partial', 'contig_length', 'contig_gc_content']
 
 
 def export_functions_in_long_format(functions_dict, output_file, run, progress, include_contig_info=False):
@@ -167,7 +167,7 @@ def main():
                 gene_call = genes_in_contigs_dict.get(entry['gene_callers_id'], {})
                 contig_name = gene_call.get('contig', '')
                 contig_info = contigs_info_dict.get(contig_name, {})
-                entry['contig'] = contig_name
+                entry['contig_name'] = contig_name
                 entry['start'] = gene_call.get('start', '')
                 entry['stop'] = gene_call.get('stop', '')
                 entry['direction'] = gene_call.get('direction', '')

--- a/anvio/cli/export_functions.py
+++ b/anvio/cli/export_functions.py
@@ -59,14 +59,19 @@ def export_functions_in_matrix_format(functions_dict, sources_to_include, output
     run.info('Output file', output_file)
 
 
-def export_functions_in_long_format(functions_dict, output_file, run, progress):
+CONTIG_INFO_FIELDS = ['contig', 'start', 'stop', 'direction', 'partial', 'contig_length', 'contig_gc_content']
+
+
+def export_functions_in_long_format(functions_dict, output_file, run, progress, include_contig_info=False):
     """Export functions in long format: one row per annotation."""
 
     progress.new('Exporting functions')
     progress.update('...')
 
+    headers = t.gene_function_calls_table_structure + (CONTIG_INFO_FIELDS if include_contig_info else [])
+
     output = open(output_file, 'w')
-    output.write('\t'.join(t.gene_function_calls_table_structure) + '\n')
+    output.write('\t'.join(headers) + '\n')
 
     sorted_entries = sorted(functions_dict.values(), key=lambda x: x['gene_callers_id'])
 
@@ -75,7 +80,7 @@ def export_functions_in_long_format(functions_dict, output_file, run, progress):
         if entry['e_value'] is None:
             entry['e_value'] = 0.0
 
-        output.write('\t'.join([str(entry[key]) for key in t.gene_function_calls_table_structure]) + '\n')
+        output.write('\t'.join([str(entry[key]) for key in headers]) + '\n')
         num_entries_reported += 1
 
     output.close()
@@ -98,6 +103,9 @@ def main():
         contigs_db = dbops.ContigsDatabase(args.contigs_db)
         annotation_sources = contigs_db.meta['gene_function_sources']
         functions_dict = contigs_db.db.get_table_as_dict(t.gene_function_calls_table_name)
+        if args.include_contig_info:
+            genes_in_contigs_dict = contigs_db.db.get_table_as_dict(t.genes_in_contigs_table_name)
+            contigs_info_dict = contigs_db.db.get_table_as_dict(t.contigs_info_table_name)
         contigs_db.disconnect()
         progress.end()
 
@@ -148,6 +156,26 @@ def main():
             functions_dict = utils.get_filtered_dict(functions_dict, 'source', set(requested_sources))
             progress.end()
 
+        if args.include_contig_info and args.matrix_format:
+            raise ConfigError("The flag --include-contig-info has no effect with --matrix-format. Please "
+                              "remove one of these flags and try again.")
+
+        if args.include_contig_info and not args.matrix_format:
+            progress.new('Enriching output with contig info')
+            progress.update('...')
+            for entry in functions_dict.values():
+                gene_call = genes_in_contigs_dict.get(entry['gene_callers_id'], {})
+                contig_name = gene_call.get('contig', '')
+                contig_info = contigs_info_dict.get(contig_name, {})
+                entry['contig'] = contig_name
+                entry['start'] = gene_call.get('start', '')
+                entry['stop'] = gene_call.get('stop', '')
+                entry['direction'] = gene_call.get('direction', '')
+                entry['partial'] = gene_call.get('partial', '')
+                entry['contig_length'] = contig_info.get('length', '')
+                entry['contig_gc_content'] = contig_info.get('gc_content', '')
+            progress.end()
+
         if args.matrix_format:
             if args.annotation_sources:
                 sources_to_include = [s.strip() for s in args.annotation_sources.split(',')]
@@ -156,7 +184,7 @@ def main():
 
             export_functions_in_matrix_format(functions_dict, sources_to_include, args.output_file, run, progress)
         else:
-            export_functions_in_long_format(functions_dict, args.output_file, run, progress)
+            export_functions_in_long_format(functions_dict, args.output_file, run, progress, include_contig_info=args.include_contig_info)
     except ConfigError as e:
         print(e)
         sys.exit(-1)
@@ -177,6 +205,10 @@ def get_args():
     parser.add_argument(*anvio.A('genes-of-interest'), **anvio.K('genes-of-interest'))
     parser.add_argument(*anvio.A('matrix-format'), **anvio.K('matrix-format', {'help': "Export functions in wide format: "
                     "one row per gene, sources as columns."}))
+    parser.add_argument('--include-contig-info', action='store_true', default=False,
+                        help="Extend the long-format output with positional and contig-level columns: "
+                             "contig name, gene start/stop coordinates, strand direction, partial call "
+                             "flag, contig length, and contig GC content. Has no effect with --matrix-format.")
 
     return parser.get_args(parser)
 

--- a/anvio/docs/programs/anvi-export-functions.md
+++ b/anvio/docs/programs/anvi-export-functions.md
@@ -12,3 +12,13 @@ You can also get annotations for only a specific list of sources. For example:
 anvi-export-functions -c %(contigs-db)s \
                       --annotation-sources source_1,source_2,source_3
 {{ codestop }}
+
+To include positional and contig-level context for each gene in the output, use `--include-contig-info`. This extends the long-format output with seven additional columns: the contig name, gene start and stop coordinates, strand direction, whether the gene call is partial, contig length, and contig GC content:
+
+{{ codestart }}
+anvi-export-functions -c %(contigs-db)s \
+                      --include-contig-info \
+                      -o output.txt
+{{ codestop }}
+
+Note: `--include-contig-info` has no effect when used together with `--matrix-format`.


### PR DESCRIPTION
This PR adds a new flag (`--include-contig-info`) to the program anvi-export-functions so that users have additional insights into contigs that encode the genes that are reported.