### PR TITLE
Add nodes resource trnaseq sra download

### DIFF
--- a/anvio/workflows/sra_download/rules/download.smk
+++ b/anvio/workflows/sra_download/rules/download.smk
@@ -29,6 +29,8 @@ NOTES:
     log:
         rule_log("prefetch", "{accession}_prefetch"),
     threads: M.T("prefetch")
+    resources:
+        nodes=M.T("prefetch"),
     params:
         SRA_OUTPUT_DIR=os.path.join(dirs_dict["SRA_prefetch"]),
         MAX_SIZE=M.get_param_value_from_config(["prefetch", "--max-size"]),
@@ -68,6 +70,8 @@ rule check_md5sum:
     log:
         rule_log("check_md5sum", "{accession}_check_md5sum"),
     threads: M.T("check_md5sum")
+    resources:
+        nodes=M.T("check_md5sum"),
     params:
         md5sum=os.path.join(
             dirs_dict["SRA_prefetch"], "{accession}", "{accession}.json"
@@ -135,6 +139,8 @@ Threads:
     log:
         rule_log("fasterq_dump", "{accession}_fasterq_dump"),
     threads: M.T("fasterq_dump")
+    resources:
+        nodes=M.T("fasterq_dump"),
     params:
         SRA_INPUT_DIR=os.path.join(dirs_dict["SRA_prefetch"], "{accession}"),
         OUTPUT_DIR=dirs_dict["FASTAS"],
@@ -180,6 +186,8 @@ example:
     log:
         rule_log("pigz", "{accession}_pigz"),
     threads: M.T("pigz")
+    resources:
+        nodes=M.T("pigz"),
     params:
         READS=os.path.join(dirs_dict["FASTAS"], "{accession}*.fastq"),
     shell:
@@ -211,6 +219,9 @@ Threads:
         done=touch(os.path.join(dirs_dict["FASTAS"], "generate_samples_txt.done")),
     log:
         rule_log("generate_samples_txt", "generate_samples_txt"),
+    threads: 1
+    resources:
+        nodes=1,
     params:
         ACCESSION=M.accessions_list,
         OUTPUT_DIR=dirs_dict["FASTAS"],

--- a/anvio/workflows/trnaseq/rules/identification.smk
+++ b/anvio/workflows/trnaseq/rules/identification.smk
@@ -10,6 +10,9 @@ rule anvi_reformat_fasta:
         ),
     log:
         rule_log("anvi_reformat_fasta", "reformat_fasta"),
+    threads: M.T("anvi_reformat_fasta")
+    resources:
+        nodes=M.T("anvi_reformat_fasta"),
     params:
         simplify_names=M.get_rule_param("anvi_reformat_fasta", "--simplify-names"),
     run:
@@ -74,6 +77,9 @@ rule all_reformatting_done:
         ),
     output:
         done=touch(os.path.join(dirs_dict["QC_DIR"], "ALL_REFORMATTING.done")),
+    threads: 1
+    resources:
+        nodes=1,
 
 
 rule anvi_trnaseq:
@@ -89,6 +95,8 @@ rule anvi_trnaseq:
     log:
         rule_log("anvi_trnaseq", "anvi_trnaseq"),
     threads: M.T("anvi_trnaseq")
+    resources:
+        nodes=M.T("anvi_trnaseq"),
     params:
         overwrite_output_destinations=M.get_rule_param(
             "anvi_trnaseq", "--overwrite-output-destinations"

--- a/anvio/workflows/trnaseq/rules/merge_taxonomy.smk
+++ b/anvio/workflows/trnaseq/rules/merge_taxonomy.smk
@@ -12,6 +12,8 @@ rule anvi_merge_trnaseq:
     log:
         rule_log("anvi_merge_trnaseq", "anvi_merge_trnaseq"),
     threads: M.T("anvi_merge_trnaseq")
+    resources:
+        nodes=M.T("anvi_merge_trnaseq"),
     params:
         trnaseq_dbs=expand(
             os.path.join(
@@ -61,6 +63,8 @@ rule anvi_run_trna_taxonomy:
     log:
         rule_log("anvi_run_trna_taxonomy", "anvi_run_trna_taxonomy"),
     threads: M.T("anvi_run_trna_taxonomy")
+    resources:
+        nodes=M.T("anvi_run_trna_taxonomy"),
     params:
         contigs_db=os.path.join(
             os.path.join(
@@ -101,6 +105,9 @@ rule anvi_tabulate_trnaseq:
         done=touch(os.path.join(dirs_dict["CONVERT_DIR"], "TABULATE.done")),
     log:
         rule_log("anvi_tabulate_trnaseq", "anvi_tabulate_trnaseq"),
+    threads: M.T("anvi_tabulate_trnaseq")
+    resources:
+        nodes=M.T("anvi_tabulate_trnaseq"),
     params:
         contigs_db=os.path.join(
             os.path.join(

--- a/anvio/workflows/trnaseq/rules/qc.smk
+++ b/anvio/workflows/trnaseq/rules/qc.smk
@@ -8,6 +8,9 @@ rule make_iu_input:
         ),
     log:
         rule_log("make_iu_input", "make_iu_input"),
+    threads: 1
+    resources:
+        nodes=1,
     run:
         library_num = M.sample_names.index(wildcards.sample_name)
         r1_path = M.r1_paths[library_num]
@@ -29,6 +32,9 @@ rule iu_gen_configs:
         ),
     log:
         rule_log("iu_gen_configs", "iu_gen_configs"),
+    threads: 1
+    resources:
+        nodes=1,
     run:
         out_dir = os.path.join(dirs_dict["QC_DIR"], wildcards.sample_name)
         library_num = M.sample_names.index(wildcards.sample_name)
@@ -60,6 +66,8 @@ rule iu_merge_pairs:
     log:
         rule_log("iu_merge_pairs", "iu_merge_pairs"),
     threads: M.T("iu_merge_pairs")
+    resources:
+        nodes=M.T("iu_merge_pairs"),
     params:
         marker_gene_stringent=M.get_rule_param(
             "iu_merge_pairs", "--marker-gene-stringent"
@@ -119,6 +127,9 @@ rule gen_qc_report:
         report=os.path.join(dirs_dict["QC_DIR"], "qc_report.txt"),  # optional target file that triggers Illumina-utils QC steps
     log:
         rule_log("gen_qc_report", "gen_qc_report"),
+    threads: 1
+    resources:
+        nodes=1,
     run:
         report_dict = {}
         headers = []


### PR DESCRIPTION
Add nodes resource to all trnaseq and sra_download workflow rules.
Why: Snakemake's --resources nodes=N flag caps the total threads in use across all running jobs, it is the knob users rely on to limit their cluster footprint. It only works if each rule declares resources: nodes=<thread count>. The trnaseq and sra_download workflows declared threads on their heavy rules but never declared nodes, so --resources nodes= was silently dropped for them and a user (like @ivagljiva) who thought they were limiting CPU usage was not.

What: every rule in both workflows now declares both threads: and a matching resources: nodes= block, consistent with the already-correct workflows (metagenomics, contigs, pangenomics, read_recruitment, phylogenomics, qc).

Note that ecophylo suffers from the same issue. I did not change anything because the ongoing rework #2675.
