### PR TITLE
Exit with status code 1 in case of an error - fatal warning

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -87,7 +87,7 @@ if '--tmp-dir' in sys.argv:
         os.environ['TMPDIR'] = TMP_DIR
     except Exception as e:
         print("OSError: ", e)
-        sys.exit()
+        sys.exit(1)
 
 def P(d, dont_exit=False):
     """Poor man's debug output printer during debugging."""

--- a/anvio/cli/compute_completeness.py
+++ b/anvio/cli/compute_completeness.py
@@ -46,7 +46,7 @@ def compute_completeness(args):
         if len(splits_of_interest) != len(splits_in_users_list):
             if not len(splits_of_interest):
                 run.warning('None of the split names you provided in %s matched split names in the database...' % args.splits_of_interest)
-                sys.exit()
+                sys.exit(1)
             else:
                 run.warning('Only %d of %d split names you listed in "%s" matched split names in the database...'
                                                 % (len(splits_of_interest), len(splits_in_users_list), args.splits_of_interest))

--- a/anvio/cli/help.py
+++ b/anvio/cli/help.py
@@ -23,7 +23,7 @@ def main():
         ProgramSearch(args).process()
     except ConfigError as e:
         print(e)
-        sys.exit()
+        sys.exit(1)
 
 
 def get_args():

--- a/anvio/constants.py
+++ b/anvio/constants.py
@@ -227,7 +227,7 @@ for run_type, default_config in [('single', single_default),
               f"       If you are a developer and getting this error, please make sure the file \n"
               f"       is in anvi'o distribution. If you are a user and getting this error, it \n"
               f"       something went terribly wrong with your installation :(\n")
-        sys.exit()
+        sys.exit(1)
 
 for dir in [d.strip('/').split('/')[-1] for d in glob.glob(os.path.join(clustering_configs_dir, '*/'))]:
     clustering_configs[dir] = {}

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -55,7 +55,7 @@ except ModuleNotFoundError as e:
           f"properly initialized since Python complains that it cannot\n"
           f"import '{module_name}'. Are you sure you have initialized\n"
           f"the anvi'o environment properly?\n\n")
-    sys.exit()
+    sys.exit(1)
 
 # psutil is causing lots of problems for lots of people :/
 with SuppressAllOutput():

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -181,7 +181,7 @@ class VariabilityFilter:
             header = "Filtering failed. Here is the log:"
             self.report_filter_info_log(header)
             print(e)
-            sys.exit()
+            sys.exit(1)
 
         else:
             if verbose:


### PR DESCRIPTION
The tests inside the component tests pipeline was failing but the workflow itself wasn't: https://github.com/merenlab/anvio/actions/runs/26166457784/job/76971855168

I updated the exit code for error - fatal warning cases so that any tooling wrapping anvio will be able to understand something is wrong. The workflow fails properly now: https://github.com/merenlab/anvio/actions/runs/26168320675/job/76978629756