### PR TITLE
Revert numba removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "illumina-utils",
     "tabulate",
     "rich-argparse",
+    "numba",
     "paste",
     "pyani",
     "psutil",


### PR DESCRIPTION
Reverts the pyproject.toml changes from fbf4ca562d45f84d4721f0ddb6ebb70750a8c97b

Fixes https://github.com/merenlab/anvio/actions/runs/26505731635/job/78057481612

`numba` is still used in the codebase. Removal of the dependency caused a missing dependency issue, ending up breaking the CI.