### PR TITLE
Use aligned FASTA for KEGG HMM construction

### DIFF
--- a/anvio/metabolism/downloads.py
+++ b/anvio/metabolism/downloads.py
@@ -455,10 +455,11 @@ class KOfamDownload(KeggSetup):
                               f"function: {tuple_of_seqs}. No alignment, no HMM. Sorry!")
 
         m = Muscle(progress=progress_quiet, run=run_quiet)
-        clw_alignment = m.run_stdin(tuple_of_seqs, debug=anvio.DEBUG, clustalw_format=True)
+        aligned_sequences = m.run_stdin(tuple_of_seqs, debug=anvio.DEBUG)
+        fasta_alignment = ''.join(['>%s\n%s\n' % (seq_id, seq) for seq_id, seq in aligned_sequences.items()])
 
-        hmmbuild_cmd_line = ['hmmbuild', '-n', hmm_name, '--informat', 'clustallike', hmm_output_file, '-'] # sending '-' in place of an alignment file so it reads from stdin
-        utils.run_command_STDIN(hmmbuild_cmd_line, log_file_path, clw_alignment)
+        hmmbuild_cmd_line = ['hmmbuild', '-n', hmm_name, '--informat', 'afa', hmm_output_file, '-'] # sending '-' in place of an alignment file so it reads from stdin
+        utils.run_command_STDIN(hmmbuild_cmd_line, log_file_path, fasta_alignment)
 
         if not os.path.exists(hmm_output_file):
             raise ConfigError(f"It seems that the `hmmbuild` command failed because there is no output model at {hmm_output_file}. "


### PR DESCRIPTION
## Summary

This PR updates KEGG/KOfam HMM construction to pass aligned FASTA (`afa`) into `hmmbuild` instead of requesting CLUSTAL-like output from the MUSCLE driver.  

CLUSTAL-like output is no longer supported by MUSCLE v5. To generate such output, conversion code will need to be added. Currently, the only place that clustalw_format output is used is by `hmmbuild`. The MUSCLE driver already returns aligned FASTA by default, and `hmmbuild` accepts this via `--informat afa`, so this removes the only in-repo need for MUSCLE's CLUSTAL output mode while preserving the resulting HMM behavior.


A follow up PR looks at updating the MUSCLE dependency or driver CLI handling.

## Testing

- Compared the old MUSCLE 3 `clustalw_format=True` + `hmmbuild --informat clustallike` path against the new aligned FASTA + `hmmbuild --informat afa` path.
- The generated HMM files were byte-identical.
- Verified `KOfamDownload.build_HMM_from_seqs()` produces a valid `HMMER3/` model.