### PR TITLE
[CLI, cosmetic] fix unwanted syntax coloring 

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1977,7 +1977,7 @@ D = {
              'type': int,
              'help': "Maximum number of threads to use for multithreading whenever possible. Very conservatively, the default "
                      "is 1. It is a good idea to not exceed the number of CPUs / cores on your system. Plus, please "
-                     "be careful with this option if you are running your commands on a SGE --if you are clusterizing your runs, "
+                     "be careful with this option if you are running your commands on a SGE -- if you are clusterizing your runs, "
                      "and asking for multiple threads to use, you may deplete your resources very fast."}
                 ),
     'num-parallel-processes': (


### PR DESCRIPTION
`--if` is highlighted as if it was a CLI parameter