### PR TITLE
Ability to download gene FASTA files for SynGCs

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -207,6 +207,7 @@ class BottleApplication(Bottle):
         self.route('/pangraph/get_pangraph_synteny_gene_cluster_region',          callback=self.get_pangraph_synteny_gene_cluster_region, method="POST")
         self.route('/pangraph/get_pangraph_synteny_gene_cluster_search_result',   callback=self.get_pangraph_synteny_gene_cluster_search_result, method="POST")
         self.route('/pangraph/get_pangraph_synteny_gc_functions_and_metabolism',  callback=self.get_pangraph_synteny_gc_functions_and_metabolism, method="POST")
+        self.route('/pangraph/get_pangraph_bin_sequences_fasta',                  callback=self.get_pangraph_bin_sequences_fasta, method="POST")
         self.route('/pangraph/session_id',                                        callback=self.get_pangraph_session_id)
         self.route('/pangraph/store_description',                                 callback=self.store_pangraph_description, method='POST')
 
@@ -1780,6 +1781,27 @@ class BottleApplication(Bottle):
                        'sources': list(self.interactive.gene_clusters_function_sources)}
 
             return json.dumps(payload, default=utils.to_jsonable)
+        except Exception as e:
+            return json.dumps({'status': 1, 'message': str(e)})
+
+
+    def get_pangraph_bin_sequences_fasta(self):
+        try:
+            payload = request.json
+            synteny_gene_clusters = payload['synteny_gene_clusters']
+            report_dna = payload.get('report_dna', False)
+
+            sequences = self.interactive.get_sequences_for_synteny_gene_clusters(
+                gene_cluster_names=set(synteny_gene_clusters),
+                report_DNA_sequences=report_dna
+            )
+
+            metadata = {}
+            for sgc in synteny_gene_clusters:
+                info = self.interactive.synteny_gene_cluster_summary_info.get(sgc, {})
+                metadata[sgc] = {'x': info.get('x', None), 'region': info.get('region', None)}
+
+            return json.dumps({'status': 0, 'sequences': sequences, 'metadata': metadata})
         except Exception as e:
             return json.dumps({'status': 1, 'message': str(e)})
 

--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -1021,9 +1021,6 @@ class PangenomeGraphUserInterface {
                 var x_max = rinfo['x_max'];
                 var x_span = x_max - x_min;
 
-                // Skip single-position (backbone-only) regions
-                if (x_span === 0) continue;
-
                 // Find the tallest node in this region so the label clears it.
                 var region_max_y = 0;
                 for (var [nid, ndata] of Object.entries(this.nodes)) {
@@ -1036,7 +1033,9 @@ class PangenomeGraphUserInterface {
                 var outer_content_r = base_outer_r + region_max_y * node_distance_y;
 
                 var x_mid = (x_min + x_max) / 2;
-                var svg_region_width = x_span * node_distance_x;
+                // Single-position regions have x_span === 0; use one node-width so the
+                // zoom threshold has a non-zero value to work against.
+                var svg_region_width = Math.max(x_span, 1) * node_distance_x;
 
                 // Store geometry as data attributes; position and font-size are set
                 // dynamically by the zoom handler so the label always clears the graph.

--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -77,6 +77,8 @@ class PangenomeGraphUserInterface {
         this.recolor_alignment = this.recolor_alignment.bind(this);
         this.alignment_download = this.alignment_download.bind(this);
         this.info_download = this.info_download.bind(this);
+        this.download_bin_fasta = this.download_bin_fasta.bind(this);
+        this.show_region_fasta_download = this.show_region_fasta_download.bind(this);
         this.add_info_to_bin = this.add_info_to_bin.bind(this);
         this.flextree_change = this.flextree_change.bind(this);
         this.save_bin = this.save_bin.bind(this);
@@ -3705,8 +3707,11 @@ class PangenomeGraphUserInterface {
         }
 
         this._last_gene_clusters = response['gene_clusters'] || {};
+        this._last_bin_sgc_ids = sgc_ids;
+        this._last_bin_functions = response['functions'] || {};
+        this._last_bin_name = raw_name;
         const title = `A summary of functions for ${sgc_ids.length} synteny gene clusters in "${bin_name}"`;
-        showPangraphFunctionsSummaryTableDialog(title, buildFunctionsContent(response, this.get_pangraph_gc_config()));
+        showPangraphFunctionsSummaryTableDialog(title, buildFunctionsContent(response, {...this.get_pangraph_gc_config(), binName: bin_name}));
         setTimeout(() => setupItemTableFiltering(this._last_gene_clusters), 100);
     }
 
@@ -3745,6 +3750,7 @@ class PangenomeGraphUserInterface {
 
         const items = [
             { title: 'Show summary of functions in region', action: () => this.show_region_functions(rid) },
+            { title: 'Download gene sequences in this region', action: () => this.show_region_fasta_download(rid) },
             { title: 'Add SynGCs in region as a new bin',   action: () => this.add_region_as_new_bin(rid) },
             { title: 'Append SynGCs in region into the active bin', action: () => this.append_region_to_active_bin(rid) },
         ];
@@ -3771,11 +3777,11 @@ class PangenomeGraphUserInterface {
         document.addEventListener('click', () => menu.remove(), { once: true });
     }
 
-    async show_region_functions(rid) {
+    _get_region_sgc_ids(rid) {
         const svg_ids = this.get_region_svg_node_ids(rid);
         if (!svg_ids.length) {
-            toastr.warning('There are no synteny gene clusters in this region.', "Nothing to show");
-            return;
+            toastr.warning('There are no synteny gene clusters in this region.', 'Nothing to show');
+            return null;
         }
 
         const sgc_ids = [];
@@ -3786,9 +3792,16 @@ class PangenomeGraphUserInterface {
             }
         }
 
+        return sgc_ids;
+    }
+
+    async _fetch_region_data(rid) {
+        const sgc_ids = this._get_region_sgc_ids(rid);
+        if (!sgc_ids) return null;
+
         if (this.server_offline) {
             toastr.error('The server is no longer accessible.', 'Request failed');
-            return;
+            return null;
         }
         showFetchOverlay('Fetching functions and metabolism data...');
 
@@ -3796,21 +3809,47 @@ class PangenomeGraphUserInterface {
         try {
             response = await this.fetch_functions_and_metabolism(sgc_ids);
         } catch(err) {
-            toastr.error('Could not reach the functions endpoint.', "Request failed");
-            return;
+            toastr.error('Could not reach the functions endpoint.', 'Request failed');
+            return null;
         } finally {
             hideFetchOverlay();
         }
 
         if (!response || response.status !== 0) {
-            toastr.error((response && response.message) || 'Could not load functional annotations.', "Server error");
-            return;
+            toastr.error((response && response.message) || 'Could not load functional annotations.', 'Server error');
+            return null;
         }
 
+        return { sgc_ids, response };
+    }
+
+    async show_region_functions(rid) {
+        const result = await this._fetch_region_data(rid);
+        if (!result) return;
+        const { sgc_ids, response } = result;
+
         this._last_gene_clusters = response['gene_clusters'] || {};
+        this._last_bin_sgc_ids = sgc_ids;
+        this._last_bin_functions = response['functions'] || {};
+        this._last_bin_name = `region_${rid}`;
+
         const title = `A summary of functions for ${sgc_ids.length} synteny gene clusters in region #${rid}`;
-        showPangraphFunctionsSummaryTableDialog(title, buildFunctionsContent(response, this.get_pangraph_gc_config()));
+        showPangraphFunctionsSummaryTableDialog(title, buildFunctionsContent(response, {...this.get_pangraph_gc_config(), binName: `Region #${rid}`}));
         setTimeout(() => setupItemTableFiltering(this._last_gene_clusters), 100);
+    }
+
+    show_region_fasta_download(rid) {
+        const sgc_ids = this._get_region_sgc_ids(rid);
+        if (!sgc_ids) return;
+
+        this._last_bin_sgc_ids = sgc_ids;
+        this._last_bin_functions = {};
+        this._last_bin_name = `region_${rid}`;
+
+        showFastaOptionsDialog(
+            `Download sequences from region #${rid} as FASTA`,
+            buildFastaOptionsHTML({})
+        );
     }
 
     add_region_as_new_bin(rid) {
@@ -4107,6 +4146,90 @@ class PangenomeGraphUserInterface {
         }
         var blob = new Blob([csv_data]);
         this.download_blob(blob, title + ".fa");
+    }
+
+    async download_bin_fasta() {
+        const sgc_ids = this._last_bin_sgc_ids || [];
+        if (!sgc_ids.length) {
+            toastr.warning('No gene clusters to export.', 'Nothing to download');
+            return;
+        }
+
+        const report_dna = document.querySelector('input[name="fasta_seq_type"]:checked')?.value === 'dna';
+        const wrap_sequences = document.getElementById('fasta_wrap_sequences')?.checked ?? false;
+        const active_tokens = [...document.querySelectorAll('.fasta-defline-opt:checked')].map(el => el.value);
+        const functions = this._last_bin_functions || {};
+
+        showFetchOverlay('Fetching sequences...');
+
+        let response;
+        try {
+            response = await $.ajax({
+                url: '/pangraph/get_pangraph_bin_sequences_fasta',
+                type: 'POST',
+                data: JSON.stringify({ synteny_gene_clusters: sgc_ids, report_dna }),
+                contentType: 'application/json',
+                dataType: 'json',
+                timeout: 30000,
+            });
+        } catch(err) {
+            toastr.error('Could not reach the sequences endpoint.', 'Request failed');
+            return;
+        } finally {
+            hideFetchOverlay();
+        }
+
+        if (!response || response.status !== 0) {
+            toastr.error((response && response.message) || 'Could not fetch sequences.', 'Server error');
+            return;
+        }
+
+        const sequences = response.sequences || {};
+        const metadata = response.metadata || {};
+
+        let fasta = '';
+        const sorted_clusters = Object.entries(sequences).sort(([a], [b]) => {
+            const xa = metadata[a]?.x ?? Infinity;
+            const xb = metadata[b]?.x ?? Infinity;
+            return xa !== xb ? xa - xb : a.localeCompare(b);
+        });
+
+        for (const [sgc_id, genomes] of sorted_clusters) {
+            const meta = metadata[sgc_id] || {};
+
+            // Build per-cluster tokens (same for every gene in this cluster)
+            const cluster_parts = [];
+            if (active_tokens.includes('gene_cluster')) cluster_parts.push(`SynGC:${sgc_id}`);
+            if (active_tokens.includes('position') && meta.x != null) cluster_parts.push(`pos:${meta.x}`);
+            if (active_tokens.includes('region') && meta.region) cluster_parts.push(`region:${meta.region}`);
+            if (active_tokens.includes('function')) {
+                const sgc_funcs = functions[sgc_id] || {};
+                const first_source = Object.keys(sgc_funcs)[0];
+                if (first_source) {
+                    const fn = sgc_funcs[first_source]?.function;
+                    if (fn && fn !== 'N/A' && fn !== '-') cluster_parts.push(`function:${fn}`);
+                }
+            }
+
+            for (const [genome, gene_calls] of Object.entries(genomes).sort(([a], [b]) => a.localeCompare(b))) {
+                for (const [gene_callers_id, sequence] of Object.entries(gene_calls)) {
+                    if (!sequence || !sequence.length) continue;
+                    const defline_suffix = cluster_parts.length ? ' ' + cluster_parts.join('|') : '';
+                    fasta += `>${genome}_${gene_callers_id}${defline_suffix}\n`;
+                    fasta += (wrap_sequences ? sequence.match(/.{1,120}/g).join('\n') : sequence) + '\n';
+                }
+            }
+        }
+
+        if (!fasta.length) {
+            toastr.warning('No sequences were available for this bin.', 'Nothing to download');
+            return;
+        }
+
+        const project = (this.data['meta']['project_name'] || 'project').replace(/\s+/g, '_');
+        const bin = (this._last_bin_name || 'bin').replace(/\s+/g, '_');
+        const seq_type = report_dna ? 'DNA' : 'AA';
+        this.download_blob(new Blob([fasta]), `${project}_${bin}_GENES_${seq_type}.fa`);
     }
 
     save_bin() {

--- a/anvio/data/interactive/js/utils.js
+++ b/anvio/data/interactive/js/utils.js
@@ -678,6 +678,7 @@ function showFastaOptionsDialog(title, content) {
         dialogStyle: 'pointer-events: all; max-width: 480px; width: auto;'
     });
 }
+
 /**
  * Show gene functions in splits summary table dialog
  * @param {string} title - Dialog title

--- a/anvio/data/interactive/js/utils.js
+++ b/anvio/data/interactive/js/utils.js
@@ -522,6 +522,7 @@ function _createModalDialog(options) {
         content,
         modalClass = 'genericDialog',
         dialogClass = 'modal-dialog',
+        dialogStyle = 'pointer-events: all; max-width: 90vw; width: 90vw;',
         noteHTML = null
     } = options;
 
@@ -534,7 +535,7 @@ function _createModalDialog(options) {
     const template = `
         <div class="modal fade ${modalClass}" id="modal${randomID}" role="dialog">
             <div class="${dialogClass} modal-dialog modal-dialog-centered"
-                 style="pointer-events: all; max-width: 90vw; width: 90vw;">
+                 style="${dialogStyle}">
                 <div class="modal-content" style="max-height: 80vh; display: flex; flex-direction: column;">
                     <div class="modal-header" style="flex-shrink: 0;">
                         <h4 class="modal-title">${title}</h4>
@@ -668,6 +669,15 @@ function showPangraphFunctionsSummaryTableDialog(title, content) {
     });
 }
 
+function showFastaOptionsDialog(title, content) {
+    _createModalDialog({
+        title,
+        content,
+        modalClass: 'fastaOptionsDialog',
+        dialogClass: 'fasta-options-modal-dialog',
+        dialogStyle: 'pointer-events: all; max-width: 480px; width: auto;'
+    });
+}
 /**
  * Show gene functions in splits summary table dialog
  * @param {string} title - Dialog title
@@ -1259,10 +1269,50 @@ function buildFunctionsContent(response, config) {
     if (config.dialogFunction === 'showGeneFunctionsInSplitsSummaryTableDialog') {
         content += buildContigAndSplitNamesTable(response, config);
     }
+    if (config.dialogFunction === 'showPangraphFunctionsSummaryTableDialog') {
+        content += buildFastaDownloadSection(response, config.binName);
+        content += '<hr style="margin: 30px !important;">';
+    }
     content += buildMetabolismTable(response, config, fmtPct);
     content += '<hr style="margin: 30px !important;">';
     content += buildFunctionsTable(response, config);
     return content;
+}
+
+function buildFastaOptionsHTML(response) {
+    const has_functions = response.functions && Object.keys(response.functions).some(sgc => Object.keys(response.functions[sgc] || {}).length > 0);
+    return `
+<div style="margin: 0 10px 35px 10px;">
+    <div style="margin-bottom: 10px;">
+        <label style="margin-right: 15px; font-weight: 600;">Sequence type:</label>
+        <label style="margin-right: 12px;"><input type="radio" name="fasta_seq_type" value="aa" checked> Amino acids</label>
+        <label><input type="radio" name="fasta_seq_type" value="dna"> DNA</label>
+    </div>
+    <div style="margin-bottom: 15px;">
+        <label style="font-weight: 600; display: block; margin-bottom: 6px;">Include in defline:</label>
+        <div style="display: flex; flex-wrap: wrap; gap: 6px 20px;">
+            <label><input type="checkbox" class="fasta-defline-opt" value="gene_cluster"> SynGC ID</label>
+            <label><input type="checkbox" class="fasta-defline-opt" value="position"> Graph position</label>
+            <label><input type="checkbox" class="fasta-defline-opt" value="region"> Region type (BR/VR)</label>
+            ${has_functions ? `<label><input type="checkbox" class="fasta-defline-opt" value="function"> Consensus function</label>` : ''}
+        </div>
+    </div>
+    <div style="margin-bottom: 15px;">
+        <label><input type="checkbox" id="fasta_wrap_sequences"> Wrap sequences in the output</label>
+    </div>
+    <button class="btn btn-sm btn-outline-dark" onclick="pgui.download_bin_fasta()">Download FASTA</button>
+</div>`;
+}
+
+function buildFastaDownloadSection(response, binName) {
+    const sgc_ids = Object.keys(response.gene_clusters || {});
+    if (!sgc_ids.length) return '';
+
+    const header_label = binName ? `Download sequences in "${binName}" as FASTA` : 'Download sequences as FASTA';
+
+    return `
+<p class="bin-modal-header" style="background: #e8f5e978;">${header_label}</p>
+${buildFastaOptionsHTML(response)}`;
 }
 
 function buildContigAndSplitNamesTable(response, config) {


### PR DESCRIPTION
We have `anvi-export-pan-subgraph` to get everything from the pan-graph databases, but while working with the interface sometimes the user (meren) simply wishes to download all the sequences for all SynGCs in a given bin, that are associated with a region, or the user (meren) simply clicked upon.

This PR adds that function for our users (merens) to benefit from such interface conveniences.