### PR TITLE
A crisper display for anvi-display-pan-graph

### DIFF
--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -2158,6 +2158,56 @@ class PangenomeGraphUserInterface {
 
         $('#svgbox').empty().html(svg_core[0].outerHTML);
 
+        // Minimum on-screen line width. The graph lives in a huge viewBox that
+        // gets squeezed into the viewport, so at fit-view stroke widths (set in
+        // user units) collapse to sub-pixel widths and render as faint, shimmery
+        // "antialiased garbage". We keep strokes scaling naturally with the graph
+        // (so they stay proportional and look right at every zoom) but never let
+        // a rendered stroke drop below MIN_PX device pixels:
+        //   rendered_px = baseW * realZoom  ->  clamp so it's >= MIN_PX
+        //   => stroke-width attr = max(baseW, MIN_PX / realZoom)
+        // Zoomed in, MIN_PX/realZoom is tiny so widths are natural; zoomed out,
+        // the floor keeps thin lines crisp instead of collapsing.
+        //
+        // Snapshot every strokable element's natural (base) width once per redraw
+        // so the per-zoom pass just reads dataset.baseStroke.
+        this._lineEls = [];
+        document.querySelectorAll('#result [stroke-width]').forEach(el => {
+            const baseW = parseFloat(el.getAttribute('stroke-width'));
+            if (baseW > 0) {
+                el.dataset.baseStroke = baseW;
+                this._lineEls.push(el);
+            }
+        });
+        this._minBaseStroke = this._lineEls.reduce(
+            (m, el) => Math.min(m, parseFloat(el.dataset.baseStroke)), Infinity);
+        this._strokeRegime = null;
+
+        this.apply_stroke_floor = () => {
+            if (!this._lineEls || !this._lineEls.length || !this.panZoomInstance) return;
+            const to_base = () => {
+                // Only touch the DOM when leaving the floor regime, so ordinary
+                // zoomed-in interaction does no per-element work.
+                if (this._strokeRegime === 'base') return;
+                this._lineEls.forEach(el => el.setAttribute('stroke-width', el.dataset.baseStroke));
+                this._strokeRegime = 'base';
+            };
+            // High-performance mode: skip the floor entirely (cheap pan/zoom;
+            // lines may go sub-pixel when fully zoomed out).
+            if ($('#flexhighperf').prop('checked')) { to_base(); return; }
+            const MIN_PX = parseFloat($('#min_line_px')[0].value) || 0;
+            if (MIN_PX <= 0) { to_base(); return; }
+            const realZoom = this.panZoomInstance.getSizes().realZoom;
+            const floor = MIN_PX / realZoom;
+            // Even the thinnest line already renders >= MIN_PX -> nothing to do.
+            if (floor <= this._minBaseStroke) { to_base(); return; }
+            this._lineEls.forEach(el => {
+                const baseW = parseFloat(el.dataset.baseStroke);
+                el.setAttribute('stroke-width', baseW > floor ? baseW : floor);
+            });
+            this._strokeRegime = 'floor';
+        };
+
         this.refresh_region_label_visibility = () => {
             if (!$('#flexregionlabels').prop('checked')) return;
             const realZoom = this.panZoomInstance.getSizes().realZoom;
@@ -2201,7 +2251,7 @@ class PangenomeGraphUserInterface {
             controlIconsEnabled: false,
             minZoom: 0.1,
             maxZoom: 100,
-            onZoom: () => { this.refresh_region_label_visibility(); this._render_bin_visuals(); }
+            onZoom: () => { this.apply_stroke_floor(); this.refresh_region_label_visibility(); this._render_bin_visuals(); }
         });
 
         // Restore pan/zoom from before the redraw (e.g. after a color change).
@@ -2209,6 +2259,9 @@ class PangenomeGraphUserInterface {
             this.panZoomInstance.zoom(savedZoom);
             this.panZoomInstance.pan(savedPan);
         }
+
+        // Apply the min-line-width floor for the initial view.
+        this.apply_stroke_floor();
 
         // Auto-size region labels once on first load.
         //
@@ -2726,6 +2779,8 @@ class PangenomeGraphUserInterface {
 
         // edges
         $('#edge')[0].value = state['edges']['width'];
+        // min line width floor — fall back to the HTML default for older states
+        $('#min_line_px')[0].value = state['edges']['min_line_width_px'] ?? 0.5;
 
         // graph_layout
         const gl = state['graph_layout'];
@@ -3253,6 +3308,15 @@ class PangenomeGraphUserInterface {
 
         $('#flextree').on("change", this.flextree_change)
         $('#flexsaturation').on("change", () => this.main_draw())
+        // Min line width / high-performance mode only re-clamp existing strokes,
+        // so no redraw is needed -- just re-run the floor pass. Reset the regime
+        // cache first so the pass re-evaluates from scratch.
+        $('#min_line_px, #flexhighperf').on("change", () => {
+            if (this.apply_stroke_floor) {
+                this._strokeRegime = null;
+                this.apply_stroke_floor();
+            }
+        })
         $('#flexregionlabels').on("change", () => this.main_draw())
         $('#region_label_size, #region_label_min_width, #region_label_distance').on("change", () => {
             if (this.panZoomInstance && $('#flexregionlabels').prop('checked')) {
@@ -4468,7 +4532,8 @@ class PangenomeGraphUserInterface {
                 }
             },
             edges: {
-                width: Number($('#edge')[0].value)
+                width: Number($('#edge')[0].value),
+                min_line_width_px: Number($('#min_line_px')[0].value)
             },
             graph_layout: {
                 grouping_enabled: $('#flexcondtr').prop('checked'),

--- a/anvio/data/interactive/pangraph.html
+++ b/anvio/data/interactive/pangraph.html
@@ -375,6 +375,26 @@
                           <input type="text" class="form-control float-end text-end flex-fill p-0 border-0" style= "background-color: #e9ecef;" id="edge" name="edge" value=0 aria-label="..." data-toggle="tooltip" data-placement="top" title="Choose your color">
                         </div>
                       </div>
+                      <div class="col-12 d-flex mb-1">
+                        <div class="col-1 d-flex align-items-center">
+                        </div>
+                        <div class="col-9 d-flex align-items-center">
+                          Min line width (px)
+                        </div>
+                        <div class="d-flex col-2">
+                          <input type="text" class="form-control float-end text-end flex-fill p-0 border-0" style="background-color: #e9ecef;" id="min_line_px" name="min_line_px" value=0.5 aria-label="..." data-toggle="tooltip" data-placement="top" title="Lines never render thinner than this many screen pixels, so they stay crisp at any zoom instead of collapsing into sub-pixel antialiasing. Otherwise lines scale normally with the graph. Set to 0 to disable the floor.">
+                        </div>
+                      </div>
+                      <div class="col-12 d-flex mb-1">
+                        <div class="col-1 d-flex align-items-center">
+                          <div class="form-switch d-flex">
+                            <input class="" type="checkbox" id="flexhighperf" name="flexhighperf" aria-label="..." data-toggle="tooltip" data-placement="top" title="Skips the per-zoom minimum-line-width adjustment for faster pan/zoom on very large graphs. When on, lines scale normally and may collapse into sub-pixel artifacts when the whole graph is fit to the screen.">
+                          </div>
+                        </div>
+                        <div class="col-11 d-flex align-items-center">
+                          High-performance mode (skip min line width, faster pan/zoom)
+                        </div>
+                      </div>
                     </div>
 
                     <span class="settings-secondary-header mb-3 mt-3">Region Labels</span>

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -1961,7 +1961,8 @@ class PangenomeGraph():
                 }
             },
             'edges': {
-                'width': 5
+                'width': 5,
+                'min_line_width_px': 0.5
             },
             'graph_layout': {
                 'grouping_enabled': self.gene_cluster_grouping_threshold != -1,


### PR DESCRIPTION
`anvi-display-pan-graph` has a problem. When it is initialized, it draws the display as one large SVG within a viewBox that is tens of thousands of units wide that is squeezed into the browser viewport.

When we look at the entirety of a graph, the lines (or stroke widths in SVG lingo) are collapsed to sub-pixel widths (since you can squeeze things only so much) and as a result the lines are typically rendered as faint, shimmery antialiased garbage (even though when you download the SVG and open it in Inkscape, or zoom in all the way, you see perfectly fine lines). Here is an example of what user sees and that annoys the crap out of the user because the user wants to be able to just take screenshots and send it to their colleagues but they can't do it because this is what things look like which is why the user is so annoyed:

<img width="1782" height="1784" alt="image" src="https://github.com/user-attachments/assets/db268d45-4e50-4df2-b84d-72a8d43c0f85" />

When it should look like THIS, which is what this PR enables:

<img width="1782" height="1784" alt="image" src="https://github.com/user-attachments/assets/d537f50e-45be-41f8-94ee-6761bd69c46a" />

This is happening how we resolved some performance issues we experienced before. We used non-scaling-stroke (constant screen-pixel width, so no computation when zoomed in and out or panned the display around), which made lines obnoxiously thick at 100% view while looking fine zoomed in. That obviously was not the solution. What this PR does it that it keeps strokes scaling naturally with the graph but clamps each to a minimum on-screen width applied in the zoom handler. So lines stay proportional and nice at every level of 'zoom', but never never drop below the default min line width (which is now by default 0.5px) and shrivel into some antialiased garbage like they do in the first image.

This PR also introduces two controls: min line width (px) input so the user can change the default if they wish, a checkbox for "high-performance mode" so they user can toggle that to skip the per-zoom pass on very large graphs (plus a regime cache so zoomed-in interaction does zero per-element work):

```js
            // High-performance mode: skip the floor entirely (cheap pan/zoom;
            // lines may go sub-pixel when fully zoomed out).
            if ($('#flexhighperf').prop('checked')) { to_base(); return; }
```

So we can have our 🍰 and eat it too.

It would have been great if @TianyiChang could do a git pull and see if this solution works for MGEs or smaller pangraphs (re: #2695)