### PR TITLE
migration tests += an ancient (pre-2018) pangenome dataset

### DIFF
--- a/anvio/tests/run_migration_tests_for_ancient_anvio_databases.sh
+++ b/anvio/tests/run_migration_tests_for_ancient_anvio_databases.sh
@@ -10,7 +10,6 @@ pip install h5py==3.9.0
 SETUP_WITH_OUTPUT_DIR $1 $2 $3
 #####################################
 
-
 #########################################################################################
 # POUCHITIS DATA FROM 2015
 #########################################################################################
@@ -66,4 +65,31 @@ INFO "[$TEST] Running SCG taxonomy"
 anvi-run-scg-taxonomy -c CONTIGS.db $thread_controller
 INFO "[$TEST] Estimating SCG taxonomy"
 anvi-estimate-scg-taxonomy -c CONTIGS.db
+INFO "[$TEST] Done!"
+
+#########################################################################################
+# PHROCLOROCOCCUS METAPANGENOME FROM 2018
+#########################################################################################
+
+cd $output_dir
+TEST="PHROCLOROCOCCUS_METAPANGENOME_FROM_2018"
+mkdir $TEST && cd $TEST
+INFO "[$TEST] Downloading the data pack"
+curl -L https://ndownloader.figshare.com/files/9416623 -o ANVIO-METAPANGENOME-FOR-PROCHLOROCOCCUS-ISOLATES.tar.gz
+INFO "[$TEST] Unpacking"
+tar -zxvf ANVIO-METAPANGENOME-FOR-PROCHLOROCOCCUS-ISOLATES.tar.gz && cd ANVIO-METAPANGENOME-FOR-PROCHLOROCOCCUS-ISOLATES
+INFO "[$TEST] Migrating the pan-db"
+ANVIO_SAMPLES_DB=Prochlorococcus-METAPAN-SAMPLES.db anvi-migrate Prochlorococcus-PAN-PAN.db --migrate-quickly
+INFO "[$TEST] Migrating the genomes-storage-db"
+anvi-migrate Prochlorococcus-GENOMES.h5 --migrate-quickly
+INFO "[$TEST] Importing additional data layers into the pan-db"
+# Converting additional data layers to the new format -- this will
+# only be necessary for this particular project
+echo -e "pc_name\tDetection#EDG\tDetection#ECG\tDetection#NA" | sed 's/#/!/g' > ENVIRONMENTAL-CORE-FIXED.txt
+grep -v 'pc_name' ENVIRONMENTAL-CORE.txt | awk 'BEGIN{FS=";"}{print $1 "\t" $2 "\t" $3}' >> ENVIRONMENTAL-CORE-FIXED.txt
+anvi-import-misc-data -t items ENVIRONMENTAL-CORE-FIXED.txt -p Prochlorococcus-PAN-PAN.db
+# let's remove unnecessary files while we're at it
+rm -rf *SAMPLES* ENVIRONMENTAL-CORE.txt 00_run.sh ENVIRONMENTAL-CORE-GENES.txt
+INFO "[$TEST] Running anvi-db-info on the pan-db"
+anvi-db-info -p Prochlorococcus-PAN-PAN.db
 INFO "[$TEST] Done!"

--- a/anvio/tests/run_migration_tests_for_ancient_anvio_databases.sh
+++ b/anvio/tests/run_migration_tests_for_ancient_anvio_databases.sh
@@ -68,7 +68,7 @@ anvi-estimate-scg-taxonomy -c CONTIGS.db
 INFO "[$TEST] Done!"
 
 #########################################################################################
-# PHROCLOROCOCCUS METAPANGENOME FROM 2018
+# PROCHLOROCOCCUS METAPANGENOME FROM 2018
 #########################################################################################
 
 cd $output_dir


### PR DESCRIPTION
This PR brings in a [published](https://doi.org/10.7717/peerj.4320) anvi'o metapangenome data pack for Prochlorococcus that has been first shared -and is still availble- [here](https://merenlab.org/data/prochlorococcus-metapangenome/).

When I run,

```
anvi-self-test --suite database-migrations -o MIGRATIONS -T 12
```

I can see this after almost a decade for Phroclorococcus by going into the MIGRATIONS directory and running `anvi-display-pan`:

<img width="1805" height="1858" alt="image" src="https://github.com/user-attachments/assets/7b715545-30ac-4d17-b0e0-1dc9dcbbf14f" />

Mmm

<img width="569" height="208" alt="image" src="https://github.com/user-attachments/assets/0456cefe-ef50-4acc-9968-95b3792c2c44" />
