### PR TITLE
Support for 'descriptions' in pan-graph-db files

### DIFF
--- a/anvio/cli/pan_genome_graph.py
+++ b/anvio/cli/pan_genome_graph.py
@@ -116,6 +116,7 @@ def get_args():
 
     groupF = parser.add_argument_group('METADATA & LAYERS', "Display and metadata options for the resulting pan-graph.")
 
+    groupF.add_argument(*anvio.A('description'), **anvio.K('description'))
     groupF.add_argument('--project-name', default=None, help = "Optional name stored in the pan-graph-db metadata (for display/export).")
     groupF.add_argument('--load-state', default='default', type=str, help="Initial display state name to store/use in the pan-graph-db.")
     groupF.add_argument('--import-values', default='start,stop,partial,call_type', type=str, help = "Comma-separated "

--- a/anvio/cli/update_db_description.py
+++ b/anvio/cli/update_db_description.py
@@ -16,7 +16,7 @@ __license__ = "GPL 3.0"
 __version__ = anvio.__version__
 __authors__ = ['meren']
 __requires__ = ['contigs-db']
-__can_use__ = ['pan-db', 'profile-db', 'genomes-storage-db']
+__can_use__ = ['pan-db', 'pan-graph-db', 'profile-db', 'genomes-storage-db']
 __description__ = "Update the description in an anvi'o database"
 
 

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -1594,6 +1594,13 @@ class PangenomeGraph():
         self.load_state = A('load_state')
         self.import_values = A('import_values').split(',') if A('import_values') else []
 
+        description_file_path = A('description')
+        if description_file_path:
+            filesnpaths.is_file_plain_text(description_file_path)
+            self.description = open(os.path.abspath(description_file_path), 'r').read()
+        else:
+            self.description = ''
+
         # STANDARD CLASS VARIABLES
         self.version = anvio.__pangraph__version__
         self.functional_annotation_sources_available = DBInfo(self.genomes_storage, expecting='genomestorage').get_functional_annotation_sources() if self.genomes_storage else []
@@ -1958,6 +1965,7 @@ class PangenomeGraph():
             'anvio_version': anvio.__version__,
             'version': self.version,
             'project_name': self.project_name,
+            'description': self.description,
             # genome provenance
             'genomes_storage_hash': self.genomes_storage_hash,
             'genome_names': ','.join(self.genome_names),


### PR DESCRIPTION
Most anvi'o dbs have 'description' key in their `self` tables that enable users to add markdown-formatted free text into dbs for downstream use.

This PR enables pan-graph-dbs to benefit from the same functionality.