### PR TITLE
Set up KEGG data for metabolism workflow tests

### DIFF
--- a/.github/workflows/component-tests-and-migrations.yaml
+++ b/.github/workflows/component-tests-and-migrations.yaml
@@ -76,8 +76,26 @@ jobs:
         anvi-self-test --suite pangenomics --no-interactive
         anvi-self-test --suite inversions --no-interactive
 
+    - name: "Set up KEGG data for metabolism tests"
+      shell: bash -l {0}
+      env:
+        KEGG_ARCHIVE: ${{ runner.temp }}/KEGG_build_2024-09-08_5a9644d40061.tar.gz
+        KEGG_ARCHIVE_URL: https://cloud.uol.de/public.php/dav/files/KRA5koHkaF7dBtC
+        kegg_data_dir: ${{ runner.temp }}/anvio-kegg/KEGG
+      run: |
+        mkdir -p "$(dirname "$kegg_data_dir")"
+        cd "${{ runner.temp }}"
+        curl --fail --location --retry 5 --retry-all-errors --connect-timeout 30 --ipv4 \
+          --output "$KEGG_ARCHIVE" \
+          "$KEGG_ARCHIVE_URL"
+        anvi-setup-kegg-data --kegg-archive "$KEGG_ARCHIVE" --kegg-data-dir "$kegg_data_dir"
+        test -s "$kegg_data_dir/MODULES.db"
+        test -s "$kegg_data_dir/orphan_data/estimated_thresholds_for_stray_kos.txt"
+
     - name: "Run component tests for metabolism framework"
       shell: bash -l {0}
+      env:
+        kegg_data_dir: ${{ runner.temp }}/anvio-kegg/KEGG
       run: |
         anvi-self-test --suite metabolism --no-interactive
 


### PR DESCRIPTION
This PR adds the KEGG data setup prior to running the metabolism testing suites. Prior to this, there was an issue runnign the tests as no KEGG data dir was available for the runner, see #2713. 

Locally it could be solved by making sure `anvi-setup-kegg-data` had been ran but I wasn't sure whether that was possible here and whether the provided storage was large enough.

I tested adding a pinned KEGG setup step before the metabolism suite using the `v2024-09-08` snapshot. A few findings:

- Disk space is pretty large! In an earlier commit I added some `du` and `df` calls to see how much space is available and was surprised itis around 100G! After the three earlier self-tests, there was still ~81G free before KEGG setup and ~61G free after setup.
- The KEGG archive was ~5.46G, and the installed KEGG directory was ~15G.
- Calling `anvi-setup-kegg-data --kegg-snapshot v2024-09-08` directly failed in Actions with a network error from Python/urllib:
  `[Errno 101] Network is unreachable`
- The same URL worked outside Actions, so I switched the workflow to download the pinned archive with `curl --ipv4 --retry ...`, then run:
  `anvi-setup-kegg-data --kegg-archive ...`
- With that change, KEGG setup completed and the metabolism test suite passed.

Successful run (with the extra diagnostic info not included in this commit/PR):
https://github.com/bcoltman/anvio/actions/runs/27099291702

So the fix is to explicitly prepare KEGG data in the workflow before running the metabolism suite. The only issue being that snapshot download is handled by `curl` with IPv4/retries, then passed to anvi’o as a local archive as opposed to being handled fully by `anvi-setup-kegg-data`