### PR TITLE
F541 fix and ruff.toml update

### DIFF
--- a/anvio/cli/compute_trnaseq_functional_affinity.py
+++ b/anvio/cli/compute_trnaseq_functional_affinity.py
@@ -1299,7 +1299,7 @@ def get_table_with_codon_tree_labels(args, df, multiple_sources=False):
                 # (<function_accession>)", unless no function accession is available (e.g., for
                 # BRITE categories), in which case labels end in empty parentheses.
                 if accession == '':
-                    label_suffix = f" ()"
+                    label_suffix = " ()"
                 else:
                     label_suffix = f" ({accession})"
                 labels.append(name + label_suffix)
@@ -2430,7 +2430,7 @@ def load_sample_linkage_from_newick(args, subset_affinities_dict):
     """Load a Newick-formatted tree of tRNA-seq samples as a cluster linkage. The x-axis dendrogram
     in the plot derives from the linkage object."""
     sample_tree = Tree(args.plot_sample_tree_file)
-    run.info(f"Loaded tree of tRNA-seq samples", args.plot_sample_tree_file)
+    run.info("Loaded tree of tRNA-seq samples", args.plot_sample_tree_file)
 
     leaves = sample_tree.iter_leaves()
     leaf_labels = decode_newick_labels(sample_tree.get_leaf_names())

--- a/anvio/cli/get_sequences_for_hmm_hits.py
+++ b/anvio/cli/get_sequences_for_hmm_hits.py
@@ -91,7 +91,7 @@ def run_program():
         defline_data_dict = hmmops.SequencesForHMMHits(None).defline_data_dict
         defline_format = hmmops.SequencesForHMMHits(None).defline_format
 
-        run.warning(f"Here are the variables you can use to provide a user-defined defline template: ")
+        run.warning("Here are the variables you can use to provide a user-defined defline template: ")
         for key in defline_data_dict.keys():
             run.info_single("{%s}" % key)
         run.info_single("Remember, by default, anvi'o will use the following template to format the deflines of "

--- a/anvio/drivers/vmatch.py
+++ b/anvio/drivers/vmatch.py
@@ -216,7 +216,7 @@ class Vmatch(object):
 
         pid = "Vmatch"
         self.progress.new(pid)
-        self.progress.update(f"Setting up search")
+        self.progress.update("Setting up search")
 
         with open(self.fasta_query_path) as query_file:
             for line_num, line in enumerate(query_file, 1):

--- a/anvio/tables/collections.py
+++ b/anvio/tables/collections.py
@@ -94,9 +94,9 @@ class TablesForCollections(Table):
 
         if bins_info_dict:
             if set(collection_dict.keys()) - set(bins_info_dict.keys()):
-                raise ConfigError(f"Bins in the collection dict do not match to the ones in the bins info dict. "
-                                  f"They do not have to be identical, but for each bin id, there must be a unique "
-                                  f"entry in the bins informaiton dict. There is something wrong with your input :/")
+                raise ConfigError("Bins in the collection dict do not match to the ones in the bins info dict. "
+                                  "They do not have to be identical, but for each bin id, there must be a unique "
+                                  "entry in the bins informaiton dict. There is something wrong with your input :/")
 
         if drop_collection:
             # remove any pre-existing information for 'collection_name'

--- a/anvio/trnaseq.py
+++ b/anvio/trnaseq.py
@@ -8070,7 +8070,7 @@ class ResultPlotter(object):
                     continue
 
                 if not taxon_rank_filter and not loop_ranks:
-                    warning(f"A taxon or at least one rank must be given.", "PROGRAM REQUIREMENT")
+                    warning("A taxon or at least one rank must be given.", "PROGRAM REQUIREMENT")
                     continue
 
                 loop_ranks = sorted(loop_ranks, key=lambda rank: RANKS.index(rank))
@@ -8081,7 +8081,7 @@ class ResultPlotter(object):
 
                 if single_aa and single_anticodon:
                     if ANTICODON_AA_DICT[single_anticodon] == single_aa:
-                        warning(f"An amino acid is not needed with the anticodon.", "UNNECESSARY FIELD")
+                        warning("An amino acid is not needed with the anticodon.", "UNNECESSARY FIELD")
                         single_aa = None
                     else:
                         warning(f"The anticodon ('{single_anticodon}') does not decode the amino acid ('{single_aa}').", "INVALID FIELD")

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -24,7 +24,7 @@ try:
     import webbrowser
     import subprocess
     import tracemalloc
-    import urllib.request, urllib.error, urllib.parse
+    import urllib.request
 
     import numpy as np
     import pandas as pd

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -205,8 +205,8 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                     with open(sanity_checked_metagenomes_file, 'w') as fp:
                         pass
                 else:
-                    self.run.warning(f"You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
-                                     f"for any genomes or metagenomes that cause issues downstream in ecophylo.")
+                    self.run.warning("You have declared run_genomes_sanity_check == false. anvi'o takes no responsibility "
+                                     "for any genomes or metagenomes that cause issues downstream in ecophylo.")
                     self.metagenomes_name_list = self.metagenomes_df.name.to_list()
                     self.metagenomes_path_list = self.metagenomes_df.contigs_db_path.to_list()
             else:
@@ -281,8 +281,8 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                 raise ConfigError("You provided a samples.txt so you're in profile mode! Please change AA_mode to false.")
 
         else:
-            self.run.warning(f"Since you did not provide a samples.txt, EcoPhylo will assume you do not want "
-                             f"to profile the ecology of your proteins and will just be making trees for now!")
+            self.run.warning("Since you did not provide a samples.txt, EcoPhylo will assume you do not want "
+                             "to profile the ecology of your proteins and will just be making trees for now!")
 
         # Pick which tree algorithm
         self.run_iqtree = self.get_param_value_from_config(['iqtree', 'run'])
@@ -325,11 +325,11 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
                               f"Please check your config file {self.config_file} and change cluster_representative_method to one of the following: 'mmseqs' and 'cluster_rep_with_coverages'")
 
         if self.cluster_representative_method == 'cluster_rep_with_coverages' and len(self.contigs_db_name_bam_dict) == 0:
-            raise ConfigError(f"The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages without BAM files..."
-                              f"Please edit your metagenomes.txt or external-genomes.txt and add BAM files.")
+            raise ConfigError("The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages without BAM files..."
+                              "Please edit your metagenomes.txt or external-genomes.txt and add BAM files.")
 
         if self.cluster_representative_method == 'cluster_rep_with_coverages' and self.AA_mode == True:
-            raise ConfigError(f"The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages in AA_mode")
+            raise ConfigError("The EcoPhylo workflow can't use the cluster representative method cluster_rep_with_coverages in AA_mode")
 
         # Parse clustering parameter space
         self.clustering_param_space = self.get_param_value_from_config(['cluster_X_percent_sim_mmseqs', 'clustering_threshold_for_OTUs'])
@@ -543,6 +543,6 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
         # TODO: I hope we can change that in the future, probably by making a contigs.db for the representative sequence,
         # in tree mode or not.
         if len(unique_group) < len(self.hmm_dict) and self.run_scg_taxonomy:
-            raise ConfigError(f"You have one or more 'group' in your HMM list file (or multiple identical entries - but you "
-                              f"shouldn't be doing that) and at the moment it is not compatible with anvi-estimate-scg-taxonomy. "
-                              f"The good news is that you can turn off anvi-run-scg-taxonmy in your config file.")
+            raise ConfigError("You have one or more 'group' in your HMM list file (or multiple identical entries - but you "
+                              "shouldn't be doing that) and at the moment it is not compatible with anvi-estimate-scg-taxonomy. "
+                              "The good news is that you can turn off anvi-run-scg-taxonmy in your config file.")

--- a/anvio/workflows/sra_download/__init__.py
+++ b/anvio/workflows/sra_download/__init__.py
@@ -109,7 +109,7 @@ class SRADownloadWorkflow(WorkflowSuperClass):
     def get_target_files(self):
         """Get list of target files for snakemake target rule"""
 
-        target_files = [os.path.join(self.dirs_dict['FASTAS'], f"generate_samples_txt.done")]
+        target_files = [os.path.join(self.dirs_dict['FASTAS'], "generate_samples_txt.done")]
 
         return target_files
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,4 +7,6 @@ select = [
     "UP009",
     # https://docs.astral.sh/ruff/rules/trailing-whitespace/
     "W291",
+    # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/
+    "F541",
 ]


### PR DESCRIPTION
This PR ensures that the codebase will no longer have any missing f-string placeholders.

(It also removes some unused imports from `utils.py` but it is more of a cosmetics than anything critical for review -- sorry).