### PR TITLE
fix crash when additional_params default is null in workflow params.json

### DIFF
--- a/anvio/workflows/__init__.py
+++ b/anvio/workflows/__init__.py
@@ -640,7 +640,7 @@ class WorkflowSuperClass:
         if 'additional_params' in self.config[rule].keys() and self.forbidden_params.get(rule):
             # if the rule has 'additional_params' we need to make sure
             # that the user didn't include forbidden params there as well
-            params = self.config[rule]['additional_params'].split(' ')
+            params = (self.config[rule]['additional_params'] or '').split(' ')
 
             bad_params = [p for p in self.forbidden_params.get(rule) if p in params]
             if bad_params:

--- a/anvio/workflows/ecophylo/__init__.py
+++ b/anvio/workflows/ecophylo/__init__.py
@@ -242,7 +242,7 @@ class EcoPhyloWorkflow(WorkflowSuperClass):
         self.bowtie2_additional_params = self.get_param_value_from_config(['run_metagenomics_workflow','bowtie2_additional_params'])
         self.anvi_profile_min_percent_identity = self.get_param_value_from_config(['run_metagenomics_workflow','anvi_profile_min_percent_identity'])
 
-        metagenomics_workflow_snakemake_additional_params_list = self.metagenomics_workflow_snakemake_additional_params.split(' ')
+        metagenomics_workflow_snakemake_additional_params_list = (self.metagenomics_workflow_snakemake_additional_params or '').split(' ')
 
         if self.clusterize_metagenomics_workflow:
             if not self.metagenomics_workflow_snakemake_additional_params:

--- a/anvio/workflows/ecophylo/params.json
+++ b/anvio/workflows/ecophylo/params.json
@@ -13,19 +13,19 @@
         "anvi_run_hmms_hmmsearch": {
             "threads_genomes":    {"type": "int", "default": 1},
             "threads_metagenomes":{"type": "int", "default": 5},
-            "additional_params":  {"type": "str", "default": null}
+            "additional_params":  {"type": "str", "default": ""}
         },
         "anvi_run_scg_taxonomy": {
             "threads":           {"type": "int",  "default": 2},
             "run":               {"type": "bool", "default": true},
-            "additional_params": {"type": "str",  "default": null}
+            "additional_params": {"type": "str",  "default": ""}
         },
         "filter_hmm_hits_by_model_coverage": {
             "threads":                      {"type": "int",   "default": 1},
             "--min-model-coverage":         {"type": "float", "default": 0.8},
             "--min-gene-coverage":          {"type": "float", "default": null},
             "--filter-out-partial-gene-calls":{"type": "bool","default": true},
-            "additional_params":            {"type": "str",   "default": null}
+            "additional_params":            {"type": "str",   "default": ""}
         },
         "process_hmm_hits": {
             "threads": {"type": "int", "default": 2}
@@ -45,7 +45,7 @@
             "--cov-mode":                   {"type": "int",   "default": 1},
             "clustering_threshold_for_OTUs":{"type": "list",  "default": [0.99, 0.98]},
             "AA_mode":                      {"type": "bool",  "default": false},
-            "additional_params":            {"type": "str",   "default": null}
+            "additional_params":            {"type": "str",   "default": ""}
         },
         "anvi_profile_blitz": {
             "threads": {"type": "int", "default": 1}
@@ -64,7 +64,7 @@
             "threads":           {"type": "int",  "default": 5},
             "-gt":               {"type": "float","default": null},
             "-gappyout":         {"type": "bool", "default": true},
-            "additional_params": {"type": "str",  "default": null}
+            "additional_params": {"type": "str",  "default": ""}
         },
         "remove_sequences_with_X_percent_gaps": {
             "threads":              {"type": "int", "default": 5},
@@ -90,7 +90,7 @@
             "threads":           {"type": "int",  "default": 5},
             "run":               {"type": "bool", "default": false},
             "-m":                {"type": "str",  "default": "MFP"},
-            "additional_params": {"type": "str",  "default": null}
+            "additional_params": {"type": "str",  "default": ""}
         },
         "make_metagenomics_config_file": {
             "threads": {"type": "int", "default": 1}
@@ -100,8 +100,8 @@
             "clusterize":                 {"type": "bool", "default": false},
             "clusterize_submission_params":{"type": "str", "default": null},
             "HPC_string":                 {"type": "str",  "default": null},
-            "snakemake_additional_params":{"type": "str",  "default": null},
-            "bowtie2_additional_params":  {"type": "str",  "default": null},
+            "snakemake_additional_params":{"type": "str",  "default": ""},
+            "bowtie2_additional_params":  {"type": "str",  "default": ""},
             "anvi_profile_min_percent_identity":{"type": "float", "default": null}
         },
         "add_default_collection": {

--- a/anvio/workflows/metagenomics/params.json
+++ b/anvio/workflows/metagenomics/params.json
@@ -118,7 +118,7 @@
         },
         "bowtie_build": {
             "threads":          {"type": "int", "default": 1},
-            "additional_params":{"type": "str", "default": null}
+            "additional_params":{"type": "str", "default": ""}
         },
         "bowtie": {
             "threads":          {"type": "int", "default": 3},
@@ -192,12 +192,12 @@
         "anvi_summarize": {
             "threads":          {"type": "int",  "default": 1},
             "run":              {"type": "bool", "default": null},
-            "additional_params":{"type": "str",  "default": null}
+            "additional_params":{"type": "str",  "default": ""}
         },
         "anvi_split": {
             "threads":          {"type": "int",  "default": 1},
             "run":              {"type": "bool", "default": null},
-            "additional_params":{"type": "str",  "default": null}
+            "additional_params":{"type": "str",  "default": ""}
         },
         "krakenuniq": {
             "threads":          {"type": "int",  "default": 3},

--- a/anvio/workflows/pangenomics/params.json
+++ b/anvio/workflows/pangenomics/params.json
@@ -59,7 +59,7 @@
         "anvi_compute_genome_similarity": {
             "threads":           {"type": "int",  "default": 1},
             "run":               {"type": "bool", "default": false},
-            "additional_params": {"type": "str",  "default": null}
+            "additional_params": {"type": "str",  "default": ""}
         }
     }
 }

--- a/anvio/workflows/phylogenomics/params.json
+++ b/anvio/workflows/phylogenomics/params.json
@@ -20,13 +20,13 @@
         "trimal": {
             "threads":           {"type": "int",   "default": 1},
             "-gt":               {"type": "float", "default": 0.5},
-            "additional_params": {"type": "str",   "default": null}
+            "additional_params": {"type": "str",   "default": ""}
         },
         "iqtree": {
             "threads":           {"type": "int", "default": 8},
             "-m":                {"type": "str", "default": "WAG"},
             "-bb":               {"type": "int", "default": 1000},
-            "additional_params": {"type": "str", "default": null}
+            "additional_params": {"type": "str", "default": ""}
         }
     }
 }

--- a/anvio/workflows/read_recruitment/rules/main.smk
+++ b/anvio/workflows/read_recruitment/rules/main.smk
@@ -32,7 +32,7 @@ ALL_RS_RE = w.regex_from_ids(SR_READSETS + LR_READSETS)
 BT2_EXT = (
     "bt2l"
     if "--large-index"
-    in M.get_param_value_from_config(["bowtie_build", "additional_params"])
+    in (M.get_param_value_from_config(["bowtie_build", "additional_params"]) or "")
     else "bt2"
 )
 BT2_PREFIX = os.path.join(dirs_dict["MAPPING_DIR"], "{group}", "{group}-contigs")


### PR DESCRIPTION
Issue spotted by @ivagljiva.
Fixes a TypeError: argument of type 'NoneType' is not iterable crash when running workflows.
Since the workflow refactor moved defaults into per-workflow params.json, several additional_params entries were declared with "type": "str" but "default": null. That null flows into the config as Python None, and code that treats the value as a string crashes.

Solution: changed every null additional_params default to "".
Also: new guard/defense against a user who decided to put `null` instead of the new default `""` in read_recruitment/rules/main.smk, workflows/__init__.py and ecophylo/__init__.py.