### PR TITLE
Gene highlight in inspect page

### DIFF
--- a/anvio/data/interactive/js/bin.js
+++ b/anvio/data/interactive/js/bin.js
@@ -1595,6 +1595,11 @@ Bins.prototype.ExportBin = function(bin_id_to_export, use_bin_id = false) {
  * @param {Array|string} item_list - Items to highlight
  */
 Bins.prototype.HighlightItems = function(item_list) {
+    // clear any function-search gene highlights tied to a previous highlight. the function-search
+    // path (search.js) re-populates this key right after calling us, so every other caller leaves
+    // it empty and the gene highlight stays correctly tied to a gene-centric search.
+    try { localStorage.removeItem('search_highlighted_genes'); } catch (e) { /* localStorage may be unavailable */ }
+
     if (!Array.isArray(item_list)) {
         item_list = [item_list];
     }
@@ -1617,6 +1622,7 @@ Bins.prototype.HighlightItems = function(item_list) {
  * Clear highlighted items
  */
 Bins.prototype.ClearHighlightedItems = function() {
+    try { localStorage.removeItem('search_highlighted_genes'); } catch (e) { /* localStorage may be unavailable */ }
     this.higlighted_items = [];
     this.RedrawBins();
 };

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -46,6 +46,12 @@ var charts;
 var brush;
 var inspect_mode;
 var highlightBoxes;
+// gene_callers_id strings (for the inspected split) that matched a function search on the main
+// page. populated in loadAll() from localStorage. see search.js.
+var search_highlighted_genes = [];
+// solid pale-amber soft-pill accent for those genes — opaque so it never blends with the
+// translucent grey band behind the gene arrows, and a quiet contrast to the green gene arrows.
+var search_highlight_color = '#F7DFBB';
 var indels_enabled;
 var show_nucleotides = true;
 var maxNucleotidesInWindow = 300;
@@ -152,6 +158,18 @@ function loadAll() {
     contig_id = getParameterByName('id');
     highlight_gene = getParameterByName('highlight_gene') === 'true';
     gene_mode = getParameterByName('gene_mode') === 'true';
+
+    // if this split was highlighted on the main page via a function (annotation) search, mark the
+    // matching genes so the user doesn't have to click every gene to find them. in gene_mode
+    // `contig_id` is a gene id rather than a split name, so this is a no-op there.
+    if (!gene_mode) {
+        try {
+            let shg = JSON.parse(localStorage.search_highlighted_genes || '{}');
+            if (shg[contig_id]) {
+                search_highlighted_genes = shg[contig_id].map(x => '' + x);
+            }
+        } catch (e) { /* malformed or absent key: feature stays inactive */ }
+    }
 
     state = typeof localStorage.state === 'undefined' ? {} : JSON.parse(localStorage.state);
 

--- a/anvio/data/interactive/js/inspectionutils.js
+++ b/anvio/data/interactive/js/inspectionutils.js
@@ -379,22 +379,20 @@ function drawArrows(_start, _stop, colortype, gene_offset_y, color_genes=null) {
                         (gene.direction == 'f' && gene.stop_in_split  < _stop);
         var left_pad  = offset + ((has_arrow && gene.direction == 'r') ? arrow_overhang : 0);
         var right_pad = offset + ((has_arrow && gene.direction == 'f') ? arrow_overhang : 0);
-        var box = paths.append('svg:rect')
+        // soft solid pale-amber "pill" behind highlighted genes — both the gene being inspected
+        // (gene/context mode) and genes that matched a function search. opaque on purpose: the
+        // inspect-page background is a translucent grey band, so a semi-transparent fill would
+        // blend into it and read as muddy. see gene_highlight_demo.html.
+        paths.append('svg:rect')
            .attr('x', start - left_pad)
            .attr('width', stop + left_pad + right_pad)
            .attr('y', y - offset)
            .attr('height', 2 * offset)
-           .attr('stroke-width', 0);
-
-        if (is_inspected_gene) {
-          // the inspected gene (gene/context mode) keeps its solid yellow box, and wins when both apply.
-          box.attr('fill', 'yellow').attr('fill-opacity', 1);
-        } else {
-          // soft solid pale-amber "pill" behind genes that matched a function search. opaque on
-          // purpose: the inspect-page background is a translucent grey band, so a semi-transparent
-          // fill would blend into it and read as muddy. see gene_highlight_demo.html.
-          box.attr('fill', search_highlight_color).attr('fill-opacity', 1).attr('rx', 5).attr('ry', 5);
-        }
+           .attr('stroke-width', 0)
+           .attr('fill', search_highlight_color)
+           .attr('fill-opacity', 1)
+           .attr('rx', 5)
+           .attr('ry', 5);
       }
 
       // M10 15 l20 0

--- a/anvio/data/interactive/js/inspectionutils.js
+++ b/anvio/data/interactive/js/inspectionutils.js
@@ -382,7 +382,7 @@ function drawArrows(_start, _stop, colortype, gene_offset_y, color_genes=null) {
         // soft solid pale-amber "pill" behind highlighted genes — both the gene being inspected
         // (gene/context mode) and genes that matched a function search. opaque on purpose: the
         // inspect-page background is a translucent grey band, so a semi-transparent fill would
-        // blend into it and read as muddy. see gene_highlight_demo.html.
+        // blend into it and read as muddy.
         paths.append('svg:rect')
            .attr('x', start - left_pad)
            .attr('width', stop + left_pad + right_pad)

--- a/anvio/data/interactive/js/inspectionutils.js
+++ b/anvio/data/interactive/js/inspectionutils.js
@@ -366,17 +366,35 @@ function drawArrows(_start, _stop, colortype, gene_offset_y, color_genes=null) {
         category = gene.gene_callers_id;
       }
 
-      if (highlight_gene && gene.gene_callers_id == contig_id)
+      let is_inspected_gene = highlight_gene && gene.gene_callers_id == contig_id;
+      let is_search_match = search_highlighted_genes.includes('' + gene.gene_callers_id);
+      if (is_inspected_gene || is_search_match)
       {
         var offset = 6;
-        paths.append('svg:rect')
-           .attr('x', start - offset)
-           .attr('width', stop + offset * 2)
+        // the arrowhead (marker-end) overhangs the gene line's tip by ~6px (markerWidth 2 x
+        // strokeWidth 6, tip at viewBox x=5). without compensating, the box looks flush at the
+        // tip but padded at the flat end. add the overhang on whichever side the arrow is drawn.
+        var arrow_overhang = 6;
+        var has_arrow = (gene.direction == 'r' && gene.start_in_split > _start) ||
+                        (gene.direction == 'f' && gene.stop_in_split  < _stop);
+        var left_pad  = offset + ((has_arrow && gene.direction == 'r') ? arrow_overhang : 0);
+        var right_pad = offset + ((has_arrow && gene.direction == 'f') ? arrow_overhang : 0);
+        var box = paths.append('svg:rect')
+           .attr('x', start - left_pad)
+           .attr('width', stop + left_pad + right_pad)
            .attr('y', y - offset)
            .attr('height', 2 * offset)
-           .attr('fill', 'yellow')
-           .attr('fill-opacity', 1)
            .attr('stroke-width', 0);
+
+        if (is_inspected_gene) {
+          // the inspected gene (gene/context mode) keeps its solid yellow box, and wins when both apply.
+          box.attr('fill', 'yellow').attr('fill-opacity', 1);
+        } else {
+          // soft solid pale-amber "pill" behind genes that matched a function search. opaque on
+          // purpose: the inspect-page background is a translucent grey band, so a semi-transparent
+          // fill would blend into it and read as muddy. see gene_highlight_demo.html.
+          box.attr('fill', search_highlight_color).attr('fill-opacity', 1).attr('rx', 5).attr('ry', 5);
+        }
       }
 
       // M10 15 l20 0

--- a/anvio/data/interactive/js/main.js
+++ b/anvio/data/interactive/js/main.js
@@ -60,6 +60,9 @@ var last_settings;
 
 var search_column;
 var search_results = [];
+// map of split_name -> [gene_callers_id, ...] populated only by a function (annotation) search,
+// so the inspect page can highlight the matching genes for a highlighted split. see search.js.
+var genes_per_split_from_function_search = {};
 
 var views = {};
 var layers = {};

--- a/anvio/data/interactive/js/search.js
+++ b/anvio/data/interactive/js/search.js
@@ -32,6 +32,7 @@ function searchContigs()
     var _len = layerdata.length;
     var _counter = 0;
     search_results = [];
+    genes_per_split_from_function_search = {};
 
     $('#search_result_message').html("Searching...");
 
@@ -109,6 +110,7 @@ function searchFunctions() {
 
                 search_results = [];
                 search_column = 'Annotation';
+                genes_per_split_from_function_search = {};
 
                 for (var i=0; i < data['results'].length; i++) {
                     console.log(mode);
@@ -129,6 +131,10 @@ function searchFunctions() {
                         var _annotation     = data['results'][i][3];
                         var _search_term    = data['results'][i][4];
                         var _split_name     = data['results'][i][5];
+
+                        // remember which gene(s) matched in each split so the inspect page can
+                        // highlight them when this split is highlighted on the tree.
+                        (genes_per_split_from_function_search[_split_name] ||= []).push(_gene_caller_id);
                     }
 
                     var _beginning = _annotation.toLowerCase().indexOf(_search_term.toLowerCase());
@@ -195,6 +201,7 @@ function filterGeneClusters() {
 
                 search_results = [];
                 search_column = '';
+                genes_per_split_from_function_search = {};
 
                 for (var i=0; i < data['gene_clusters_list'].length; i++) {
                     search_results.push({'split': data['gene_clusters_list'][i], 'value': ''});
@@ -245,10 +252,35 @@ function highlightResult() {
     }
 
     bins.HighlightItems(highlighted_splits);
+    writeSearchHighlightedGenes(highlighted_splits);
 }
 
 function highlightSplit(name) {
     bins.HighlightItems(name);
+    writeSearchHighlightedGenes([name]);
+}
+
+function writeSearchHighlightedGenes(split_names) {
+    // tie gene-level highlighting on the inspect page to the split highlight, but only when the
+    // highlight came from a function (annotation) search. bins.HighlightItems() clears the
+    // transport key, so this must run *after* it to be the one path that leaves it populated.
+    try {
+        if (search_column != 'Annotation') {
+            return;
+        }
+
+        var genes = {};
+        for (var i=0; i < split_names.length; i++) {
+            var s = split_names[i];
+            if (genes_per_split_from_function_search[s]) {
+                genes[s] = genes_per_split_from_function_search[s];
+            }
+        }
+
+        localStorage.search_highlighted_genes = JSON.stringify(genes);
+    } catch (e) {
+        // localStorage may be unavailable; the feature simply won't activate.
+    }
 }
 
 function appendResult() {

--- a/anvio/docs/artifacts/interactive.md
+++ b/anvio/docs/artifacts/interactive.md
@@ -192,7 +192,7 @@ At the very bottom of the Search tab are a few buttons to view and explore the r
 ![search view](../../images/interactive_interface/search_view.png){:.center-img .width-70}
 
   - __List Results__: there you can choose to display the detail of the searched items. By clicking on that button, a table will appear with the details of the items matching your search.
-  - __Highlight the search__: you can highlight the items matching the search by clicking, change the color of the highlight and remove any existing highlight.
+  - __Highlight the search__: you can highlight the items matching the search by clicking, change the color of the highlight and remove any existing highlight. When the highlight comes from a __Search functions__ query, opening one of those splits in the inspect page (%(anvi-inspect)s) will also highlight the gene(s) that matched, so you can spot them at a glance instead of clicking through every gene.
   - __Append/Remove items from selected bin__: you can choose to add the items matching your search to the current bin, or to remove them from your current bin.
 
 ### News tab


### PR DESCRIPTION
When you search for a gene function in the interactive interface, you can highlight the splits containing genes with a matches. But when you inspect that split, you have to search among the ~20 genes for the one matching your search. ANNOYING.
Solution: highlight the genes:
<img width="1535" height="871" alt="image" src="https://github.com/user-attachments/assets/3fa5ec11-c611-4614-bcd6-f7b371f29aa2" />
