### PR TITLE
enzymes-txt support for anvi-draw-kegg-pathways

### DIFF
--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -24,13 +24,27 @@ __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"
 __version__ = VERSION
 __requires__ = ['kegg-data']
-__can_use__ = ['contigs-db', 'external-genomes', 'pan-db', 'genomes-storage-db']
+__can_use__ = ['contigs-db', 'external-genomes', 'pan-db', 'genomes-storage-db', 'reaction-network']
 __provides__ = ['kegg-pathway-map']
 __description__ = DESCRIPTION
 
 
 def get_args() -> Namespace:
     parser = ArgumentParser(description=DESCRIPTION)
+
+    groupJSON = parser.add_argument_group(
+        "REACTION NETWORK JSON",
+        "Display KO data from a reaction network JSON file produced by 'anvi-reaction-network "
+        "--enzymes-txt' or 'anvi-get-metabolic-model-file'. This bypasses the need for a contigs "
+        "database and allows pathway maps to be drawn from any custom enzyme list."
+    )
+    groupJSON.add_argument(
+        '--reaction-network-json', type=str, metavar='FILE', help=
+        "Path to a reaction network JSON file (produced by 'anvi-reaction-network --enzymes-txt' "
+        "or 'anvi-get-metabolic-model-file'). KO IDs are extracted from the gene annotations in "
+        "the JSON and used to highlight reactions in pathway maps. Use '--ko' to activate KO "
+        "drawing when using this option."
+    )
 
     groupCONTIGS = parser.add_argument_group(
         "CONTIGS DATABASE",
@@ -318,6 +332,24 @@ def consolidate_contigs_dbs(args: Namespace) -> None:
     assert external_genomes_table.columns.tolist() == ['name', 'contigs_db_path']
     args.contigs_dbs += external_genomes_table['contigs_db_path'].tolist()
 
+def map_json_network_ko_data(args: Namespace, mapper: Mapper) -> None:
+    """Draw KO data from a reaction network JSON file."""
+    map_reaction_network_json_kos = mapper.map_reaction_network_json_kos
+
+    if args.set_color is None or args.set_color is True:
+        pass
+    else:
+        map_reaction_network_json_kos = functools.partial(
+            map_reaction_network_json_kos, color_hexcode=args.set_color
+        )
+
+    map_reaction_network_json_kos(
+        args.reaction_network_json,
+        args.output_dir,
+        pathway_numbers=args.pathway_numbers,
+        draw_maps_lacking_kos=args.draw_bare_maps
+    )
+
 def map_single_contigs_db_ko_data(args: Namespace, mapper: Mapper) -> None:
     """Draw KO data from a single contigs database source in the absence of a colormap."""
     map_contigs_database_kos = mapper.map_contigs_database_kos
@@ -563,6 +595,10 @@ def main() -> None:
                         categorize_files=args.categorize_files)
         performed = False
 
+        if args.reaction_network_json is not None and args.ko is True:
+            map_json_network_ko_data(args, mapper)
+            performed = True
+
         if (
             args.contigs_dbs is not None and
             len(args.contigs_dbs) == 1 and
@@ -588,8 +624,9 @@ def main() -> None:
 
         if not performed:
             raise ConfigError(
-                "No task was performed! The minimum requirements are a database source, such as "
-                "`--contigs-dbs`, and a data type to draw, such as `--ko`."
+                "No task was performed! The minimum requirements are a data source (such as "
+                "`--reaction-network-json`, `--contigs-dbs`, or `--pan-db`) and a data type to "
+                "draw, such as `--ko`."
             )
 
     except ConfigError as e:

--- a/anvio/cli/reaction_network.py
+++ b/anvio/cli/reaction_network.py
@@ -3,6 +3,8 @@ DESCRIPTION = """This program generates a metabolic reaction network in an anvi'
 
 import sys
 
+import anvio.filesnpaths as filesnpaths
+
 from argparse import Namespace
 
 from anvio.argparse import ArgumentParser
@@ -15,8 +17,8 @@ __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"
 __version__ = VERSION
 __authors__ = ["semiller10"]
-__requires__ = ["contigs-db", "kegg-functions"]
-__can_use__ = ["reaction-ref-data", "kegg-data"]
+__requires__ = ["kegg-functions"]
+__can_use__ = ["contigs-db", "enzymes-txt", "reaction-ref-data", "kegg-data"]
 __provides__ = ["reaction-network"]
 __description__ = DESCRIPTION
 
@@ -27,7 +29,22 @@ def main() -> None:
     try:
         constructor = Constructor(kegg_dir=args.kegg_dir, modelseed_dir=args.modelseed_dir)
 
-        if args.contigs_db:
+        if args.enzymes_txt:
+            if not args.output_json:
+                raise ConfigError(
+                    "When using `--enzymes-txt`, you must also provide `--output-json` to specify "
+                    "where the resulting reaction network JSON file should be written."
+                )
+            filesnpaths.is_output_file_writable(args.output_json)
+            network = constructor.make_enzymes_txt_network(
+                enzymes_txt=args.enzymes_txt,
+                stats_file=args.stats_file
+            )
+            network.export_json(
+                args.output_json,
+                overwrite=args.overwrite_existing_network
+            )
+        elif args.contigs_db:
             constructor.make_network(
                 contigs_db=args.contigs_db,
                 overwrite_existing_network=args.overwrite_existing_network,
@@ -44,9 +61,9 @@ def main() -> None:
             )
         else:
             raise ConfigError(
-                "Either a contigs database (`--contigs-db`) OR a pan database (`--pan-db`) and genomes "
-                "storage database (`--genomes-storage`) must be provided to make a (meta)genomic or "
-                "pangenomic reaction network, respectively."
+                "A data source is required. Provide an enzymes file (`--enzymes-txt`), a contigs "
+                "database (`--contigs-db`), or a pan database (`--pan-db`) with a genomes storage "
+                "database (`--genomes-storage`)."
             )
     except ConfigError as e:
         print(e)
@@ -60,19 +77,41 @@ def get_args() -> Namespace:
     parser = ArgumentParser(description=__description__)
 
     groupA = parser.add_argument_group(
+        "ENZYMES FILE INPUT",
+        "Generate a reaction network from a tab-delimited enzymes file, bypassing the need for a "
+        "contigs database. This enables reaction networks from custom enzyme lists such as "
+        "transcriptomic/proteomic data or LCA gene content predictions. The file must have columns "
+        "'gene_id', 'enzyme_accession', and 'source'; only rows with source 'KOfam' are used. "
+        "See 'anvi-estimate-metabolism' for the full enzymes-txt format specification."
+    )
+    groupA.add_argument(
+        '--enzymes-txt', type=str, metavar='FILE', help=
+        "Path to a tab-delimited enzymes file with required columns 'gene_id', "
+        "'enzyme_accession', and 'source'. Rows where 'source' is 'KOfam' are used to build "
+        "the reaction network. Use '--output-json' to specify where the resulting network file "
+        "is written."
+    )
+    groupA.add_argument(
+        '--output-json', type=str, metavar='FILE', help=
+        "Path for the output reaction network JSON file. Required when using '--enzymes-txt'. "
+        "The file can be loaded by 'anvi-draw-kegg-pathways' via its '--reaction-network-json' "
+        "option."
+    )
+
+    groupB = parser.add_argument_group(
         "SINGLE GENOME OR METAGENOME INPUT",
         "Generate a reaction network from a contigs database and store the network in the database."
     )
-    groupA.add_argument(*A('contigs-db'), **K('contigs-db', {'required': False}))
+    groupB.add_argument(*A('contigs-db'), **K('contigs-db', {'required': False}))
 
-    groupB = parser.add_argument_group(
+    groupC = parser.add_argument_group(
         "PANGENOME INPUT",
         "Generate a reaction network from a pan database and associated genomes storage database, "
         "and store the network in the pan database."
     )
-    groupB.add_argument(*A('pan-db'), **K('pan-db', {'required': False}))
-    groupB.add_argument(*A('genomes-storage'), **K('genomes-storage', {'required': False}))
-    groupB.add_argument(
+    groupC.add_argument(*A('pan-db'), **K('pan-db', {'required': False}))
+    groupC.add_argument(*A('genomes-storage'), **K('genomes-storage', {'required': False}))
+    groupC.add_argument(
         '--consensus-threshold', default=None, type=float, metavar='FLOAT', help=
         "If this argument is provided, then a protein annotation must be assigned to this minimum "
         "proportion of genes in a cluster to be imputed to the cluster as a whole. By default, "
@@ -80,7 +119,7 @@ def get_args() -> Namespace:
         "of the cluster (also see --discard-ties). The consensus threshold must be a number from 0 "
         "to 1."
     )
-    groupB.add_argument(
+    groupC.add_argument(
         '--discard-ties', default=False, action='store_true', help=
         "By default, a gene cluster is assigned a protein annotation by finding the protein "
         "ortholog that occurs in the greatest number of genes in the cluster (see "
@@ -88,27 +127,28 @@ def get_args() -> Namespace:
         "flag, a tie instead results in an ortholog annotation not being assigned to the cluster."
     )
 
-    groupC = parser.add_argument_group(
+    groupD = parser.add_argument_group(
         "DATABASE", "KEGG and ModelSEED reference database information"
     )
-    groupC.add_argument(
+    groupD.add_argument(
         '--kegg-dir', type=str, metavar='PATH', help=
         "Path to KEGG database directory. If this option is not used, the program expects a "
         "database set up in the default location used by 'anvi-setup-kegg-data'."
     )
-    groupC.add_argument(
+    groupD.add_argument(
         '--modelseed-dir', type=str, metavar='PATH', help=
         "Path to ModelSEED Biochemistry database directory. If this option is not used, the "
         "program expects a database set up in the default location used by "
         "'anvi-setup-modelseed-database'."
     )
 
-    groupD = parser.add_argument_group("OTHER OPTIONS")
-    groupD.add_argument(
+    groupE = parser.add_argument_group("OTHER OPTIONS")
+    groupE.add_argument(
         '--overwrite-existing-network', default=False, action='store_true', help=
-        "Overwrite an existing reaction network in the database with the newly computed network."
+        "Overwrite an existing reaction network in the database (for contigs/pan DB modes) or "
+        "overwrite the output JSON file (for enzymes-txt mode) if it already exists."
     )
-    groupD.add_argument(
+    groupE.add_argument(
         '--stats-file', type=str, metavar='PATH', help=
         "Write a tab-delimited file of network overview statistics (statistics also printed to the "
         "terminal) to the output path."

--- a/anvio/docs/programs/anvi-draw-kegg-pathways.md
+++ b/anvio/docs/programs/anvi-draw-kegg-pathways.md
@@ -76,6 +76,25 @@ Here is a simple example of the output file structure produced with `--name-file
 
 Gene sequences in anvi'o databases can be annotated with KEGG Orthologs (KOs): see %(anvi-run-kegg-kofams)s. A KO indicates functional capabilities of the gene product. KO data from one or more contigs databases or a pan database can be mapped using the `--ko` flag, enabling investigation of the metabolic capabilities of individual organisms or multiple organisms, including community samples. Reactions associated with KOs are colored on the pathway maps.
 
+### From a reaction network JSON file
+
+Pathway maps can be drawn from a reaction network JSON file produced by %(anvi-reaction-network)s or %(anvi-get-metabolic-model-file)s, bypassing the need for a contigs database entirely. This is especially useful with custom enzyme lists — for example, annotations from transcriptomic or proteomic data, or predicted gene content of a last common ancestor.
+
+First, generate the reaction network JSON from an enzymes file:
+
+{{ codestart }}
+anvi-reaction-network --enzymes-txt /path/to/enzymes.txt \
+                      --output-json /path/to/network.json
+{{ codestop }}
+
+Then draw pathway maps directly from that JSON:
+
+{{ codestart }}
+anvi-draw-kegg-pathways --reaction-network-json /path/to/network.json \
+                        --ko \
+                        -o output_maps/
+{{ codestop }}
+
 ### Single contigs database
 
 Here is the basic command to draw KO data from a single %(contigs-db)s.

--- a/anvio/docs/programs/anvi-reaction-network.md
+++ b/anvio/docs/programs/anvi-reaction-network.md
@@ -44,6 +44,27 @@ anvi-setup-modelseed-database --dir path/to/other/directory
 
 ## Usage
 
+### From an enzymes file (no contigs database needed)
+
+%(anvi-reaction-network)s can build a reaction network directly from a tab-delimited enzymes file — no contigs database required. This is useful when working with custom enzyme lists from transcriptomic/proteomic data, ancestral gene content predictions, or any other source outside of anvi'o's standard annotation workflow.
+
+The enzymes file must have three columns: `gene_id`, `enzyme_accession`, and `source`. Only rows where `source` is `KOfam` are used. This is the same format used by %(anvi-estimate-metabolism)s.
+
+{{ codestart }}
+anvi-reaction-network --enzymes-txt /path/to/enzymes.txt \
+                      --output-json /path/to/network.json
+{{ codestop }}
+
+The resulting JSON file can be directly used by %(anvi-draw-kegg-pathways)s via its `--reaction-network-json` option:
+
+{{ codestart }}
+anvi-draw-kegg-pathways --reaction-network-json /path/to/network.json \
+                        --ko \
+                        -o output_maps/
+{{ codestop }}
+
+### From a contigs database
+
 %(anvi-reaction-network)s takes a either a %(contigs-db)s OR a %(pan-db)s and %(genomes-storage-db)s as required input. Genes stored within the %(contigs-db)s or %(genomes-storage-db)s must have KO protein annotations, which can be assigned by %(anvi-run-kegg-kofams)s.
 
 {{ codestart }}

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -271,6 +271,91 @@ class Mapper:
 
         return drawn
 
+
+    def map_reaction_network_json_kos(
+        self,
+        json_path: str,
+        output_dir: str,
+        pathway_numbers: Iterable[str] = None,
+        color_hexcode: str = '#2ca02c',
+        draw_maps_lacking_kos: bool = False
+    ) -> Dict[str, bool]:
+        """
+        Draw pathway maps highlighting KOs present in a reaction network JSON file.
+
+        The JSON file must be in the format produced by 'anvi-get-metabolic-model-file' or by
+        'anvi-reaction-network --enzymes-txt ... --output-json ...'. KO IDs are extracted
+        directly from the gene annotations in the JSON, so no reference databases are required.
+
+        Parameters
+        ==========
+        json_path : str
+            Path to an anvi'o reaction network JSON file.
+
+        output_dir : str
+            Path to the output directory in which pathway map PDF files are drawn.
+
+        pathway_numbers : Iterable[str], None
+            Regex patterns to match the ID numbers of the drawn pathway maps. The default of None
+            draws all available pathway maps in the KEGG data directory.
+
+        color_hexcode : str, '#2ca02c'
+            Color for reactions containing KOs from the JSON network. Can also be 'original'.
+
+        draw_maps_lacking_kos : bool, False
+            If False, only draw maps containing any of the KOs in the network.
+
+        Returns
+        =======
+        Dict[str, bool]
+            Keys are pathway numbers. Values are True if the map was drawn, False if not.
+        """
+        filesnpaths.is_file_exists(json_path)
+
+        self.progress.new("Loading KO data from the reaction network JSON")
+        self.progress.update("...")
+
+        with open(json_path) as f:
+            json_dict = json.load(f)
+
+        required_keys = {'genes', 'reactions', 'metabolites'}
+        missing_keys = required_keys - set(json_dict)
+        if missing_keys:
+            self.progress.end()
+            raise ConfigError(
+                f"The file at '{json_path}' does not appear to be an anvi'o reaction network "
+                f"JSON: it is missing the required top-level keys: "
+                f"{', '.join(sorted(missing_keys))}."
+            )
+
+        ko_ids = set()
+        for gene_entry in json_dict.get('genes', []):
+            for ko_id in gene_entry.get('annotation', {}).get('ko', {}).keys():
+                ko_ids.add(ko_id)
+
+        self.progress.end()
+
+        if not ko_ids:
+            raise ConfigError(
+                f"No KO annotations were found in the reaction network JSON at '{json_path}'. "
+                f"There is nothing to draw."
+            )
+
+        self.run.info("KOs found in network JSON", len(ko_ids))
+
+        drawn = self._map_kos_fixed_colors(
+            ko_ids,
+            output_dir,
+            pathway_numbers=pathway_numbers,
+            color_hexcode=color_hexcode,
+            draw_maps_lacking_kos=draw_maps_lacking_kos
+        )
+        count = sum(drawn.values()) if drawn else 0
+        self.run.info("Number of maps drawn", count)
+
+        return drawn
+
+
     def map_genomes_storage_genome_kos(
         self,
         genomes_storage_db: str,

--- a/anvio/reactionnetwork.py
+++ b/anvio/reactionnetwork.py
@@ -3353,6 +3353,8 @@ class GenomicNetwork(ReactionNetwork):
         super().__init__(run=run, progress=progress, verbose=verbose)
         self.contigs_db_source_path: str = None
         self.profile_db_source_path: str = None
+        self.enzymes_txt_source_path: str = None
+        self.json_source_path: str = None
         self.genes: Dict[int, Gene] = {}
         self.proteins: Dict[int, Protein] = {}
 
@@ -6389,6 +6391,111 @@ class Constructor:
             )
         return network
 
+
+    def load_network_from_json(self, path: str, stats_file: str = None) -> GenomicNetwork:
+        """
+        Load a genomic reaction network from an anvi'o JSON file produced by
+        'anvi-get-metabolic-model-file' or by 'GenomicNetwork.export_json'.
+
+        The network is reconstructed by re-running KEGG and ModelSEED reference database lookups
+        on the gene-KO relationships recorded in the JSON file.
+
+        Parameters
+        ==========
+        path : str
+            Path to an anvi'o reaction network JSON file.
+
+        stats_file : str, None
+            Write network overview statistics to a tab-delimited file at this output path.
+
+        Returns
+        =======
+        GenomicNetwork
+            The network loaded from the JSON file.
+        """
+        filesnpaths.is_file_exists(path)
+
+        if stats_file is not None:
+            filesnpaths.is_output_file_writable(stats_file)
+
+        self.run.info("Reaction network JSON", path)
+
+        with open(path) as f:
+            json_dict = json.load(f)
+
+        required_keys = {'genes', 'reactions', 'metabolites'}
+        missing_keys = required_keys - set(json_dict)
+        if missing_keys:
+            raise ConfigError(
+                f"The JSON file at '{path}' does not appear to be an anvi'o reaction network "
+                f"JSON, as it is missing the following required top-level keys: "
+                f"{', '.join(sorted(missing_keys))}."
+            )
+
+        gene_ko_rows = []
+        for gene_entry in json_dict['genes']:
+            gene_id = gene_entry['id']
+            ko_annotation = gene_entry.get('annotation', {}).get('ko', {})
+            for ko_id, ko_data in ko_annotation.items():
+                try:
+                    e_value = float(ko_data.get('e_value', 0.0))
+                except (TypeError, ValueError):
+                    e_value = 0.0
+                gene_ko_rows.append({
+                    'gene_id': gene_id,
+                    'enzyme_accession': ko_id,
+                    'e_value': e_value
+                })
+
+        if not gene_ko_rows:
+            raise ConfigError(
+                f"No gene-KO annotations were found in the JSON file at '{path}'. "
+                f"The file may not be a valid anvi'o reaction network JSON, or the network "
+                f"may have been built without any KO annotations."
+            )
+
+        gene_ko_df = pd.DataFrame(gene_ko_rows).drop_duplicates()
+
+        self.progress.new("Building reaction network from JSON")
+
+        network = GenomicNetwork(run=self.run, progress=self.progress)
+        network.json_source_path = os.path.abspath(path)
+
+        self.progress.update("Loading KEGG reference database")
+        kegg_db = KEGGData(kegg_dir=self.kegg_dir)
+
+        self.progress.update("Loading ModelSEED Biochemistry reference database")
+        modelseed_db = ModelSEEDDatabase(modelseed_dir=self.modelseed_dir)
+
+        undefined_ko_ids, _ = self._build_genomic_network(gene_ko_df, network, kegg_db, modelseed_db)
+
+        self.progress.end()
+
+        if undefined_ko_ids:
+            self.run.info_single(
+                f"The following KO IDs from the JSON were not found in the KEGG reference "
+                f"database and were excluded from the network: "
+                f"{', '.join(sorted(set(undefined_ko_ids)))}"
+            )
+
+        kegg_dir = kegg_db.kegg_context.kegg_data_dir
+        modelseed_dir = self.modelseed_dir if self.modelseed_dir else ModelSEEDDatabase.default_dir
+        self.run.info("Reference KEGG database directory", kegg_dir, nl_before=1)
+        self.run.info("Reference ModelSEED database directory", modelseed_dir, nl_after=1)
+
+        precomputed_counts = {
+            'total_genes': int(len(json_dict['genes'])),
+            'genes_assigned_kos': int(gene_ko_df['gene_id'].nunique()),
+            'kos_assigned_genes': int(gene_ko_df['enzyme_accession'].nunique())
+        }
+        stats = network.get_overview_statistics(precomputed_counts=precomputed_counts)
+        network.print_overview_statistics(stats=stats)
+        if stats_file:
+            network.write_overview_statistics(stats_file, stats=stats)
+
+        return network
+
+
     def load_contigs_database_network(
         self,
         contigs_db: str,
@@ -7860,6 +7967,264 @@ class Constructor:
             network.write_overview_statistics(stats_file, stats=stats)
 
         return network
+
+
+    def _build_genomic_network(self, gene_ko_df: pd.DataFrame, network: GenomicNetwork, kegg_db: 'KEGGData', modelseed_db: 'ModelSEEDDatabase') -> Tuple[List[str], List[str]]:
+        """
+        Populate a GenomicNetwork from a DataFrame of gene-KO pairs and reference databases.
+
+        This is shared by 'make_enzymes_txt_network' and 'load_network_from_json'.
+
+        Parameters
+        ==========
+        gene_ko_df : pandas.DataFrame
+            DataFrame with columns 'gene_id', 'enzyme_accession', and 'e_value'. Gene IDs may be
+            strings or integers; they are stored as-is in Gene.gcid and as keys in network.genes.
+
+        network : GenomicNetwork
+            Network object to populate in place.
+
+        kegg_db : KEGGData
+            Loaded KEGG reference data.
+
+        modelseed_db : ModelSEEDDatabase
+            Loaded ModelSEED Biochemistry reference data.
+
+        Returns
+        =======
+        Tuple[List[str], List[str]]
+            Lists of (undefined KO IDs, undefined ModelSEED reaction IDs).
+        """
+        kegg_kos_data = kegg_db.ko_data
+        kegg_modules_data = kegg_db.module_data
+        kegg_pathways_data = kegg_db.pathway_data
+        kegg_hierarchies_data = kegg_db.hierarchy_data
+        modelseed_kegg_reactions_table = modelseed_db.kegg_reactions_table
+        modelseed_ec_reactions_table = modelseed_db.ec_reactions_table
+        modelseed_compounds_table = modelseed_db.compounds_table
+
+        undefined_ko_ids: List[str] = []
+        undefined_modelseed_reaction_ids: List[str] = []
+
+        total_ko_matches = len(gene_ko_df)
+        num_ko_matches_parsed = -1
+        for row in gene_ko_df.itertuples(index=False):
+            num_ko_matches_parsed += 1
+            self.progress.update(
+                f"Gene-KO matches parsed: {num_ko_matches_parsed} / {total_ko_matches}"
+            )
+
+            gene_id = row.gene_id
+            ko_id = row.enzyme_accession
+            e_value = float(row.e_value) if row.e_value is not None else 0.0
+
+            if gene_id in network.genes:
+                gene = network.genes[gene_id]
+                is_new_gene = False
+            else:
+                gene = Gene()
+                gene.gcid = gene_id
+                is_new_gene = True
+
+            try:
+                ko = network.kos[ko_id]
+                is_new_ko = False
+            except KeyError:
+                is_new_ko = True
+
+            if not is_new_ko:
+                gene.ko_ids.append(ko_id)
+                gene.e_values[ko_id] = e_value
+                if is_new_gene:
+                    network.genes[gene_id] = gene
+                continue
+
+            try:
+                ko_info = kegg_kos_data[ko_id]
+            except KeyError:
+                undefined_ko_ids.append(ko_id)
+                continue
+
+            ko_kegg_reaction_ids = self._get_ko_kegg_reaction_ids(ko_info)
+            ko_ec_numbers = self._get_ko_ec_numbers(ko_info)
+
+            if not ko_kegg_reaction_ids and not ko_ec_numbers:
+                continue
+
+            old_kegg_reaction_ids, new_kegg_reaction_ids = self._find_kegg_reaction_ids(
+                ko_kegg_reaction_ids, network
+            )
+            old_ec_numbers, new_ec_numbers = self._find_ec_numbers(ko_ec_numbers, network)
+
+            modelseed_kegg_reactions_dict: Dict[int, Dict] = modelseed_kegg_reactions_table[
+                modelseed_kegg_reactions_table['KEGG_REACTION_ID'].isin(new_kegg_reaction_ids)
+            ].to_dict(orient='index')
+
+            modelseed_ec_reactions_dict: Dict[int, Dict] = modelseed_ec_reactions_table[
+                modelseed_ec_reactions_table['EC_number'].isin(new_ec_numbers)
+            ].to_dict(orient='index')
+
+            if not (
+                old_kegg_reaction_ids or
+                old_ec_numbers or
+                modelseed_kegg_reactions_dict or
+                modelseed_ec_reactions_dict
+            ):
+                continue
+
+            undefined_modelseed_reaction_ids += self._remove_undefined_reactions(
+                ko_kegg_reaction_ids,
+                new_kegg_reaction_ids,
+                ko_ec_numbers,
+                new_ec_numbers,
+                modelseed_kegg_reactions_dict,
+                modelseed_ec_reactions_dict
+            )
+
+            if not (
+                old_kegg_reaction_ids or
+                new_kegg_reaction_ids or
+                old_ec_numbers or
+                new_ec_numbers
+            ):
+                continue
+
+            if is_new_gene:
+                network.genes[gene_id] = gene
+
+            ko = KO()
+            ko.id = ko_id
+            ko.name = ko_id
+            network.kos[ko_id] = ko
+            gene.ko_ids.append(ko_id)
+            gene.e_values[ko_id] = e_value
+
+            self._process_added_reactions(
+                old_kegg_reaction_ids,
+                old_ec_numbers,
+                network,
+                ko,
+                ko_kegg_reaction_ids,
+                ko_ec_numbers
+            )
+
+            self._add_reactions(
+                modelseed_kegg_reactions_dict,
+                modelseed_ec_reactions_dict,
+                network,
+                modelseed_compounds_table,
+                ko,
+                old_kegg_reaction_ids,
+                new_kegg_reaction_ids,
+                old_ec_numbers,
+                new_ec_numbers
+            )
+
+            self._add_ko_classification(
+                ko,
+                network,
+                ko_info,
+                kegg_modules_data,
+                kegg_pathways_data,
+                kegg_hierarchies_data
+            )
+
+        self._relate_modules_pathways(network, kegg_modules_data)
+
+        return undefined_ko_ids, undefined_modelseed_reaction_ids
+
+
+    def make_enzymes_txt_network(self, enzymes_txt: str, stats_file: str = None) -> GenomicNetwork:
+        """
+        Make a metabolic reaction network from KOfam annotations in an enzymes file.
+
+        This bypasses the need for a contigs database and allows reaction networks to be built
+        from custom enzyme lists, e.g., from transcriptomic or proteomic data.
+
+        Parameters
+        ==========
+        enzymes_txt : str
+            Path to a tab-delimited enzymes file with required columns 'gene_id',
+            'enzyme_accession', and 'source'. Only rows where 'source' is 'KOfam' are used.
+
+        stats_file : str, None
+            Write network overview statistics to a tab-delimited file at this output path.
+
+        Returns
+        =======
+        GenomicNetwork
+            The network derived from the enzymes file.
+        """
+        if stats_file is not None:
+            filesnpaths.is_output_file_writable(stats_file)
+
+        filesnpaths.is_file_tab_delimited(enzymes_txt)
+
+        self.run.info("Enzymes file", enzymes_txt)
+
+        enzymes_df = pd.read_csv(enzymes_txt, sep='\t')
+        required_columns = {'gene_id', 'enzyme_accession', 'source'}
+        missing_columns = required_columns - set(enzymes_df.columns)
+        if missing_columns:
+            raise ConfigError(
+                f"The enzymes file, '{enzymes_txt}', is missing required columns: "
+                f"{', '.join(sorted(missing_columns))}. The file must contain at least "
+                f"'gene_id', 'enzyme_accession', and 'source' columns."
+            )
+
+        kofam_df = enzymes_df[enzymes_df['source'] == 'KOfam'][
+            ['gene_id', 'enzyme_accession']
+        ].drop_duplicates()
+
+        if len(kofam_df) == 0:
+            present_sources = ', '.join(f"'{s}'" for s in sorted(enzymes_df['source'].unique()))
+            raise ConfigError(
+                f"No KOfam annotations were found in '{enzymes_txt}' (source column value "
+                f"must be 'KOfam'). Reaction networks require KO annotations. Sources present "
+                f"in the file: {present_sources}."
+            )
+
+        kofam_df = kofam_df.assign(e_value=0.0)
+
+        self.progress.new("Building reaction network")
+
+        network = GenomicNetwork(run=self.run, progress=self.progress)
+        network.enzymes_txt_source_path = os.path.abspath(enzymes_txt)
+
+        self.progress.update("Loading KEGG reference database")
+        kegg_db = KEGGData(kegg_dir=self.kegg_dir)
+
+        self.progress.update("Loading ModelSEED Biochemistry reference database")
+        modelseed_db = ModelSEEDDatabase(modelseed_dir=self.modelseed_dir)
+
+        undefined_ko_ids, _ = self._build_genomic_network(kofam_df, network, kegg_db, modelseed_db)
+
+        self.progress.end()
+
+        if undefined_ko_ids:
+            self.run.info_single(
+                f"The following KO IDs from the enzymes file were not found in the KEGG "
+                f"reference database and were excluded from the network: "
+                f"{', '.join(sorted(set(undefined_ko_ids)))}"
+            )
+
+        kegg_dir = kegg_db.kegg_context.kegg_data_dir
+        modelseed_dir = self.modelseed_dir if self.modelseed_dir else ModelSEEDDatabase.default_dir
+        self.run.info("Reference KEGG database directory", kegg_dir, nl_before=1)
+        self.run.info("Reference ModelSEED database directory", modelseed_dir, nl_after=1)
+
+        precomputed_counts = {
+            'total_genes': int(enzymes_df['gene_id'].nunique()),
+            'genes_assigned_kos': int(kofam_df['gene_id'].nunique()),
+            'kos_assigned_genes': int(kofam_df['enzyme_accession'].nunique())
+        }
+        stats = network.get_overview_statistics(precomputed_counts=precomputed_counts)
+        network.print_overview_statistics(stats=stats)
+        if stats_file:
+            network.write_overview_statistics(stats_file, stats=stats)
+
+        return network
+
 
     def make_pangenomic_network(
         self,


### PR DESCRIPTION
This PR adds `enzymes-txt` support for `anvi-reaction-network` and `anvi-draw-kegg-pathways`, which allows the programs to work without a contigs-db. 

I used a simple [test-enzymes.txt](https://github.com/user-attachments/files/28643487/test-enzymes.txt), which looked like this,

|**`gene_id`**|**`enzyme_accession`**|**`source`**|
|:--|:--|:--|
|gene_001|K00844|KOfam|
|gene_002|K01810|KOfam|
|gene_003|K00850|KOfam|
|gene_004|K01623|KOfam|
|gene_005|K00134|KOfam|
|gene_006|K00927|KOfam|
|gene_007|K01834|KOfam|
|gene_008|K01689|KOfam|
|gene_009|K00873|KOfam|
|gene_010|K00024|KOfam|
|gene_011|K01647|KOfam|
|gene_012|K01681|KOfam|
|gene_013|K00031|KOfam|
|gene_014|K00030|KOfam|
|gene_015|K00164|KOfam|
|gene_016|K00658|KOfam|
|gene_017|K01902|KOfam|
|gene_018|K01903|KOfam|
|gene_019|K00382|KOfam|
|gene_020|K01899|KOfam|

to test the new parameters. Using this test file I got the necessary JSON output first:

```
anvi-reaction-network --enzymes-txt test-enzymes.txt \
                      --output-json test-network.json
```

And then passed it to `anvi-draw-kegg-pathways`:

```
anvi-draw-kegg-pathways --reaction-network-json test-network.json \
                        --ko \
                        -o test-pathway-maps/
```

And got all the maps expected given the enzymes mentioned in the test file (that touched on Glycolysis, TCA cycle, Carbon metabolism etc).

Here are some of the enzymes in this file in the context of Glycolisis:

<img  alt="image" src="https://github.com/user-attachments/assets/aeffca1a-9e2d-47eb-83eb-497b4bff5bc7" />

---

And here is an example of those in TCA cycle:

<img alt="image" src="https://github.com/user-attachments/assets/a8c66c36-e2a9-4c5a-8045-607f4e786aa9" />

This finally implements a feature request by @ivagljiva (#2487), and closes an issue (#2705), addressing @rpeguil's need.