### PR TITLE
Snakemake Workflows: create subdirs for logs before we start running things

### DIFF
--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -427,6 +427,12 @@ class WorkflowSuperClass:
                 else:
                     os.environ['ANVIO_WORKFLOW_MANIFEST_PATH'] = original_manifest_env_var
 
+                # remove per-rule log subdirectories that were pre-created but never used
+                for rule in self.rules:
+                    rule_log_dir = os.path.join(self.dirs_dict["LOGS_DIR"], rule)
+                    if os.path.isdir(rule_log_dir) and not os.listdir(rule_log_dir):
+                        os.rmdir(rule_log_dir)
+
 
     def dry_run(self, workflow_graph_output_file_path_prefix='workflow'):
         """Not your regular dry run.

--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -164,8 +164,10 @@ class WorkflowSuperClass:
         self.dirs_dict.update(self.config.get("output_dirs", ''))
         self.dirs_dict["LOGS_DIR"] = self.get_workflow_logs_dir()
 
-        # create log dir if it doesn't exist
+        # create log dir and per-rule subdirectories if they don't exist
         os.makedirs(self.dirs_dict["LOGS_DIR"], exist_ok=True)
+        for rule in self.rules:
+            os.makedirs(os.path.join(self.dirs_dict["LOGS_DIR"], rule), exist_ok=True)
 
         # lets check everything
         if not self.this_workflow_is_inherited_by_another:


### PR DESCRIPTION
There was a recent change to the snakemake workflows: log files are now organized into subdirs within the overall log output directory, first by workflow name and then by rule. Creating directory structures like this:
```
00_LOGS/sra_download/check_md5sum  
00_LOGS/sra_download/fasterq_dump  
00_LOGS/sra_download/pigz  
00_LOGS/sra_download/prefetch
```

This works fine when the workflow is run locally, because snakemake handles the directory creation as needed. But we usually run these workflows on an HPC using [`clusterize` ](https://github.com/merenlab/clusterize) -- and `clusterize` will not let a job start if the log's directory doesn't exist when you submit it. This led to job submission errors like `00_LOGS/sra_download/prefetch isn't a directory so clusterize is unwilling to set 00_LOGS/sra_download/prefetch/SRRXXXXXX_prefetch.log as the output file`.

To fix it, this PR adds two lines of code so that snakemake will create the log file subdirectories before starting.

It makes one subdir for each rule in `self.rules`. The only problem is that this variable contains all possible rules for the workflow -- not just those that actually run. Which means the log directory gets populated with a bunch of subdirs that stay empty. To address this, I added a cleanup step that runs after the workflow finishes and `rmdir`s any empty log subdirectory.

I'm currently testing it using the SRA download workflow, but I think we also need to test it at least with metagenomics (particularly to ensure the cleanup step works, as that workflow has a LOT of rules that we hardly ever run).

If you can think of a better alternative fix than this, let me know.