### PR TITLE
anvi-draw-kegg-pathways enzymes-txt direct input

### DIFF
--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -24,7 +24,8 @@ __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
 __license__ = "GPL 3.0"
 __version__ = VERSION
 __requires__ = ['kegg-data']
-__can_use__ = ['contigs-db', 'external-genomes', 'pan-db', 'genomes-storage-db', 'reaction-network']
+__can_use__ = ['contigs-db', 'external-genomes', 'pan-db',
+               'genomes-storage-db', 'reaction-network', 'enzymes-txt']
 __provides__ = ['kegg-pathway-map']
 __description__ = DESCRIPTION
 
@@ -32,11 +33,22 @@ __description__ = DESCRIPTION
 def get_args() -> Namespace:
     parser = ArgumentParser(description=DESCRIPTION)
 
+    groupTXT = parser.add_argument_group(
+        "ENZYMES TEXT FILE",
+        "Display KO data from a tab-delimited enzymes text file. This allows pathway maps to be "
+        "drawn directly from a custom enzyme list."
+    )
+    groupTXT.add_argument(*A('enzymes-txt'), **K('enzymes-txt', {'help':
+        "Path to a tab-delimited enzymes text file with the required columns 'gene_id', "
+        "'enzyme_accession', and 'source'. KO IDs are extracted from the rows where 'source' is "
+        "'KOfam' and used to highlight reactions in pathway maps. Use '--ko' to activate KO "
+        "drawing when using this option."
+    }))
+
     groupJSON = parser.add_argument_group(
         "REACTION NETWORK JSON",
         "Display KO data from a reaction network JSON file produced by 'anvi-reaction-network "
-        "--enzymes-txt' or 'anvi-get-metabolic-model-file'. This bypasses the need for a contigs "
-        "database and allows pathway maps to be drawn from any custom enzyme list."
+        "--enzymes-txt' or 'anvi-get-metabolic-model-file'."
     )
     groupJSON.add_argument(
         '--reaction-network-json', type=str, metavar='FILE', help=
@@ -350,6 +362,24 @@ def map_json_network_ko_data(args: Namespace, mapper: Mapper) -> None:
         draw_maps_lacking_kos=args.draw_bare_maps
     )
 
+def map_enzymes_txt_ko_data(args: Namespace, mapper: Mapper) -> None:
+    """Draw KO data from an enzymes text file."""
+    map_enzymes_txt_kos = mapper.map_enzymes_txt_kos
+
+    if args.set_color is None or args.set_color is True:
+        pass
+    else:
+        map_enzymes_txt_kos = functools.partial(
+            map_enzymes_txt_kos, color_hexcode=args.set_color
+        )
+
+    map_enzymes_txt_kos(
+        args.enzymes_txt,
+        args.output_dir,
+        pathway_numbers=args.pathway_numbers,
+        draw_maps_lacking_kos=args.draw_bare_maps
+    )
+
 def map_single_contigs_db_ko_data(args: Namespace, mapper: Mapper) -> None:
     """Draw KO data from a single contigs database source in the absence of a colormap."""
     map_contigs_database_kos = mapper.map_contigs_database_kos
@@ -595,6 +625,10 @@ def main() -> None:
                         categorize_files=args.categorize_files)
         performed = False
 
+        if args.enzymes_txt is not None and args.ko is True:
+            map_enzymes_txt_ko_data(args, mapper)
+            performed = True
+
         if args.reaction_network_json is not None and args.ko is True:
             map_json_network_ko_data(args, mapper)
             performed = True
@@ -625,8 +659,8 @@ def main() -> None:
         if not performed:
             raise ConfigError(
                 "No task was performed! The minimum requirements are a data source (such as "
-                "`--reaction-network-json`, `--contigs-dbs`, or `--pan-db`) and a data type to "
-                "draw, such as `--ko`."
+                "`--enzymes-txt`, `--reaction-network-json`, `--contigs-dbs`, or `--pan-db`) and a "
+                "data type to draw, such as `--ko`."
             )
 
     except ConfigError as e:

--- a/anvio/docs/artifacts/enzymes-txt.md
+++ b/anvio/docs/artifacts/enzymes-txt.md
@@ -1,6 +1,6 @@
 This artifact is a TAB-delimited file that describes a set of enzymes.
 
-The user can generate this file to define an arbitrary set of enzymes that they want to estimate metabolism on, using the program %(anvi-estimate-metabolism)s.
+The user can generate this file to define an arbitrary set of enzymes that they want to estimate metabolism on, using the program %(anvi-estimate-metabolism)s. The file can be used to draw KEGG pathway maps highlighting its KOfam annotations with %(anvi-draw-kegg-pathways)s and to build a metabolic reaction network with %(anvi-reaction-network)s.
 
 
 ## Minimal file format

--- a/anvio/docs/programs/anvi-draw-kegg-pathways.md
+++ b/anvio/docs/programs/anvi-draw-kegg-pathways.md
@@ -74,20 +74,21 @@ Here is a simple example of the output file structure produced with `--name-file
 
 ## KO occurrence
 
-Gene sequences in anvi'o databases can be annotated with KEGG Orthologs (KOs): see %(anvi-run-kegg-kofams)s. A KO indicates functional capabilities of the gene product. KO data from one or more contigs databases or a pan database can be mapped using the `--ko` flag, enabling investigation of the metabolic capabilities of individual organisms or multiple organisms, including community samples. Reactions associated with KOs are colored on the pathway maps.
+Gene sequences in anvi'o databases can be annotated with KEGG Orthologs (KOs): see %(anvi-run-kegg-kofams)s. A KO indicates functional capabilities of the gene product. KO data from one or more organisms can be mapped using the `--ko` flag, enabling the comparison of metabolic capabilities. Reactions associated with KOs are colored on the pathway maps.
 
-### From a reaction network JSON file
+### Enzymes text file
 
-Pathway maps can be drawn from a reaction network JSON file produced by %(anvi-reaction-network)s or %(anvi-get-metabolic-model-file)s, bypassing the need for a contigs database entirely. This is especially useful with custom enzyme lists — for example, annotations from transcriptomic or proteomic data, or predicted gene content of a last common ancestor.
-
-First, generate the reaction network JSON from an enzymes file:
+Pathway maps can be drawn directly from an %(enzymes-txt)s file. This is the quickest way to visualize a custom enzyme list. KO IDs are read from the rows of the file where the `source` column is `KOfam`. Here is a basic command.
 
 {{ codestart }}
-anvi-reaction-network --enzymes-txt /path/to/enzymes.txt \
-                      --output-json /path/to/network.json
+anvi-draw-kegg-pathways --enzymes-txt /path/to/enzymes.txt \
+                        --ko \
+                        -o output_maps/
 {{ codestop }}
 
-Then draw pathway maps directly from that JSON:
+### Reaction network JSON file
+
+Pathway maps can be drawn from a reaction network JSON file produced by %(anvi-reaction-network)s or %(anvi-get-metabolic-model-file)s. This is especially useful with custom enzyme lists — for example, annotations from transcriptomic or proteomic data, or predicted gene content of a last common ancestor.
 
 {{ codestart }}
 anvi-draw-kegg-pathways --reaction-network-json /path/to/network.json \
@@ -97,7 +98,7 @@ anvi-draw-kegg-pathways --reaction-network-json /path/to/network.json \
 
 ### Single contigs database
 
-Here is the basic command to draw KO data from a single %(contigs-db)s.
+Pathway maps can be drawn from KO data in a single %(contigs-db)s.
 
 {{ codestart }}
 anvi-draw-kegg-pathways --contigs-dbs %(contigs-db)s \

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -356,6 +356,99 @@ class Mapper:
         return drawn
 
 
+    def map_enzymes_txt_kos(
+        self,
+        enzymes_txt: str,
+        output_dir: str,
+        pathway_numbers: Iterable[str] = None,
+        color_hexcode: str = '#2ca02c',
+        draw_maps_lacking_kos: bool = False
+    ) -> Dict[str, bool]:
+        """
+        Draw pathway maps highlighting KOs present in an enzymes text file.
+
+        The enzymes text file is a tab-delimited file in the format accepted by
+        'anvi-reaction-network --enzymes-txt' and 'anvi-estimate-metabolism --enzymes-txt'. KO IDs
+        are read directly from the rows where 'source' is 'KOfam', so no reference databases are
+        required. This allows pathway maps to be drawn directly from a custom enzyme list.
+
+        Parameters
+        ==========
+        enzymes_txt : str
+            Path to a tab-delimited enzymes file with the required columns 'gene_id',
+            'enzyme_accession', and 'source'. KO IDs are taken from rows where 'source' is 'KOfam'.
+
+        output_dir : str
+            Path to the output directory in which pathway map PDF files are drawn.
+
+        pathway_numbers : Iterable[str], None
+            Regex patterns to match the ID numbers of the drawn pathway maps. The default of None
+            draws all available pathway maps in the KEGG data directory.
+
+        color_hexcode : str, '#2ca02c'
+            Color for reactions containing KOs from the enzymes file. Can also be 'original'.
+
+        draw_maps_lacking_kos : bool, False
+            If False, only draw maps containing any of the KOs in the enzymes file.
+
+        Returns
+        =======
+        Dict[str, bool]
+            Keys are pathway numbers. Values are True if the map was drawn, False if not.
+        """
+        filesnpaths.is_file_tab_delimited(enzymes_txt)
+
+        self.progress.new("Loading KO data from the enzymes text file")
+        self.progress.update("...")
+
+        enzymes_df = pd.read_csv(enzymes_txt, sep='\t')
+        required_columns = {'gene_id', 'enzyme_accession', 'source'}
+        missing_columns = required_columns - set(enzymes_df.columns)
+        if missing_columns:
+            self.progress.end()
+            raise ConfigError(
+                f"The enzymes text file at '{enzymes_txt}' is missing the following required "
+                f"columns: {', '.join(sorted(missing_columns))}. The file must contain at least "
+                f"'gene_id', 'enzyme_accession', and 'source' columns, as described by the "
+                f"enzymes-txt artifact documentation."
+            )
+
+        # Blank cells are read by pandas as NaN, so drop them to keep the KO count accurate and to
+        # ensure the empty-input check below fires when no real accessions are present.
+        ko_ids = set(
+            enzymes_df.loc[enzymes_df['source'] == 'KOfam', 'enzyme_accession'].dropna()
+        )
+
+        self.progress.end()
+
+        if not ko_ids:
+            present_sources = sorted(enzymes_df['source'].astype(str).unique())
+            if present_sources:
+                sources_str = ', '.join(f"'{source}'" for source in present_sources)
+                sources_statement = f"Sources present in the file: {sources_str}."
+            else:
+                sources_statement = "In fact, the file does not contain any data rows."
+            raise ConfigError(
+                f"No KOfam annotations were found in the enzymes text file at '{enzymes_txt}' "
+                f"(the value in the 'source' column must be 'KOfam'), so there is nothing to draw. "
+                f"{sources_statement}"
+            )
+
+        self.run.info("KOs found in enzymes text file", len(ko_ids))
+
+        drawn = self._map_kos_fixed_colors(
+            ko_ids,
+            output_dir,
+            pathway_numbers=pathway_numbers,
+            color_hexcode=color_hexcode,
+            draw_maps_lacking_kos=draw_maps_lacking_kos
+        )
+        count = sum(drawn.values()) if drawn else 0
+        self.run.info("Number of maps drawn", count)
+
+        return drawn
+
+
     def map_genomes_storage_genome_kos(
         self,
         genomes_storage_db: str,

--- a/anvio/tests/run_component_tests_for_kegg_mapping.sh
+++ b/anvio/tests/run_component_tests_for_kegg_mapping.sh
@@ -15,9 +15,11 @@ cp ${files}/mock_data_for_pangenomics/*.db ${output_dir}/
 cp ${files}/mock_data_for_pangenomics/external-genomes.txt ${output_dir}/
 cp ${files}/example_description.md ${output_dir}/
 cp ${files}/mock_data_for_pangenomics/group-information.txt ${output_dir}/pan-group-information.txt
+cp ${files}/data/input_files/minimal_enzymes_input.txt ${output_dir}/
 awk -F'\t' 'NR==1 {print $0} NR>1 {$1=$1".db"; print $0}' OFS='\t' \
 ${output_dir}/pan-group-information.txt > ${output_dir}/contigs-db-group-information.txt
 cd ${output_dir}/
+mkdir enzymes_txt_kos
 mkdir contigs_db_kos
 mkdir contigs_dbs_kos_count
 mkdir pan_db_kos_genome_count_emphasize_shared
@@ -63,6 +65,15 @@ args+=( "--no-progress" )
 anvi-reaction-network "${args[@]}"
 
 pathway_numbers=( "00010" "01100" "01200" )
+
+INFO "Testing mapping KOs from an enzymes text file"
+args=()
+args+=( "--enzymes-txt" "minimal_enzymes_input.txt" )
+args+=( "--output-dir" ${output_dir}/enzymes_txt_kos )
+args+=( "--ko" )
+args+=( "--pathway-numbers" "${pathway_numbers[@]}" )
+args+=( "--no-progress" )
+anvi-draw-kegg-pathways "${args[@]}"
 
 INFO "Testing mapping KOs from a genomic contigs database"
 args=()


### PR DESCRIPTION
This PR allows `anvi-draw-kegg-pathways` to take `enzymes-txt` directly as input rather than going through a contigs database or metabolic model JSON file. The KOs in the text file are colored in output KEGG pathway map files.