### PR TITLE
anvi-run-kegg-kofams KeyError fix

### DIFF
--- a/anvio/metabolism/annotate.py
+++ b/anvio/metabolism/annotate.py
@@ -77,12 +77,17 @@ class AnnotationWorker(multiprocessing.Process):
         Workers close (but do not unlink) the segment — only the main process unlinks.
         """
         from multiprocessing.shared_memory import SharedMemory
-        from multiprocessing import resource_tracker
+        from multiprocessing import resource_tracker, get_start_method
 
         shm = SharedMemory(name=self.shared_data_shm_name, create=False)
-        resource_tracker.unregister('/' + shm.name, 'shared_memory')
+        # With 'fork', all workers share the parent's resource tracker (RT) pipe; we don't unregister here because that
+        # would remove the main process's entry and cause its unlink() to KeyError in the resource tracker.
+        # With 'spawn', each worker has its own RT and must unregister to prevent it from calling
+        # shm_unlink when the worker exits.
+        if get_start_method() != 'fork':
+            resource_tracker.unregister('/' + shm.name, 'shared_memory')
         bundle = pickle.loads(bytes(shm.buf[:self.shared_data_size]))
-        shm._name = None  # shm.close() also calls unregister; nulling _name prevents a KeyError message from the second call to unregister
+        shm._name = None  # prevent close() from calling unregister a second time
         shm.close()
 
         self.ko_dict = bundle['ko_dict']

--- a/anvio/metabolism/annotate.py
+++ b/anvio/metabolism/annotate.py
@@ -82,6 +82,7 @@ class AnnotationWorker(multiprocessing.Process):
         shm = SharedMemory(name=self.shared_data_shm_name, create=False)
         resource_tracker.unregister('/' + shm.name, 'shared_memory')
         bundle = pickle.loads(bytes(shm.buf[:self.shared_data_size]))
+        shm._name = None  # shm.close() also calls unregister; nulling _name prevents a KeyError message from the second call to unregister
         shm.close()
 
         self.ko_dict = bundle['ko_dict']


### PR DESCRIPTION
With the new changes in https://github.com/merenlab/anvio/pull/2653, we started seeing non-fatal `KeyErrors` in the output of `anvi-run-kegg-kofams`, but only when running it on HPCs.

This PR fixes that.

Basically, there is a resource tracker (RT) that is in charge of cleaning up SharedMemory objects if a worker crashes. 

When on Mac (where I tested this PR initially), workers are generated with the `spawn` method, which gives them their own isolated resource tracker, so the "main" one isn't supposed to take care of their stuff. Meaning that workers on Mac have to explicitly unregister their SharedMemory objects from the main RT so that when they finish normally, the main RT doesn't try to clean up things that don't exist anymore.

But on Linux, workers are generated with `fork` and they inherit their parent processes RT (the "main" one). That means the main RT always tries to clean up their stuff after workers are done, and unregister() is called twice -- first by the worker, and then by the main RT. The second time unregister() is called, the SharedMemory object is already unregistered and hence we get a KeyError because it cannot be found :)

The fix was to explicitly check how the worker was spawned (fork or not), and from there decide whether or not the worker will unregister its SharedMemory object itself.