### PR TITLE
Fix crash in anvi-gen-structure-database

### DIFF
--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -348,7 +348,7 @@ class StructureSuperclass(object):
 
         self.num_threads = A('num_threads', int)
         self.queue_size = self.num_threads * 2
-        self.write_buffer_size = int(A('write_buffer_size') or A('write_buffer_size_per_thread') or 5000)
+        self.write_buffer_size = int(A('write_buffer_size', null) or A('write_buffer_size_per_thread', null) or 5000)
 
         self.genes_of_interest_path = A('genes_of_interest', null)
         self.gene_caller_ids = A('gene_caller_ids', null)


### PR DESCRIPTION
Fix crash in anvi-gen-structure-database: line 351 called the A helper with one arg, but structureops' A requires a type-caster. Introduced in 8e3b27948 when swapping --write-buffer-size-per-thread for --write-buffer-size.