### PR TITLE
restore setting panel closing annimation

### DIFF
--- a/anvio/data/interactive/css/main.css
+++ b/anvio/data/interactive/css/main.css
@@ -479,6 +479,13 @@ html, body, #wrapper {
     top: 0px;
     left: 0px;
     opacity: 0.9;
+    transition: left 0.3s ease-out;
+}
+
+#panel-left.panel-closed {
+    /* slide by the sidebar's full width (#sidebar min-width: 560px), which is wider
+       than the 490px panel, so no sliver of the settings panel is left peeking out */
+    left: -560px;
 }
 
 #panel-center {
@@ -519,11 +526,13 @@ html, body, #wrapper {
     cursor: pointer;
     font-size: 10px;
     padding-top: 9px;
+    z-index: 10;   /* keep pill above #panel-left in both states */
+    left: 0;       /* closed/default position, flush to the left edge */
 }
 
-.toggle-panel-left-pos {
+/* ID+class so it wins over the base #toggle-panel-left { left: 0 } above */
+#toggle-panel-left.toggle-panel-left-pos {
     left: 560px;
-    z-index: 1;
 }
 
 #toggle-panel-left:hover {

--- a/anvio/data/interactive/js/animations.js
+++ b/anvio/data/interactive/js/animations.js
@@ -33,12 +33,27 @@ function toggleLeftPanel() {
     const svgContainer = document.getElementById('svgbox');
     if (svgContainer) svgContainer.style.pointerEvents = 'none';
 
-    const onDone = () => {
+    let cleaned_up = false;
+    let fallback_timer = null;
+
+    const cleanup = () => {
+        if (cleaned_up) return;   // run exactly once (transitionend vs. fallback race)
+        cleaned_up = true;
+        if (fallback_timer !== null) clearTimeout(fallback_timer);
         panel.removeEventListener('transitionend', onDone);
         if (svgContainer) svgContainer.style.pointerEvents = '';
         is_left_panel_sliding = false;
     };
+
+    const onDone = (ev) => {
+        if (ev && ev.target !== panel) return;   // ignore transitions bubbling from descendants
+        cleanup();
+    };
+
     panel.addEventListener('transitionend', onDone);
+    // Fallback: if no CSS 'transition' is defined on #panel-left, transitionend never
+    // fires. Slightly longer than the 0.3s transition so the event wins when it exists.
+    fallback_timer = setTimeout(cleanup, 350);
 
     if (is_panel_open) {
         is_panel_open = false;


### PR DESCRIPTION
The left "Settings" pill stopped working when using anvi-interactive (#2721): it disappeared on load and couldn't close/open the panel. Issue coming from from #2704 (853eecdce), which moved toggleLeftPanel() to depend on CSS hooks (transition, .panel-closed, pill z-index) that only exist in pangraph.css but was never loaded by index.html. With no transition, transitionend never fired, so the slide flag wedged and the panel never closed.

  - main.css: add the missing transition + .panel-closed rules and keep the pill positioned/on top in both states (slide -560px to clear the wider #sidebar).
  - animations.js: harden toggleLeftPanel() with a one-time cleanup() + fallback timer so the slide flag can never get permanently stuck, even if no transition fires.

@meren mentioned the idea to merge things into shared js library, which they are with the animation.js. The differences is in the individual .css files. Don't know if it is worth merging anything there and for now, I kept it to the minimal fix which restore the expected interactive behavior and not touched anything on the pangraph side. 