### PR TITLE
Use current PFAM HMM output flag

### DIFF
--- a/anvio/docs/artifacts/hmm-list.md
+++ b/anvio/docs/artifacts/hmm-list.md
@@ -14,7 +14,7 @@ Here is an example of an %(hmm-list)s using the HMM Ribosomal_L16 and Ribosomal_
 You can also use external %(hmm-source)ss! An easy way to get an anvi'o ready HMM directory is to use the script %(anvi-script-pfam-accessions-to-hmms-directory)s to download a [Pfam HMM](https://pfam.xfam.org/).
 
 {{ codestart }}
-anvi-script-pfam-accessions-to-hmms-directory --pfam-accessions-list PF00016 -O RuBisCO_large_HMM
+anvi-script-pfam-accessions-to-hmms-directory --pfam-accessions-list PF00016 -o RuBisCO_large_HMM
 {{ codestop }}
 
 Here is what the `hmm_list.txt` should look like with a combination of internal and external %(hmm-source)ss:

--- a/anvio/docs/artifacts/hmm-source.md
+++ b/anvio/docs/artifacts/hmm-source.md
@@ -64,7 +64,7 @@ It is also possible to generate an anvi'o compatible HMMs directory for a given 
 
 {{ codestart }}
 %(anvi-script-pfam-accessions-to-hmms-directory)s --pfam-accessions-list PF00705 PF00706 \
-                                               -O AD_HOC_HMMs
+                                               -o AD_HOC_HMMs
 {{ codestop }}
 
 These IDs can be given through the command line as a list, or through an input file where every line is a unique accession id.
@@ -79,7 +79,7 @@ One can run this command:
 
 {{ codestart }}
 %(anvi-script-pfam-accessions-to-hmms-directory)s --pfam-accessions-list PF06603 \
-                                                -O UpxZ
+                                                -o UpxZ
 {{ codestop }}
 
 which would createa a directory called `UpxZ`. Then, one would run this command to find matches to this model in a given contigs database:

--- a/anvio/docs/artifacts/user-modules-data.md
+++ b/anvio/docs/artifacts/user-modules-data.md
@@ -117,7 +117,7 @@ Annotating PF06603.14 requires an extra step, because we first need to create a 
 
 {{ codestart }}
 %(anvi-script-pfam-accessions-to-hmms-directory)s --pfam-accessions-list PF06603.14 \
-                                               -O METABOLISM_HMM
+                                               -o METABOLISM_HMM
 %(anvi-run-hmms)s -c CONTIGS.db \
                -H METABOLISM_HMM \
                --add-to-functions-table \

--- a/anvio/tests/run_component_tests_for_metagenomics.sh
+++ b/anvio/tests/run_component_tests_for_metagenomics.sh
@@ -147,7 +147,7 @@ anvi-run-hmms -c $output_dir/CONTIGS.db \
 
 INFO "Generating an ad hoc HMM source from two PFAM accessions (A STEP THAT REQUIRES INTERNET CONNECTION AND RESPONSE FROM XFAM.ORG)"
 anvi-script-pfam-accessions-to-hmms-directory --pfam-accessions-list PF00705 PF00706 \
-                                              -O $output_dir/ADHOC_HMMs \
+                                              -o $output_dir/ADHOC_HMMs \
                                               --no-progress
 
 INFO "Running the HMMs in the ad hoc user directory"


### PR DESCRIPTION
Updates the PFAM accession helper examples and metagenomics component
test from the old -O output flag to the current -o flag.

Companion PR: https://github.com/merenlab/anvio/pull/2701

Together with the companion PR, this change allowed the local equivalents of the Component Tests and Migrations workflow
suites to complete:
- anvi-self-test --suite metagenomics-full --no-interactive
- anvi-self-test --suite pangenomics --no-interactive
- anvi-self-test --suite inversions --no-interactive