### PR TITLE
Display structure colabfold

### DIFF
--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -738,59 +738,76 @@ function get_model_info_table_html(model_data) {
 
     var geneModelHtml = '';
 
-    /* TEMPLATES */
-    geneModelHtml += '<div class="widget">'
-    geneModelHtml += '<span class="settings-header"><h4>Templates Used</h4></span>'
-    geneModelHtml += '<table class="table table-sm table-responsive" id="model_info_table"><tbody>';
-
-    var header = '<tr>';
-    for (const col_name of Object.keys(templates[0])) {
-        header += '<td><label class="col-md-4 settings-label">' + col_name + '</label></td>';
+    /* PREDICTION ENGINE */
+    var engine_labels = {'modeller': 'MODELLER', 'colabfold': 'ColabFold', 'external': 'External'};
+    var engine = model_data['engine'];
+    if (engine) {
+        geneModelHtml += '<div class="widget">'
+        geneModelHtml += '<span class="settings-header"><h4>Prediction engine</h4></span>'
+        geneModelHtml += '<p>' + (engine_labels[engine] || engine) + '</p>';
+        geneModelHtml += "</div>";
     }
-    header += '</tr>';
-    geneModelHtml += header;
 
-    for (var i = 0; i < Object.keys(templates).length; i++) {
-        var row = templates[i];
-        var tr = '<tr>';
+    /* TEMPLATES */
+    // template-free engines (ColabFold) and external structures report no templates
+    if (Object.keys(templates).length > 0) {
+        geneModelHtml += '<div class="widget">'
+        geneModelHtml += '<span class="settings-header"><h4>Templates Used</h4></span>'
+        geneModelHtml += '<table class="table table-sm table-responsive" id="model_info_table"><tbody>';
 
-        for (const [col_name, value] of Object.entries(row)) {
-            if (col_name == 'PDB') {
-                formatted_value = '<a href="https://www.rcsb.org/structure/' + value + '" target=_"blank">' + value.toUpperCase() + '</a>'
-            } else if (col_name == '%Identity') {
-                formatted_value = Number(value).toFixed(2);
-            } else if (col_name == 'Align fraction') {
-                formatted_value = Number(value).toFixed(3);
-            } else {
-                formatted_value = value
+        var header = '<tr>';
+        for (const col_name of Object.keys(templates[0])) {
+            header += '<td><label class="col-md-4 settings-label">' + col_name + '</label></td>';
+        }
+        header += '</tr>';
+        geneModelHtml += header;
+
+        for (var i = 0; i < Object.keys(templates).length; i++) {
+            var row = templates[i];
+            var tr = '<tr>';
+
+            for (const [col_name, value] of Object.entries(row)) {
+                if (col_name == 'PDB') {
+                    formatted_value = '<a href="https://www.rcsb.org/structure/' + value + '" target=_"blank">' + value.toUpperCase() + '</a>'
+                } else if (col_name == '%Identity') {
+                    formatted_value = Number(value).toFixed(2);
+                } else if (col_name == 'Align fraction') {
+                    formatted_value = Number(value).toFixed(3);
+                } else {
+                    formatted_value = value
+                }
+                tr += '<td>' + formatted_value + '</td>'
             }
-            tr += '<td>' + formatted_value + '</td>'
+
+            tr += '</tr>'
+            geneModelHtml += tr;
         }
 
-        tr += '</tr>'
-        geneModelHtml += tr;
+        geneModelHtml += "</tbody></table></div>";
     }
-
-    geneModelHtml += "</tbody></table></div>";
 
     /* MODELS */
-    geneModelHtml += '<div class="widget">'
-    geneModelHtml += '<span class="settings-header"><h4>Model Scores</h4></span>'
-    geneModelHtml += '<table class="table table-sm table-responsive" id="model_info_table"><tbody>';
+    // external structures carry no model scores
+    if (models) {
+        geneModelHtml += '<div class="widget">'
+        geneModelHtml += '<span class="settings-header"><h4>Model Scores</h4></span>'
+        geneModelHtml += '<table class="table table-sm table-responsive" id="model_info_table"><tbody>';
 
-    var header = '<tr>';
-    var row = '<tr>';
-    for (const [col_name, value] of Object.entries(models)) {
-        header += '<td><label class="col-md-4 settings-label">' + col_name + '</label></td>';
-        row += '<td>' + Number(value).toFixed(2) + '</td>';
+        var header = '<tr>';
+        var row = '<tr>';
+        for (const [col_name, value] of Object.entries(models)) {
+            header += '<td><label class="col-md-4 settings-label">' + col_name + '</label></td>';
+            row += '<td>' + Number(value).toFixed(2) + '</td>';
+        }
+        header += '</tr>';
+        row += '</tr>';
+
+        geneModelHtml += header;
+        geneModelHtml += row;
+
+        geneModelHtml += "</tbody></table></div>";
     }
-    header += '</tr>';
-    row += '</tr>';
 
-    geneModelHtml += header;
-    geneModelHtml += row;
-
-    geneModelHtml += "</tbody></table></div>";
     return geneModelHtml;
 }
 
@@ -1094,8 +1111,16 @@ function create_ui() {
                 size_legend[engine] = {};
             }
 
+            // residue_info columns that also have a column_info entry are added below with a
+            // friendly title, so we skip them here to avoid listing the same variable twice
+            let column_info_color_names = new Set(
+                column_info
+                    .filter((item) => (item['as_view'] | item['as_filter']) && item['data_type'] != 'text')
+                    .map((item) => item['name'])
+            );
+
             for (const [info_name, types] of Object.entries(residue_info_types)) {
-                if (types["dtype"] != "object") {
+                if (types["dtype"] != "object" && !column_info_color_names.has(info_name)) {
                     // Ok this is some type of numerical data form. We can include it
                     $('#backbone_color_variable').append(`<option value="${info_name}">${info_name}</item>`);
                     $('#surface_color_variable').append(`<option value="${info_name}">${info_name}</item>`);

--- a/anvio/data/interactive/js/structure.js
+++ b/anvio/data/interactive/js/structure.js
@@ -1112,7 +1112,9 @@ function create_ui() {
             }
 
             // residue_info columns that also have a column_info entry are added below with a
-            // friendly title, so we skip them here to avoid listing the same variable twice
+            // friendly title, so we skip them here to avoid listing the same variable twice. This
+            // predicate must stay identical to the column_info coloring loop below (same `|`) so
+            // the set contains exactly the columns that loop adds.
             let column_info_color_names = new Set(
                 column_info
                     .filter((item) => (item['as_view'] | item['as_filter']) && item['data_type'] != 'text')

--- a/anvio/docs/programs/anvi-display-structure.md
+++ b/anvio/docs/programs/anvi-display-structure.md
@@ -13,6 +13,11 @@ To run this program, you'll need to have created a %(structure-db)s which can be
 You'll also need a %(profile-db)s that was created using %(anvi-profile)s's flag `--profile-SCVs`, which means that single codon variants (SCVs) have been profiled. Very sorry if this forces you to re-profile, but as of v6.2, this is now a very expedient process.
 
 
+### MODELLER and ColabFold structures
+
+%(anvi-display-structure)s works with a %(structure-db)s regardless of whether its structures were predicted by MODELLER (template-based homology modelling) or ColabFold (AlphaFold2). The interface adapts to the prediction engine: for MODELLER structures it reports the DOPE, GA341, and molpdf model scores along with the PDB templates that were used, while for ColabFold structures it reports the model's mean pLDDT and pTM (ColabFold is template-free, so no templates are shown). For ColabFold structures, the per-residue pLDDT confidence is also available as a variable you can color the protein by and filter variants on, just like the other residue-level annotations.
+
+
 ### Basic Run
 
 There are two ways to provide the variability information to this program.

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -2336,24 +2336,15 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
 
             templates = structure_db.db.get_table_as_dataframe(
                 'templates',
-                columns_of_interest=['pdb_id', 'chain_id'],
+                columns_of_interest=['pdb_id', 'chain_id', 'percent_similarity', 'align_fraction'],
                 where_clause='corresponding_gene_call = %d' % gene_callers_id,
             ).rename(columns={
                 'pdb_id': 'PDB',
                 'chain_id': 'Chain',
+                'percent_similarity': '%Identity',
+                'align_fraction': 'Align fraction',
             })
-
-            # Check if the columns exist before accessing them
-            if 'percent_similarity' in templates.columns and 'align_fraction' in templates.columns:
-                templates['%Identity'] = templates['percent_similarity']
-                templates['Align fraction'] = templates['align_fraction']
-                templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
-            else:
-                # Handle the case when columns are not present
-                # You can set default values or handle it in a way that makes sense for your application
-                templates['%Identity'] = 0
-                templates['Align fraction'] = 0
-                templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
+            templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
 
         elif engine == 'colabfold':
             models = structure_db.db.get_table_as_dataframe(

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -2312,46 +2312,76 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
 
 
     def get_model_info(self, gene_callers_id):
-        """Returns information about the protein model, e.g. template IDs, DOPE_score, etc"""
+        """Returns information about the protein model to display in the interface
+
+        What is reported depends on the engine that predicted the structure. MODELLER reports the
+        per-model DOPE/GA341/molpdf scores and the PDB templates it used. ColabFold is template-free
+        and reports mean pLDDT and pTM instead. External structures have neither scores nor templates.
+        """
 
         structure_db = structureops.StructureDatabase(self.structure_db_path, 'none', ignore_hash=True)
+        engine = structure_db.db.get_meta_value('engine', return_none_if_not_in_table=True) or 'modeller'
 
-        models = structure_db.db.get_table_as_dataframe(
-            'models',
-            columns_of_interest=['GA341_score', 'DOPE_score', 'molpdf', 'picked_as_best'],
-            where_clause='corresponding_gene_call = %d' % gene_callers_id,
-        ).rename(columns={
-            'DOPE_score': 'DOPE',
-            'GA341_score': 'GA341',
-        })
-        models['Models tried'] = models.shape[0]
-        models = models.loc[models['picked_as_best'] == 1, ['DOPE', 'GA341', 'molpdf', 'Models tried']].reset_index(drop=True)
+        if engine == 'modeller':
+            models = structure_db.db.get_table_as_dataframe(
+                'models',
+                columns_of_interest=['GA341_score', 'DOPE_score', 'molpdf', 'picked_as_best'],
+                where_clause='corresponding_gene_call = %d' % gene_callers_id,
+            ).rename(columns={
+                'DOPE_score': 'DOPE',
+                'GA341_score': 'GA341',
+            })
+            models['Models tried'] = models.shape[0]
+            models = models.loc[models['picked_as_best'] == 1, ['DOPE', 'GA341', 'molpdf', 'Models tried']].reset_index(drop=True)
 
-        templates = structure_db.db.get_table_as_dataframe(
-            'templates',
-            columns_of_interest=['pdb_id', 'chain_id'],
-            where_clause='corresponding_gene_call = %d' % gene_callers_id,
-        ).rename(columns={
-            'pdb_id': 'PDB',
-            'chain_id': 'Chain',
-        })
+            templates = structure_db.db.get_table_as_dataframe(
+                'templates',
+                columns_of_interest=['pdb_id', 'chain_id'],
+                where_clause='corresponding_gene_call = %d' % gene_callers_id,
+            ).rename(columns={
+                'pdb_id': 'PDB',
+                'chain_id': 'Chain',
+            })
 
-        # Check if the columns exist before accessing them
-        if 'percent_similarity' in templates.columns and 'align_fraction' in templates.columns:
-            templates['%Identity'] = templates['percent_similarity']
-            templates['Align fraction'] = templates['align_fraction']
-            templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
+            # Check if the columns exist before accessing them
+            if 'percent_similarity' in templates.columns and 'align_fraction' in templates.columns:
+                templates['%Identity'] = templates['percent_similarity']
+                templates['Align fraction'] = templates['align_fraction']
+                templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
+            else:
+                # Handle the case when columns are not present
+                # You can set default values or handle it in a way that makes sense for your application
+                templates['%Identity'] = 0
+                templates['Align fraction'] = 0
+                templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
+
+        elif engine == 'colabfold':
+            models = structure_db.db.get_table_as_dataframe(
+                'models',
+                columns_of_interest=['mean_plddt', 'ptm', 'picked_as_best'],
+                where_clause='corresponding_gene_call = %d' % gene_callers_id,
+            ).rename(columns={
+                'mean_plddt': 'Mean pLDDT',
+                'ptm': 'pTM',
+            })
+            models['Models tried'] = models.shape[0]
+            models = models.loc[models['picked_as_best'] == 1, ['Mean pLDDT', 'pTM', 'Models tried']].reset_index(drop=True)
+
+            # drop any confidence metric that was not stored, so the interface does not show it
+            models = models.dropna(axis=1, how='all')
+
+            # ColabFold is template-free
+            templates = pd.DataFrame({})
+
         else:
-            # Handle the case when columns are not present
-            # You can set default values or handle it in a way that makes sense for your application
-            templates['%Identity'] = 0
-            templates['Align fraction'] = 0
-            templates = templates[['PDB', 'Chain', '%Identity', 'Align fraction']]
-
+            # external structures have neither MODELLER-style scores nor templates
+            models = pd.DataFrame({})
+            templates = pd.DataFrame({})
 
         structure_db.disconnect()
 
         return {
+            'engine': engine,
             'models': models.to_json(orient='index'),
             'templates': templates.to_json(orient='index'),
         }
@@ -2624,6 +2654,18 @@ class StructureInteractive(VariabilitySuper, ContigsSuperclass):
                 'step': 0.01,
                 'min': 0,
                 'max': 1,
+            },
+            {
+                # only populated for ColabFold structures; dropped by the filter below for other
+                # engines because `plddt` is not among their variability data columns
+                'name': 'plddt',
+                'title': 'pLDDT',
+                'as_view': True,
+                'as_filter': 'slider',
+                'data_type': 'float',
+                'step': 1,
+                'min': 0,
+                'max': 100,
             },
             {
                 'name': 'sec_struct',

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -7,7 +7,6 @@ import time
 import numpy as np
 import shutil
 import pandas as pd
-import sqlite3
 import warnings
 import datetime
 
@@ -1899,12 +1898,8 @@ class PDBDatabase(object):
             pdb_db.create_table('structures', ['representative_id', 'pdb_content'], ['text', 'blob'])
             pdb_db.create_table('clusters', ['cluster', 'id', 'representative'], ['text', 'text', 'integer'])
 
-        try:
-            # Create an index for `representative_id` for fast lookup
-            pdb_db._exec("CREATE INDEX chain_index ON structures (representative_id);")
-        except sqlite3.OperationalError:
-            # The index has already been set
-            pass
+        # Create an index for `representative_id` for fast lookup
+        pdb_db._exec("CREATE INDEX IF NOT EXISTS chain_index ON structures (representative_id);")
 
         pdb_db.disconnect()
 

--- a/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
+++ b/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
@@ -13,13 +13,18 @@ make_structure_db() {
                                 --num-threads 2 \
                                 --num-models 1
 }
-# Predict structures with ColabFold instead of MODELLER. This is NOT part of the default routines
-# because it requires ColabFold to be installed (pass its conda env with --colabfold-conda-env) and,
-# for a real run, a GPU and either internet access (--colabfold-msa-server) or a local ColabFold
-# database (--colabfold-db). Invoke it manually when you want to exercise the ColabFold engine.
+# Predict structures with ColabFold instead of MODELLER. This is opt-in: it only runs when the
+# COLABFOLD_CONDA_ENV environment variable names a conda environment in which ColabFold is installed
+# (anvi'o runs every ColabFold command via `conda run -n $COLABFOLD_CONDA_ENV`). A real run also needs
+# internet access (we use --colabfold-msa-server) and is slow without a GPU (~10 min per protein on a
+# CPU). When COLABFOLD_CONDA_ENV is unset, the ColabFold parts of the routines are simply skipped.
+#
+# For example, to exercise the ColabFold engine end-to-end:
+#     COLABFOLD_CONDA_ENV=colabfold bash run_component_tests_for_SCVs_SAAVs_structure.sh new
 make_structure_db_colabfold() {
     anvi-gen-structure-database -c test-output/one_contig_five_genes.db \
                                 --engine colabfold \
+                                --colabfold-conda-env "$COLABFOLD_CONDA_ENV" \
                                 --colabfold-msa-server \
                                 --skip-DSSP \
                                 --gene-caller-ids 2 \
@@ -66,6 +71,13 @@ display_structure3() {
               --gene-caller-ids 2,4 \
               --debug
 }
+display_structure_colabfold() {
+    anvi-display-structure -p test-output/SAMPLES-MERGED/PROFILE.db \
+              -c test-output/one_contig_five_genes.db \
+              -s test-output/STRUCTURE_COLABFOLD.db \
+              --gene-caller-ids 2 \
+              --debug
+}
 
 make_routine() {
     INFO "anvi-gen-structure-database with DSSP"
@@ -91,6 +103,14 @@ gene_callers_id	path
 4	test-output/exported_pdbs/gene_4.pdb
 EOF
     anvi-update-structure-database -s test-output/EXTERNAL_STRUCTURE.db --external-structures external_structures -c test-output/one_contig_five_genes.db --rerun --debug
+
+    # ColabFold is only exercised when the user points the test at a conda environment in which
+    # ColabFold is installed (see make_structure_db_colabfold above). Otherwise it is skipped.
+    if [ -n "$COLABFOLD_CONDA_ENV" ]
+    then
+        INFO "anvi-gen-structure-database with ColabFold (conda env: $COLABFOLD_CONDA_ENV)"
+        make_structure_db_colabfold
+    fi
 }
 
 display_routine() {
@@ -108,6 +128,15 @@ display_routine() {
 
     INFO "anvi-display-structure with external structure database"
     display_structure3
+
+    # display the ColabFold structures whenever they were generated (i.e. the ColabFold engine was
+    # exercised in a `new`/`make` run). Displaying needs neither ColabFold nor a conda env, so we gate
+    # on the database existing rather than on COLABFOLD_CONDA_ENV.
+    if [ -f "test-output/STRUCTURE_COLABFOLD.db" ]
+    then
+        INFO "anvi-display-structure with ColabFold structure database"
+        display_structure_colabfold
+    fi
 }
 
 
@@ -121,6 +150,13 @@ then
         'new'     : generate short reads, map them to the contig, gen contigs.db, make structure db, profile varability, open interactive.
         'make'    : make structure db, profile varability, open interactive.
         'display' : profile varability, open interactive.
+
+        To additionally exercise the ColabFold engine, set the COLABFOLD_CONDA_ENV environment
+        variable to the name of a conda environment in which ColabFold is installed, e.g.:
+
+            COLABFOLD_CONDA_ENV=colabfold bash run_component_tests_for_SCVs_SAAVs_structure.sh new
+
+        This requires internet access and is slow without a GPU (~10 min per protein on a CPU).
         "
         exit -1
 fi
@@ -196,6 +232,8 @@ then
     rm -rf test-output/EXTERNAL_STRUCTURE.db
     rm -rf test-output/RAW_MODELLER_OUTPUT
     rm -rf test-output/exported_pdbs
+    rm -rf test-output/STRUCTURE_COLABFOLD.db
+    rm -rf test-output/RAW_COLABFOLD_OUTPUT
 
     make_routine
     display_routine


### PR DESCRIPTION
Second PR regarding the integration of ColabFold in anvi'o (follows #2755).
This time it is about making anvi-display-structure compatible with colabfold-made structure database.

The display is now engine aware (MODELLER or ColabFold) and shows values related to one or the other engine, like mean pLDDT for ColabFold (does not exist for MODELLER) and also color residues by their pLDDT score.

Include a couple of fixes in the test, as well as an update of the test down to the visualization.
