### PR TITLE
KGML subchain deduplication fix

### DIFF
--- a/anvio/kgmlnetworkops.py
+++ b/anvio/kgmlnetworkops.py
@@ -1039,8 +1039,15 @@ class KGMLNetworkWalker:
                                 continue
 
                     # A subchain to each compound in a terminal chain is also generated as a
-                    # "candidate terminal chain" and is ignored.
-                    if terminal_chains:
+                    # "candidate terminal chain" and is ignored. The candidate is only a subchain of
+                    # the last terminal chain if the two run in the same direction: with a
+                    # compound_fate of 'both', a chain of reversible reactions is found in both
+                    # directions traversing identical compounds and reactions, and these are
+                    # distinct chains rather than subchains of one another.
+                    if (
+                        terminal_chains and
+                        terminal_chains[-1].is_consumed == candidate_terminal_chain.is_consumed
+                    ):
                         candidate_kgml_compound_ids = [
                             c.id for c in candidate_terminal_chain.kgml_compound_entries
                         ]


### PR DESCRIPTION
In walking KEGG pathways using KGML files, the walker can find both consumption chains *from* compounds and production chains *to* compounds in the pathway at the same time (`compound_fate = 'both'`). A route through the pathway consisting entirely of reversible reactions yields four chains: consumption chains in the forward and reverse directions, and production chains in the forward and reverse directions. All consumption and production chains are stored together as `terminal_chains`. The walker algorithm finds "candidate" terminal chains before confirming they are terminal chains to report, filtering out candidate chains that are subchains of the last stored terminal chain. Subchains generated in the course of the walker's operations are expected to be shorter than the longer terminal chain -- the same chain shouldn't be generated twice. However, when both consumption and production chains are sought, instead of one or the other, a consumption chain consisting only of reversible reactions taken in reverse looks like the equivalent production chain taken in the forward direction, and the consumption chain in the forward direction looks like the equivalent production chain in reverse, when comparing the two based on their ordered lists of compounds and reactions: this causes the walker to erroneously raise an `AssertionError` mistakenly identifying the full-length reversed chain as a subchain of unexpected equal length. The fix is to distinguish consumption chains (`is_consumed = True`) from production chains (`is_consumed = False`), only comparing consumption chains or production chains in subchain deduplication.