### PR TITLE
updating path for dbcan download and updated database to v14

### DIFF
--- a/anvio/cazymes.py
+++ b/anvio/cazymes.py
@@ -92,9 +92,9 @@ class CAZymeSetup(object):
         if self.args.cazyme_version:
             self.db_version = self.args.cazyme_version.upper()
         else:
-            self.db_version = 'V13'
+            self.db_version = 'V14'
 
-        self.db_url = os.path.join("https://bcb.unl.edu/dbCAN2/download/Databases", f"{self.db_version}", f"dbCAN-HMMdb-{self.db_version}.txt")
+        self.db_url = os.path.join("https://pro.unl.edu/dbCAN2/download_file.php?file=", f"dbCAN-HMMdb-{self.db_version}.txt")
 
 
     def is_database_exists(self):

--- a/anvio/docs/programs/anvi-setup-cazymes.md
+++ b/anvio/docs/programs/anvi-setup-cazymes.md
@@ -11,7 +11,7 @@ anvi-setup-cazymes
 You can use `--cazyme-version`, if you want anvi'o to download a different version of the [dbCAN2 CAZyme HMMs](https://bcb.unl.edu/dbCAN2/download/Databases/) database:
 
 {:.warning}
-The following versions have been tested for download: V9-13
+The following versions have been tested for download: V9-14
 
 {{ codestart }}
 anvi-setup-cazymes --cazyme-version V10

--- a/anvio/docs/programs/anvi-setup-cazymes.md
+++ b/anvio/docs/programs/anvi-setup-cazymes.md
@@ -2,7 +2,7 @@ This program **downloads and organizes a local copy of the data from [dbCAN2 CAZ
 
 ### Set up cazymes data
 
-anvi'o will download the newest version of the database (V13) by default:
+anvi'o will download the newest version of the database (V14) by default:
 
 {{ codestart }}
 anvi-setup-cazymes


### PR DESCRIPTION
Hello!

For a while now the dbCAN website was down and downloading the database through the link (e.g. through `anvi-setup-cazymes`) was not possible (see #2587 and #2526). There was a temporary mirror link but according to [their GitHub](https://github.com/bcb-unl/run_dbcan) it's now up and running again, however the link seems to have changed. 

I just updated the database download link in the "cazymes.py" file (line 97):
```python
        self.db_url = os.path.join("https://pro.unl.edu/dbCAN2/download_file.php?file=", f"dbCAN-HMMdb-{self.db_version}.txt")

```

... and while I was changing the file I updated it to the newest version of the database (v14, released 26-Aug-2025) (line 95):
```python
            self.db_version = 'V14'
```

The link is structured differently to before, but downloading the database worked for me afterwards.

I also updated the documentation to specify that v14 is the default version.