### PR TITLE
Adding an 'Export SVG' button to the inspect page

### DIFF
--- a/anvio/data/interactive/charts.html
+++ b/anvio/data/interactive/charts.html
@@ -238,9 +238,12 @@
                   <br><br>
         </div>
 
-        <div class="btn-group sidebar-footer pr-3 pl-3 pt-3 pb-1" role="group">
-          <a type="button" class="btn btn-outline-secondary btn-sm" onclick="showLoadStateWindow();" data-help="load-state-button" data-original-title="" title=""><i class="bi bi-upload mr-1"></i>Load State</a>
-          <a type="button" class="btn btn-outline-secondary btn-sm mr-3" onclick="showSaveStateWindow();" data-help="save-state-button" disabled-in-read-only="true" data-original-title="" title=""><i class="bi bi-download mr-1"></i>Save State</a>
+        <div class="sidebar-footer pr-3 pl-3 pt-2 pb-2">
+          <div class="btn-group w-100 mb-1" role="group">
+            <a type="button" class="btn btn-outline-secondary btn-sm" onclick="showLoadStateWindow();" data-help="load-state-button" data-original-title="" title=""><i class="bi bi-upload mr-1"></i>Load State</a>
+            <a type="button" class="btn btn-outline-secondary btn-sm" onclick="showSaveStateWindow();" data-help="save-state-button" disabled-in-read-only="true" data-original-title="" title=""><i class="bi bi-download mr-1"></i>Save State</a>
+          </div>
+          <a type="button" class="btn btn-outline-secondary btn-sm w-100" onclick="exportInspectSvg();"><i class="bi bi-image mr-1"></i>Export SVG</a>
         </div>
       </div>
 

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -2476,15 +2476,24 @@ function exportInspectSvg() {
     title.appendChild(restSpan);
     merged.appendChild(title);
 
-    function appendLayer(svgEl, offsetX, offsetY, stripSelectors) {
+    function appendLayer(svgEl, offsetX, offsetY, opts) {
         if (!svgEl) return;
         var g = document.createElementNS(prefix.svg, 'g');
         g.setAttribute('transform', 'translate(' + offsetX + ',' + offsetY + ')');
         var clone = svgEl.cloneNode(true);
-        if (stripSelectors) {
-            stripSelectors.forEach(function(sel) {
+        // remove elements that we don't want in the exported SVG
+        if (opts && opts.strip) {
+            opts.strip.forEach(function(sel) {
                 [].forEach.call(clone.querySelectorAll(sel), function(el) {
                     el.parentNode.removeChild(el);
+                });
+            });
+        }
+        // clip some elements (for instance, can pass the coverage chart here to keep only visible parts of it when zoomed)
+        if (opts && opts.clipElements) {
+            opts.clipElements.forEach(function(sel) {
+                [].forEach.call(clone.querySelectorAll(sel), function(el) {
+                    el.setAttribute('clip-path', 'url(#inspect-chart-clip)');
                 });
             });
         }

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -1723,6 +1723,8 @@ function createCharts(state){
 
     var margin = {top: 20, right: 50, bottom: 150, left: 50};
     var width = VIEWER_WIDTH * .80;
+    chart_margin = margin;
+    chart_content_width = width;
     var chartHeight = 200;
     var height = ((chartHeight + 10) * visible_layers);
     curr_height = height + 10;
@@ -2428,6 +2430,32 @@ function exportInspectSvg() {
         'g.context g.axis line { stroke-opacity: .5; }',
     ].join(' ');
     defs.appendChild(style);
+
+    // Clip path for the chart data area. When the user has zoomed in with the brush,
+    // D3 remaps data outside the visible range to x coordinates that fall outside the
+    // axis boundaries. Without a clipPath the paths overflow the chart frame in the
+    // exported SVG.
+    //
+    // The clip is applied to individual data path elements (path.chart, path.line,
+    // SNV markers) rather than to the whole layer group. This is important because
+    // the y-axis groups live in the same layer group but at x positions outside the
+    // data column — clipping the group would clip the axes too.
+    //
+    // Because each data path element sits inside a chartContainer group that is
+    // already translated by margin.left in x, the clip rect uses x=0 (not
+    // x=margin.left). When SVG evaluates the clip, x=0 in the clip path definition
+    // resolves to x=margin.left in the merged SVG coordinate system — exactly the
+    // left edge of the data column.
+    var clipPath = document.createElementNS(prefix.svg, 'clipPath');
+    clipPath.setAttribute('id', 'inspect-chart-clip');
+    var clipRect = document.createElementNS(prefix.svg, 'rect');
+    clipRect.setAttribute('x', 0);
+    clipRect.setAttribute('y', -9999);
+    clipRect.setAttribute('width', chart_content_width || (chartW - 100));
+    clipRect.setAttribute('height', 99999);
+    clipPath.appendChild(clipRect);
+    defs.appendChild(clipPath);
+
     merged.appendChild(defs);
 
     // Title matching the inspect page header: bold split name + " detailed"

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -2512,7 +2512,33 @@ function exportInspectSvg() {
     appendLayer(document.querySelector('#highlight-boxes svg'), 0, titleHeight);
     appendLayer(document.querySelector('#SNV-boxes svg'), 0, titleHeight, {clipElements: ['.SNV_text', '.indels_text', '.insertion_size_whisker_stem', '.insertion_size_whisker_cap']});
     appendLayer(document.querySelector('#sample-titles svg'), 0, titleHeight);
-    appendLayer(contextSvgEl, 0, titleHeight + contentBottom, ['g.brush']);
+    appendLayer(contextSvgEl, 0, titleHeight + contentBottom);
+
+    // Brush rects: D3 sets inline styles (visibility:hidden on .background, cursor on both)
+    // that prevent correct rendering in standalone SVG viewers. Here we explicitly set the
+    // style so every viewer renders them without needing CSS or opacity compositing.
+    // .background → light grey: composited equivalent of rgba(0,0,0,0.1) over white,
+    //              which is what the live-page CSS actually renders (the lavender rule is
+    //              overridden by a more-specific grey rule in charts.css).
+    // .extent    → slightly darker grey with a stroke border; composited equivalent of
+    //              rgba(0,0,0,0.125) over the background. Shows the zoomed region when
+    //              the user has made a selection.
+    [].forEach.call(merged.querySelectorAll('.brush rect.background'), function(rect) {
+        rect.style.removeProperty('visibility');
+        rect.style.removeProperty('cursor');
+        rect.setAttribute('fill', 'rgb(230,230,230)');
+        // g.x.brush has no transform, so moving rect.background to the first child of the
+        // parent context group keeps it at the same position but paints it before the axis,
+        // letting tick marks render on top of the background rather than behind it.
+        var contextGroup = rect.parentNode.parentNode;
+        contextGroup.insertBefore(rect, contextGroup.firstChild);
+    });
+    [].forEach.call(merged.querySelectorAll('.brush rect.extent'), function(rect) {
+        rect.style.removeProperty('cursor');
+        rect.setAttribute('fill', 'rgb(201,201,201)');
+        rect.setAttribute('stroke', 'rgb(130,130,130)');
+        rect.setAttribute('stroke-width', '1');
+    });
 
     var doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
     var svgStr = doctype + (new XMLSerializer()).serializeToString(merged);

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -2371,3 +2371,122 @@ Chart.prototype.showOnly = function(b){
 
     this.chartContainer.select(".x.axis.top").call(this.xAxisTop);
 }
+
+function exportInspectSvg() {
+    window.URL = (window.URL || window.webkitURL);
+
+    var prefix = {
+        xmlns: "http://www.w3.org/2000/xmlns/",
+        xlink: "http://www.w3.org/1999/xlink",
+        svg:   "http://www.w3.org/2000/svg"
+    };
+
+    var chartSvgEl = document.querySelector('#chart-container svg');
+    if (!chartSvgEl) {
+        toastr.error('Nothing to export — the chart has not been drawn yet.');
+        return;
+    }
+
+    var chartW = parseFloat(chartSvgEl.getAttribute('width'));
+
+    // getBBox() gives the tight bounding box of rendered content, excluding the large
+    // bottom margin reserved for axis labels. This prevents excess whitespace in the
+    // export when some sample layers are hidden.
+    var contentBox = chartSvgEl.getBBox();
+    var contentBottom = contentBox.y + contentBox.height;
+
+    var contextSvgEl = document.querySelector('#context-container svg');
+    var contextH = contextSvgEl ? parseFloat(contextSvgEl.getAttribute('height')) : 0;
+
+    var titleHeight = 50;
+    var totalH = titleHeight + contentBottom + contextH;
+
+    var merged = document.createElementNS(prefix.svg, 'svg');
+    merged.setAttributeNS(prefix.xmlns, "xmlns",       prefix.svg);
+    merged.setAttributeNS(prefix.xmlns, "xmlns:xlink", prefix.xlink);
+    merged.setAttribute('width', chartW);
+    merged.setAttribute('height', totalH);
+    merged.setAttribute('viewBox', '0 0 ' + chartW + ' ' + totalH);
+
+    var bg = document.createElementNS(prefix.svg, 'rect');
+    bg.setAttribute('width', chartW);
+    bg.setAttribute('height', totalH);
+    bg.setAttribute('fill', 'white');
+    merged.appendChild(bg);
+
+    // Inline the CSS rules that govern axis and brush rendering. Without these,
+    // SVG defaults apply: axis paths get fill:black (looking thick) and the brush
+    // background renders as a solid black box.
+    var defs = document.createElementNS(prefix.svg, 'defs');
+    var style = document.createElementNS(prefix.svg, 'style');
+    style.setAttribute('type', 'text/css');
+    style.textContent = [
+        '.axis path, .axis line { fill: none; stroke: #aaa; shape-rendering: crispEdges; }',
+        'g.context g.axis path { stroke-opacity: 0; }',
+        'g.context g.axis line { stroke-opacity: .5; }',
+    ].join(' ');
+    defs.appendChild(style);
+    merged.appendChild(defs);
+
+    // Title matching the inspect page header: bold split name + " detailed"
+    var title = document.createElementNS(prefix.svg, 'text');
+    title.setAttribute('x', chartW / 2);
+    title.setAttribute('y', '35');
+    title.setAttribute('text-anchor', 'middle');
+    title.setAttribute('font-family', 'Roboto, Helvetica, Arial, sans-serif');
+    title.setAttribute('font-size', '30px');
+    title.setAttribute('font-weight', '300');
+    title.setAttribute('fill', '#666');
+    var boldSpan = document.createElementNS(prefix.svg, 'tspan');
+    boldSpan.setAttribute('font-weight', '700');
+    boldSpan.textContent = page_header;
+    title.appendChild(boldSpan);
+    var restSpan = document.createElementNS(prefix.svg, 'tspan');
+    restSpan.textContent = ' detailed';
+    title.appendChild(restSpan);
+    merged.appendChild(title);
+
+    function appendLayer(svgEl, offsetX, offsetY, stripSelectors) {
+        if (!svgEl) return;
+        var g = document.createElementNS(prefix.svg, 'g');
+        g.setAttribute('transform', 'translate(' + offsetX + ',' + offsetY + ')');
+        var clone = svgEl.cloneNode(true);
+        if (stripSelectors) {
+            stripSelectors.forEach(function(sel) {
+                [].forEach.call(clone.querySelectorAll(sel), function(el) {
+                    el.parentNode.removeChild(el);
+                });
+            });
+        }
+        while (clone.firstChild) {
+            g.appendChild(clone.firstChild);
+        }
+        merged.appendChild(g);
+    }
+
+    // The chart, SNV, sample-title, and highlight layers all share the same screen origin.
+    // The context (gene arrows) is fixed at the bottom of the viewport, so we place it
+    // immediately after the rendered chart content in the exported SVG.
+    // The brush (g.brush) is stripped from the context layer — it is a purely interactive
+    // element and renders as a black box without its stylesheet.
+    appendLayer(chartSvgEl, 0, titleHeight);
+    appendLayer(document.querySelector('#highlight-boxes svg'), 0, titleHeight);
+    appendLayer(document.querySelector('#SNV-boxes svg'), 0, titleHeight);
+    appendLayer(document.querySelector('#sample-titles svg'), 0, titleHeight);
+    appendLayer(contextSvgEl, 0, titleHeight + contentBottom, ['g.brush']);
+
+    var doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
+    var svgStr = doctype + (new XMLSerializer()).serializeToString(merged);
+
+    var filename = (page_header || 'inspect').replace(/[^a-z0-9]/gi, '_') + '.svg';
+    var url = window.URL.createObjectURL(new Blob([svgStr], { "type": "text\/xml" }));
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.setAttribute("download", filename);
+    a.setAttribute("href", url);
+    a.style["display"] = "none";
+    a.click();
+    document.body.removeChild(a);
+
+    setTimeout(function() { window.URL.revokeObjectURL(url); }, 10);
+}

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -2418,9 +2418,9 @@ function exportInspectSvg() {
     bg.setAttribute('fill', 'white');
     merged.appendChild(bg);
 
-    // Inline the CSS rules that govern axis and brush rendering. Without these,
-    // SVG defaults apply: axis paths get fill:black (looking thick) and the brush
-    // background renders as a solid black box.
+    // Inline the CSS rules that govern axis rendering. Without these, axis paths
+    // get fill:black (looking thick). Brush rects are handled via explicit attributes
+    // below (after appendLayer) so we don't rely on CSS for their fill/visibility.
     var defs = document.createElementNS(prefix.svg, 'defs');
     var style = document.createElementNS(prefix.svg, 'style');
     style.setAttribute('type', 'text/css');
@@ -2503,14 +2503,14 @@ function exportInspectSvg() {
         merged.appendChild(g);
     }
 
-    // The chart, SNV, sample-title, and highlight layers all share the same screen origin.
-    // The context (gene arrows) is fixed at the bottom of the viewport, so we place it
-    // immediately after the rendered chart content in the exported SVG.
-    // The brush (g.brush) is stripped from the context layer — it is a purely interactive
-    // element and renders as a black box without its stylesheet.
-    appendLayer(chartSvgEl, 0, titleHeight);
+    // Clip is applied to specific data path elements only, not to the whole layer group.
+    // This keeps the y-axis groups (which live outside the data column in x) unclipped.
+    // Sample titles sit in the left margin and must not be clipped.
+    // The context layer (gene arrows) is already filtered to the visible range by
+    // drawArrows() and does not need clipping.
+    appendLayer(chartSvgEl, 0, titleHeight, {clipElements: ['path.chart', 'path.line']});
     appendLayer(document.querySelector('#highlight-boxes svg'), 0, titleHeight);
-    appendLayer(document.querySelector('#SNV-boxes svg'), 0, titleHeight);
+    appendLayer(document.querySelector('#SNV-boxes svg'), 0, titleHeight, {clipElements: ['.SNV_text', '.indels_text', '.insertion_size_whisker_stem', '.insertion_size_whisker_cap']});
     appendLayer(document.querySelector('#sample-titles svg'), 0, titleHeight);
     appendLayer(contextSvgEl, 0, titleHeight + contentBottom, ['g.brush']);
 

--- a/anvio/data/interactive/js/charts.js
+++ b/anvio/data/interactive/js/charts.js
@@ -65,6 +65,8 @@ var order_gene_colors_by_count = true;
 var indel_sequences = {};
 var indel_sequence_counter = 0;
 var indel_sequence_preview_length = 60;
+var chart_margin;
+var chart_content_width;
 
 
 function escape_html(value) {


### PR DESCRIPTION
This PR adds a button to export the inspect page as an SVG. The button is at the bottom of the inspect page's settings panel:

<img width="402" height="103" alt="image" src="https://github.com/user-attachments/assets/f08aa700-d6c3-45a4-892b-0ee0407934ea" />

In order to do this, we needed a new function in `charts.js` that would combine all SVG elements of the inspect page (since there are multiple -- the per-sample coverage charts, SNV info, sample labels, gene arrow/context, and any highlights are all separate elements) into one merged SVG before triggering the download. The function explicitly:

- Collects the five SVG layers that make up the inspect page (#chart-container, #highlight-boxes, #SNV-boxes, #sample-titles, #context-container) and merges them into a single root <svg> element, preserving their visual stacking order.
- Uses getBBox() on the chart SVG to measure only the rendered content height, so hidden sample layers do not produce excess whitespace above the gene call panel.
- Places the gene call panel (normally fixed at the bottom of the viewport) immediately below the chart content in the exported layout.
- Adds the split name as a title at the top of the figure, matching the style of the inspect page header (page_header bold + " detailed").
- Injects a minimal inline <style> block with the axis CSS rules from charts.css (fill: none; stroke: #aaa) so axis lines render at the correct weight and colour without a live stylesheet.
- Strips the brush/slider element (g.brush) from the gene call panel, since it is purely interactive and would otherwise render as a solid black box in a static file.
- Downloads the result as a well-formed SVG file (with XML declaration and DOCTYPE) named after the split.

I am not a JavaScript-savvy person, but I asked Claude to match the existing export code for the main interactive page whenever possible, and I did read through the code to ensure it looks reasonable. I've tested the export with and without hidden sample layers, with and without SNVs being shown, and the resulting SVGs look good. One example:

<img width="1467" height="1476" alt="TARA_SAMEA4398168_MAG_00000025_000000000042_split_00001" src="https://github.com/user-attachments/assets/8804f5fe-a67b-4d63-8ddc-53e6b81f4b12" />

Still, I'd appreciate if someone else would test this as well before we merge :) Thanks!
