### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.conda/environment.yaml
+++ b/.conda/environment.yaml
@@ -4,7 +4,7 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- python=3.10
+- python=3.11
 - sqlite=3.46
 - prodigal
 - idba

--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  MINICONDA_VERSION: "py310_26.1.1-1"
+  MINICONDA_VERSION: "py311_26.1.1-1"
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
       fail-fast: false
 
     steps:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -800,7 +800,7 @@ Stale docs that no longer match the code are actively harmful because they are w
 These may change over time:
 
 - `numpy==1.24.1` — pinned; many array operations throughout
-- `pandas==1.4.4` — pinned; used for tabular data
+- `pandas==1.5.2` — pinned; used for tabular data
 - `scikit-learn==1.2.2` — pinned; clustering, ordination
 - `matplotlib==3.5.1` — pinned; static figure generation
 - `bottle` — lightweight web framework for the interactive interface

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ Anvi'o is an analysis and visualization platform for 'omics data (genomics, meta
 Here is some information where things are currently:
 
 - Version: `9-dev`, codename `eunice`
-- Python requirement: **exactly 3.10.x** (enforced at import time in `anvio/__init__.py`)
+- Python requirement: **exactly 3.11.x** (enforced at import time in `anvio/__init__.py`)
 - License: GPL 3.0
 - Help: https://anvio.org
 - Repository: https://github.com/merenlab/anvio
@@ -812,4 +812,4 @@ These may change over time:
 - `networkx==3.1` — graph operations (reaction networks, programs network)
 - `ete3` — phylogenetic tree handling
 
-Python requirement is strict: `==3.10.*` (checked at import, enforced in `pyproject.toml`).
+Python requirement is strict: `==3.11.*` (checked at import, enforced in `pyproject.toml`).

--- a/Dockerfiles/anvio-main/Dockerfile
+++ b/Dockerfiles/anvio-main/Dockerfile
@@ -21,7 +21,7 @@ RUN conda config --env --add channels conda-forge
 
 # Create a conda environment for anvi'o, activate it, and make sure it will
 # always be activated
-RUN conda create -n anvioenv python=3.10
+RUN conda create -n anvioenv python=3.11
 RUN conda init bash
 RUN conda activate anvioenv
 RUN echo "conda activate anvioenv" >> ~/.bashrc

--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -32,6 +32,10 @@ from bottle import redirect, static_file
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 import anvio

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -24,6 +24,10 @@ import pandas as pd
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 from io import StringIO

--- a/anvio/drivers/hmmer.py
+++ b/anvio/drivers/hmmer.py
@@ -11,6 +11,10 @@ import shutil
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 import anvio

--- a/anvio/drivers/vmatch.py
+++ b/anvio/drivers/vmatch.py
@@ -13,6 +13,10 @@ import pandas as pd
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 from collections import defaultdict

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -13,6 +13,10 @@ from collections import OrderedDict, Counter
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -25,6 +25,10 @@ from scipy.optimize import curve_fit
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 import anvio

--- a/anvio/sequence.py
+++ b/anvio/sequence.py
@@ -12,6 +12,10 @@ import numpy as np
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 from hashlib import sha1

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -16,6 +16,10 @@ import datetime
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 from Bio.PDB import DSSP, PDBParser

--- a/anvio/taxonomyops/__init__.py
+++ b/anvio/taxonomyops/__init__.py
@@ -17,6 +17,10 @@ import pandas as pd
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 from collections import OrderedDict, Counter

--- a/anvio/trnaseq.py
+++ b/anvio/trnaseq.py
@@ -120,6 +120,10 @@ import matplotlib.pyplot as plt
 #
 #   >>> AttributeError: Can't pickle local object 'SOMEFUNCTION.<locals>.<lambda>' multiprocessing
 #
+# TODO:
+#   Update the comment above. Using multiprocess doesn't cause a pickling error with Python 3.10 anymore,
+#   but it somehow causes a GZip error with Python 3.11.
+#
 import multiprocess as multiprocessing
 
 from hashlib import sha1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
-requires-python = "==3.10.*"
+requires-python = "==3.11.*"
 dynamic = ["version"]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "paste",
     "pyani",
     "psutil",
-    "pandas==1.4.4",
+    "pandas==1.5.2",
     "snakemake",
     "multiprocess",
     "plotext",


### PR DESCRIPTION
Relates to #2618

* Declare support for Python 3.11
* Updates `pandas==1.4.4` to `==1.5.2` (the earliest version with Python 3.11 support.)

Blocked by #2642 and the fix that is going to follow it.