### PR TITLE
Fix pangenomics component test regressions

### DIFF
--- a/anvio/cli/compute_gene_cluster_homogeneity.py
+++ b/anvio/cli/compute_gene_cluster_homogeneity.py
@@ -77,7 +77,7 @@ def run_program():
     if args.collection_name:
         progress.new('Initializing gene clusters')
         progress.update('...')
-        pan = summarizer.PanSummarizer(args, r=terminal.Run(verbose=False), p=terminal.Progress(verbose=False))
+        pan = summarizer.PanSummarizer(args, lazy_init=True, r=terminal.Run(verbose=False), p=terminal.Progress(verbose=False))
         progress.end()
 
         if not args.bin_id:

--- a/anvio/cli/get_sequences_for_gene_clusters.py
+++ b/anvio/cli/get_sequences_for_gene_clusters.py
@@ -54,7 +54,7 @@ def run_program():
     if args.collection_name or args.list_collections or args.list_bins:
         progress.new('Initializing')
         progress.update('...')
-        pan = summarizer.PanSummarizer(args, r=terminal.Run(verbose=False), p=terminal.Progress(verbose=False))
+        pan = summarizer.PanSummarizer(args, lazy_init=True, r=terminal.Run(verbose=False), p=terminal.Progress(verbose=False))
         progress.end()
 
         if not args.bin_id:

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -148,7 +148,9 @@ class SummarizerSuperClass(object):
         if not self.lazy_init:
             self.sanity_check()
 
-        if self.output_directory:
+        if self.lazy_init:
+            self.output_directory = self.output_directory or "SUMMARY"
+        elif self.output_directory:
             self.output_directory = filesnpaths.check_output_directory(self.output_directory, ok_if_exists=self.delete_output_directory_if_exists or self.just_do_it)
             filesnpaths.gen_output_directory(self.output_directory, delete_if_exists=self.delete_output_directory_if_exists or self.just_do_it)
         else:
@@ -249,7 +251,7 @@ class PanSummarizer(PanSuperclass, SummarizerSuperClass):
         if not self.genomes_storage_is_available:
             raise ConfigError("No genomes storage no summary. Yes. Very simple stuff.")
 
-        if not args.__dict__.get('output_dir'):
+        if not self.lazy_init and not args.__dict__.get('output_dir'):
             project_name = self.p_meta.get('project_name') or 'PROJECT'
             args.output_dir = f'{project_name}-PAN-SUMMARY'
 

--- a/anvio/summarizer.py
+++ b/anvio/summarizer.py
@@ -320,9 +320,9 @@ class PanSummarizer(PanSuperclass, SummarizerSuperClass):
             v = None
             for gene_cluster_id in occurrence_of_functions_in_pangenome_dict[gene_cluster_function]['gene_clusters_ids']:
                 if v is None:
-                    v = gene_cluster_frequencies_dataframe.loc[gene_cluster_id, ].astype(int)
+                    v = gene_cluster_frequencies_dataframe.loc[gene_cluster_id].astype(int)
                 else:
-                    v = v.add(gene_cluster_frequencies_dataframe.loc[gene_cluster_id, ])
+                    v = v.add(gene_cluster_frequencies_dataframe.loc[gene_cluster_id])
             D[gene_cluster_function] = {}
             for genome in v.index:
                 D[gene_cluster_function][genome] = v[genome]

--- a/anvio/tests/run_component_tests_for_pangenomics.sh
+++ b/anvio/tests/run_component_tests_for_pangenomics.sh
@@ -205,10 +205,11 @@ anvi-compute-gene-cluster-homogeneity -p TEST-PAN.db \
 SHOW_FILE gene_cluster_homogeneity_results.txt
 
 INFO "Generating a pangenome-informed representative genome"
-anvi-gen-pan-genome-representative-genome -p TEST-PAN.db \
-                                          -g TEST-GENOMES.db \
-                                          -o REPRESENTATIVE_GENOME_FOR_PAN.db \
-                                          --no-progress
+anvi-gen-pan-representative -p TEST-PAN.db \
+                            -g TEST-GENOMES.db \
+                            -e external-genomes.txt \
+                            -o REPRESENTATIVE_GENOME_FOR_PAN.db \
+                            --no-progress
 
 INFO "Exporting PanRepresentative annotations for the representative genome"
 anvi-export-functions -c REPRESENTATIVE_GENOME_FOR_PAN.db \


### PR DESCRIPTION
Fixes pangenomics component-test failures by avoiding lazy pan summary directory side effects, fixing pan
summary pandas row selection, and updating the pan representative test command to the current CLI.

Companion PR: https://github.com/merenlab/anvio/pull/2700

Together with the companion PR, this change allowed the local equivalents of the Component Tests and Migrations workflow
suites to complete:
- anvi-self-test --suite metagenomics-full --no-interactive
- anvi-self-test --suite pangenomics --no-interactive
- anvi-self-test --suite inversions --no-interactive