### PR TITLE
Checkpoint structure colabfold

### DIFF
--- a/anvio/cli/gen_structure_database.py
+++ b/anvio/cli/gen_structure_database.py
@@ -199,8 +199,8 @@ def get_args():
                         --only-msa run wrote to --dump-dir, then build the structure database. You must provide the
                         SAME --contigs-db and genes of interest as the --only-msa run: anvi'o verifies that the
                         sequences match the checkpoint before predicting, and refuses to continue if they do not.
-                        Requires --dump-dir (pointing at the --only-msa output) and -o. Mutually exclusive with
-                        --only-msa.""")
+                        Requires --dump-dir (pointing at the --only-msa output); the structure database goes to -o
+                        (default STRUCTURE.db). Mutually exclusive with --only-msa.""")
 
     groupImport = parser.add_argument_group('IMPORT STRUCTURES', 'Instead of predicting structures, import '
                                             'pre-computed ones. This bypasses the --engine choice entirely.')

--- a/anvio/cli/gen_structure_database.py
+++ b/anvio/cli/gen_structure_database.py
@@ -186,6 +186,21 @@ def get_args():
                         it with an equals sign so it is not mistaken for anvi'o's own flags, e.g.
                         --colabfold-additional-parameters="--num-seeds 2 --use-dropout". Anvi'o does not validate
                         these, so use with care.""")
+    groupC.add_argument("--only-msa", action='store_true', help =
+                        """Run only ColabFold's multiple sequence alignment (MSA) step and stop, writing the MSAs
+                        and a small checkpoint manifest into --dump-dir. This creates a resumable checkpoint so
+                        you can run the CPU-heavy MSA step and the GPU-heavy prediction step separately (e.g. on
+                        different cluster nodes). This only works with a local ColabFold database (--colabfold-db):
+                        the public MSA server (--colabfold-msa-server) generates the MSA and predicts the structure
+                        in a single step that cannot be split. No structure database is produced in this mode; you
+                        finish the job later with --only-predict. Requires --dump-dir.""")
+    groupC.add_argument("--only-predict", action='store_true', help =
+                        """Skip the MSA step and predict structures from an MSA checkpoint that an earlier
+                        --only-msa run wrote to --dump-dir, then build the structure database. You must provide the
+                        SAME --contigs-db and genes of interest as the --only-msa run: anvi'o verifies that the
+                        sequences match the checkpoint before predicting, and refuses to continue if they do not.
+                        Requires --dump-dir (pointing at the --only-msa output) and -o. Mutually exclusive with
+                        --only-msa.""")
 
     groupImport = parser.add_argument_group('IMPORT STRUCTURES', 'Instead of predicting structures, import '
                                             'pre-computed ones. This bypasses the --engine choice entirely.')

--- a/anvio/docs/programs/anvi-gen-structure-database.md
+++ b/anvio/docs/programs/anvi-gen-structure-database.md
@@ -69,6 +69,34 @@ All genes of interest are predicted together in a single ColabFold run, which is
 
 You can tune the prediction with `--num-models` (how many AlphaFold2 models to run per gene), `--num-recycle` (more recycles can improve quality at the cost of runtime), and `--amber` (relax the best model with OpenMM/Amber for better side-chains). Anything not exposed as a dedicated flag can be passed straight through to `colabfold_batch` with `--colabfold-additional-parameters` (because its value starts with dashes, attach it with an equals sign, e.g. `--colabfold-additional-parameters="--num-seeds 2"`). As with the MODELLER engine, you can provide a `--dump-dir` to keep all of the raw ColabFold output.
 
+### Splitting the MSA and prediction steps (--only-msa / --only-predict)
+
+A ColabFold run has two very differently-shaped halves: generating the multiple sequence alignments (MSA) is CPU-heavy, while predicting the structures is GPU-heavy. When you scale up to many genes or genomes, you often want to run these on different machines — for example, the MSA step on CPU nodes and the prediction step on GPU nodes of a cluster, wired together by a workflow manager like Snakemake. The `--only-msa` and `--only-predict` flags let you split the run at that seam, using a `--dump-dir` as an on-disk checkpoint that connects the two steps.
+
+`--only-msa` runs only the MSA step and stops, writing the alignments and a small checkpoint manifest into `--dump-dir`. This only works with a local ColabFold database (`--colabfold-db`): the public MSA server (`--colabfold-msa-server`) generates the MSA and predicts the structure in a single step that cannot be split. No structure database is produced yet.
+
+{{ codestart }}
+anvi-gen-structure-database -c %(contigs-db)s \
+                            --engine colabfold \
+                            --colabfold-conda-env colabfold \
+                            --colabfold-db /path/to/colabfold_db \
+                            --gene-caller-ids 1,2,3 \
+                            --only-msa \
+                            --dump-dir MY_CHECKPOINT
+{{ codestop }}
+
+`--only-predict` then resumes from that checkpoint, predicting the structures and building the %(structure-db)s. You must give it the **same** %(contigs-db)s and genes of interest as the `--only-msa` run: anvi'o verifies that the sequences match the checkpoint before predicting and refuses to continue if they do not, so you cannot accidentally predict structures against MSAs that were built for different genes.
+
+{{ codestart }}
+anvi-gen-structure-database -c %(contigs-db)s \
+                            --engine colabfold \
+                            --colabfold-conda-env colabfold \
+                            --gene-caller-ids 1,2,3 \
+                            --only-predict \
+                            --dump-dir MY_CHECKPOINT \
+                            -o STRUCTURE.db
+{{ codestop }}
+
 ### Basic import run
 
 If you already possess structures and would like to create a %(structure-db)s for downstream anvi'o uses such as %(anvi-display-structure)s, you should create a %(external-structures)s file. Then, create the database as follows:

--- a/anvio/drivers/colabfold.py
+++ b/anvio/drivers/colabfold.py
@@ -59,6 +59,11 @@ class ColabFold:
         self.amber = A('amber', bool)
         self.additional_params = A('colabfold_additional_parameters', str)
 
+        # checkpoint flags that split the run into its MSA (colabfold_search) and prediction
+        # (colabfold_batch) halves. Only one may be set (see sanity_check).
+        self.only_msa = A('only_msa', bool)
+        self.only_predict = A('only_predict', bool)
+
         # anvi'o's --num-threads is authoritative: it is always forwarded to the colabfold programs,
         # overriding their own defaults (e.g. colabfold_search defaults to 64 threads). So if the user
         # leaves anvi'o's default of 1, colabfold_search is run with a single thread too.
@@ -76,6 +81,12 @@ class ColabFold:
         # (colabfold_batch queries the public MMseqs2 server)
         self.msa_source = 'local' if self.local_db else 'server'
 
+        # --only-predict resumes from a directory of .a3m files an earlier --only-msa run produced, so
+        # its prediction is always fed a local MSA directory regardless of whether an MSA source was
+        # given on the command line
+        if self.only_predict:
+            self.msa_source = 'local'
+
         self.search_program = 'colabfold_search'
         self.batch_program = 'colabfold_batch'
 
@@ -88,6 +99,21 @@ class ColabFold:
             raise ConfigError("ColabFold can predict between 1 and 5 models per protein, but you asked for %d with "
                               "--num-models. Please pick a value in that range." % self.num_models)
 
+        if self.only_msa and self.only_predict:
+            raise ConfigError("You asked for both --only-msa and --only-predict, but these are the two halves of a "
+                              "single split ColabFold run and are mutually exclusive. Run --only-msa first (it "
+                              "generates the MSAs on, say, a CPU node), then --only-predict (it predicts structures "
+                              "from those MSAs on a GPU node).")
+
+        # --only-predict resumes from a local MSA checkpoint on disk: it needs only the predictor (and a
+        # GPU), not an MSA source, since the MSAs already exist.
+        if self.only_predict:
+            self.check_program(self.batch_program)
+            self.check_gpu()
+            return
+
+        # from here on, the MSA step will run (either as part of a full run, or standalone with
+        # --only-msa), so an MSA source is required
         if self.local_db and self.use_msa_server:
             raise ConfigError("You asked ColabFold to use both a local database (--colabfold-db) and the "
                               "public MSA server (--colabfold-msa-server) for the MSA step. Please pick only one.")
@@ -98,17 +124,24 @@ class ColabFold:
                               "for a handful of sequences), or --colabfold-db to point to a local ColabFold "
                               "database directory (recommended for many sequences).")
 
+        if self.only_msa and self.msa_source != 'local':
+            raise ConfigError("--only-msa splits the ColabFold run at the MSA step, which anvi'o only runs locally "
+                              "(with colabfold_search against --colabfold-db). It cannot be combined with "
+                              "--colabfold-msa-server, because the public server generates the MSA and predicts the "
+                              "structure in a single step that cannot be split. Please provide a local ColabFold "
+                              "database with --colabfold-db instead.")
+
         if self.local_db:
             if not filesnpaths.is_file_exists(self.local_db, dont_raise=True) or not os.path.isdir(self.local_db):
                 raise ConfigError("The ColabFold database path you provided with --colabfold-db does not seem to be a "
                                   "directory that exists: '%s'. This should be the directory you set up with ColabFold's "
                                   "`setup_databases.sh` script." % self.local_db)
-
-        self.check_program(self.batch_program)
-        if self.msa_source == 'local':
             self.check_program(self.search_program)
 
-        self.check_gpu()
+        # --only-msa stops after the MSA step, so it needs neither the predictor nor a GPU
+        if not self.only_msa:
+            self.check_program(self.batch_program)
+            self.check_gpu()
 
 
     def check_program(self, program):
@@ -284,17 +317,26 @@ class ColabFold:
 
         filesnpaths.gen_output_directory(out_dir, delete_if_exists=False, dont_warn=True)
         log_file_path = os.path.join(out_dir, '00_log.txt')
+        msa_dir = os.path.join(out_dir, 'msas')
 
         # the MSA and prediction steps both append to this single log (each writing its own command
         # header + output), so we start it fresh here in case a previous run left one behind (e.g.
-        # when reusing a --dump-dir)
-        if filesnpaths.is_file_exists(log_file_path, dont_raise=True):
+        # when reusing a --dump-dir). --only-predict is the exception: it resumes an --only-msa run, so
+        # we keep that run's MSA log and append the prediction log to it for a complete record.
+        if not self.only_predict and filesnpaths.is_file_exists(log_file_path, dont_raise=True):
             os.remove(log_file_path)
 
         self.run.info('Log file path', log_file_path)
 
-        if self.msa_source == 'local':
-            msa_dir = os.path.join(out_dir, 'msas')
+        if self.only_msa:
+            # generate the MSAs locally and stop; --only-predict will resume from this directory
+            self.run_search(fasta_path, msa_dir, log_file_path)
+            return out_dir
+
+        if self.only_predict:
+            # the MSAs were produced by an earlier --only-msa run; skip straight to prediction
+            self.run_batch(msa_dir, out_dir, log_file_path)
+        elif self.msa_source == 'local':
             self.run_search(fasta_path, msa_dir, log_file_path)
             self.run_batch(msa_dir, out_dir, log_file_path)
         else:

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -522,7 +522,7 @@ class StructureSuperclass(object):
             'num_models': A('num_models', null),
             'num_recycle': A('num_recycle', null),
             'amber': A('amber', bool),
-            'colabfold_msa_source': 'local' if A('colabfold_db', null) else 'server',
+            'colabfold_msa_source': msa_source,
             'colabfold_additional_parameters': A('colabfold_additional_parameters', null),
         }
 

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -961,7 +961,10 @@ class StructureSuperclass(object):
                               (out_dir, manifest.get('contigs_db_hash'), self.contigs_db_hash))
 
         # the authoritative guard: the sequences to predict must be byte-identical to those the MSAs were
-        # generated from
+        # generated from. This rests on export_clean_genes_to_fasta being fully deterministic for a given
+        # contigs-db -- i.e. get_sequences_for_gene_callers_ids and skip_gene_if_not_clean must always
+        # produce the same clean-gene set and byte order. If a future change makes either of those
+        # non-deterministic or dependent on args not captured by the checkpoint, resume will break here.
         if manifest.get('query_fasta_hash') != utils.get_file_md5(fasta_path):
             raise ConfigError("The genes and sequences --only-predict is about to work on do not match the ones the MSA "
                               "checkpoint in '%s' was built from. This usually means the genes of interest changed, the "

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -800,10 +800,21 @@ class StructureSuperclass(object):
         out_dir = self.dump_dir or filesnpaths.get_temp_directory_path()
         filesnpaths.gen_output_directory(out_dir, delete_if_exists=False, dont_warn=True)
 
-        # the query FASTA is part of the checkpoint (so --only-predict can regenerate it and compare),
-        # so it lives inside out_dir rather than a throwaway temp directory
-        fasta_path = os.path.join(out_dir, 'genes_of_interest.fa')
+        if self.only_predict:
+            # regenerate the query FASTA into a throwaway temp file used *only* to validate against the
+            # checkpoint: prediction itself reads the .a3m directory, not this FASTA, and a mismatch must
+            # leave the existing checkpoint (its own FASTA + MSAs) untouched
+            fasta_path = os.path.join(filesnpaths.get_temp_directory_path(), 'genes_of_interest.fa')
+        else:
+            # the query FASTA is part of the checkpoint (so --only-predict can regenerate and compare it),
+            # so for --only-msa / full runs it lives inside out_dir
+            fasta_path = os.path.join(out_dir, 'genes_of_interest.fa')
+
         clean_genes = self.export_clean_genes_to_fasta(genes_of_interest, fasta_path)
+
+        if self.only_predict:
+            # make sure this checkpoint was built from exactly these sequences before predicting
+            self.load_and_validate_colabfold_checkpoint(out_dir, fasta_path)
 
         if self.only_msa:
             # generate the MSAs locally, record the checkpoint, and stop. No database is produced.
@@ -815,11 +826,8 @@ class StructureSuperclass(object):
                                  "database; it defaults to STRUCTURE.db)." % out_dir, nl_before=1, nl_after=1, mc='green')
             return
 
-        if self.only_predict:
-            # make sure this checkpoint was built from exactly these sequences before predicting
-            self.load_and_validate_colabfold_checkpoint(out_dir, fasta_path)
-
-        # run ColabFold (a full run does MSA + prediction; --only-predict skips straight to prediction)
+        # run ColabFold (a full run does MSA + prediction; --only-predict skips straight to prediction,
+        # so its fasta_path is ignored by the driver -- run_batch reads the checkpoint's .a3m directory)
         self.colabfold.process(fasta_path, out_dir)
 
         # parse each gene's output and store it

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -851,13 +851,28 @@ class StructureSuperclass(object):
                               "there is nothing to do. Please check the ColabFold log file in the output directory to "
                               "find out what happened. Bye :'(")
 
-        # clean up the ColabFold output directory (which now also holds the query FASTA) only when it was
-        # a temporary one -- i.e. when no --dump-dir was given -- and we are not debugging
-        if not anvio.DEBUG and not self.dump_dir and filesnpaths.is_file_exists(out_dir, dont_raise=True):
-            shutil.rmtree(out_dir, ignore_errors=True)
+        # clean up, unless the user is debugging. When no --dump-dir was given, out_dir is a temporary
+        # directory we own, so we remove it. When --dump-dir was given we leave it in place (the user
+        # asked to keep the raw output), but for --only-predict the query FASTA we regenerated lives in
+        # its own temp directory that we should still tidy up.
+        if not anvio.DEBUG:
+            if not self.dump_dir and filesnpaths.is_file_exists(out_dir, dont_raise=True):
+                shutil.rmtree(out_dir, ignore_errors=True)
+            elif self.only_predict and filesnpaths.is_file_exists(os.path.dirname(fasta_path), dont_raise=True):
+                shutil.rmtree(os.path.dirname(fasta_path), ignore_errors=True)
 
         self.structure_db.disconnect()
         self.run.info("Structure database", self.structure_db_path)
+
+        # we never delete a --dump-dir ourselves (the user asked to keep the raw output, and for the
+        # checkpoint flow they may still want the MSAs), but once the database is built its contents are
+        # no longer needed, so let the user know they can remove it if they like
+        if self.dump_dir:
+            self.run.info_single("Anvi'o kept the raw ColabFold output%s in '%s'. It is not needed now that the "
+                                 "structure database is built, so feel free to delete it if you want the space back "
+                                 "(anvi'o will not remove it for you)."
+                                 % (" (including the MSA checkpoint)" if self.only_predict else "", self.dump_dir),
+                                 nl_before=1, mc='yellow')
 
 
     def export_clean_genes_to_fasta(self, genes_of_interest, fasta_path):

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -806,8 +806,8 @@ class StructureSuperclass(object):
             self.write_colabfold_checkpoint_manifest(out_dir, clean_genes, fasta_path)
             self.run.info_single("The MSA step is done. Anvi'o wrote the multiple sequence alignments and a checkpoint "
                                  "manifest to '%s'. To predict structures from them, re-run this exact command with "
-                                 "--only-predict instead of --only-msa (and add -o for the output structure database)."
-                                 % out_dir, nl_before=1, nl_after=1, mc='green')
+                                 "--only-predict instead of --only-msa (optionally with -o to name the output structure "
+                                 "database; it defaults to STRUCTURE.db)." % out_dir, nl_before=1, nl_after=1, mc='green')
             return
 
         if self.only_predict:

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -513,6 +513,11 @@ class StructureSuperclass(object):
         A = lambda x, t: t(self.args.__dict__[x]) if x in self.args.__dict__ and self.args.__dict__[x] is not None else None
         null = lambda x: x
 
+        # --only-predict resumes from an --only-msa checkpoint, whose MSAs are always generated locally
+        # (the public server cannot be split), so the source is 'local' even though --colabfold-db is
+        # not re-supplied at prediction time
+        msa_source = 'local' if (A('colabfold_db', null) or self.only_predict) else 'server'
+
         return {
             'num_models': A('num_models', null),
             'num_recycle': A('num_recycle', null),

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -2,6 +2,8 @@
 """Classes to make sense of genes and variability within the context of protein structure"""
 
 import os
+import sys
+import glob
 import json
 import time
 import numpy as np
@@ -34,6 +36,7 @@ import anvio.drivers.colabfold as colabfold
 
 from anvio.errors import ConfigError, FilesNPathsError
 from anvio.dbops import ContigsSuperclass
+from anvio.version import structure_db_version
 
 J = lambda x, y: os.path.join(x, y)
 
@@ -329,6 +332,10 @@ class StructureSuperclass(object):
         exist
     """
 
+    # name of the manifest file an --only-msa run writes into --dump-dir, and that an --only-predict
+    # run reads back to verify it is resuming from the right MSAs (see run_colabfold_batch)
+    COLABFOLD_CHECKPOINT_FILENAME = 'colabfold_checkpoint.json'
+
     def __init__(self, args, create=False, run=terminal.Run(), progress=terminal.Progress()):
         self.args = args
         self.create = create
@@ -343,7 +350,11 @@ class StructureSuperclass(object):
         self.external_structures_path = A('external_structures', null)
         self.modeller_executable = A('modeller_executable', null)
         self.list_modeller_params = A('list_modeller_params', null)
-        self.full_modeller_output = A('dump_dir', null)
+
+        # --dump-dir is the directory where the raw, unabridged output of whichever prediction engine
+        # is in use is kept (MODELLER's per-gene output, or ColabFold's raw run). For the ColabFold
+        # checkpoint flags it doubles as the on-disk handoff between --only-msa and --only-predict.
+        self.dump_dir = A('dump_dir', null)
 
         # self.run_mode is determined further below, once the structure db is available (for updates,
         # the engine is read back from the db). self.engine records which prediction engine produced
@@ -359,6 +370,11 @@ class StructureSuperclass(object):
         self.gene_caller_ids = A('gene_caller_ids', null)
         self.rerun_genes = A('rerun_genes', null)
 
+        # ColabFold checkpoint flags (see run_colabfold_batch). --only-msa generates the MSAs and stops
+        # without producing a structure database; --only-predict resumes from those MSAs to build one.
+        self.only_msa = A('only_msa', bool)
+        self.only_predict = A('only_predict', bool)
+
         utils.is_contigs_db(self.contigs_db_path)
         contigs_db = dbops.ContigsDatabase(self.contigs_db_path)
         self.contigs_db_hash = contigs_db.meta['contigs_db_hash']
@@ -367,7 +383,9 @@ class StructureSuperclass(object):
         # init ContigsSuperClass
         self.contigs_super = ContigsSuperclass(self.args, r=terminal.Run(verbose=False), p=terminal.Progress(verbose=False))
 
-        if self.create:
+        # --only-msa stops after the MSA step and never produces a structure database, so it neither
+        # requires nor creates one. Every other mode sets up the structure db here.
+        if self.create and not self.only_msa:
             # check database output
             if not self.structure_db_path:
                 self.structure_db_path = "STRUCTURE.db"
@@ -378,9 +396,9 @@ class StructureSuperclass(object):
 
             filesnpaths.is_output_file_writable(self.structure_db_path)
 
-
-        # init StructureDatabase
-        self.structure_db = StructureDatabase(self.structure_db_path, self.contigs_db_hash, create_new=create)
+        # init StructureDatabase (skipped for --only-msa, which produces no database)
+        self.structure_db = None if self.only_msa else \
+            StructureDatabase(self.structure_db_path, self.contigs_db_hash, create_new=create)
 
         # determine the engine and the resulting run mode
         if self.create:
@@ -407,6 +425,13 @@ class StructureSuperclass(object):
 
             self.run_mode = 'external' if self.external_structures_path else 'modeller'
 
+        # the checkpoint flags only make sense for ColabFold, which is the only engine with a splittable
+        # MSA / prediction pipeline
+        if (self.only_msa or self.only_predict) and self.run_mode != 'colabfold':
+            raise ConfigError("--only-msa and --only-predict are specific to the ColabFold engine: they split "
+                              "ColabFold's MSA and prediction steps into a resumable checkpoint. Please add "
+                              "'--engine colabfold', or drop these flags.")
+
         if self.list_modeller_params:
             params_dict = self.structure_db.get_run_params_dict()
             for param, value in params_dict.items():
@@ -420,7 +445,7 @@ class StructureSuperclass(object):
         self.colabfold_params = self.get_colabfold_params() if self.run_mode == 'colabfold' else None
         self.skip_DSSP = A('skip_DSSP', bool)
 
-        if self.create:
+        if self.create and not self.only_msa:
             self.structure_db.db.set_meta_value('engine', self.engine)
             self.structure_db.store_modeller_params(self.modeller_params)
             if self.colabfold_params is not None:
@@ -538,10 +563,25 @@ class StructureSuperclass(object):
             # Check and populate modeller databases if required
             MODELLER.MODELLER(self.args, filesnpaths.get_temp_file_path(), check_db_only=True)
         elif self.run_mode == 'colabfold':
-            # refuse to overwrite an existing --dump-dir (it is where ColabFold's raw output will go)
-            if self.full_modeller_output and filesnpaths.is_file_exists(self.full_modeller_output, dont_raise=True):
-                raise ConfigError("The --dump-dir you provided ('%s') already exists. Anvi'o will not overwrite it. "
-                                  "Please provide a path that does not exist yet." % self.full_modeller_output)
+            # for the checkpoint flags, --dump-dir is the on-disk handoff between the two steps, so it
+            # is required: --only-msa writes the MSAs there, --only-predict reads them back from there
+            if (self.only_msa or self.only_predict) and not self.dump_dir:
+                raise ConfigError("--only-msa and --only-predict use --dump-dir as the on-disk checkpoint that "
+                                  "connects the MSA and prediction steps, so you must provide one. For --only-msa "
+                                  "it is where anvi'o writes the MSAs; for --only-predict it is where anvi'o reads "
+                                  "them back from.")
+
+            if self.only_predict:
+                # --only-predict must resume from an existing checkpoint directory
+                if not filesnpaths.is_file_exists(self.dump_dir, dont_raise=True):
+                    raise ConfigError("The --dump-dir you provided ('%s') does not exist. --only-predict resumes from "
+                                      "the MSA checkpoint that an earlier --only-msa run wrote there, so the directory "
+                                      "must already exist." % self.dump_dir)
+            else:
+                # a full run or --only-msa writes fresh ColabFold output; refuse to overwrite an existing dir
+                if self.dump_dir and filesnpaths.is_file_exists(self.dump_dir, dont_raise=True):
+                    raise ConfigError("The --dump-dir you provided ('%s') already exists. Anvi'o will not overwrite it. "
+                                      "Please provide a path that does not exist yet." % self.dump_dir)
 
             # instantiating the driver validates the conda env / ColabFold programs and the MSA source
             # choice, so we do it up front (once) and reuse it during the batched run. We pass our own
@@ -557,7 +597,7 @@ class StructureSuperclass(object):
         elif self.run_mode == 'external':
             self.run.info_single("Anvi'o will attempt to generate a database using external structures", nl_after=1, nl_before=1, mc='green')
 
-            if self.full_modeller_output:
+            if self.dump_dir:
                 raise ConfigError("No sense providing a --dump-dir when --external-structures are provided.")
 
             self.external_structures = ExternalStructuresFile(path=self.external_structures_path, contigs_db_path=self.contigs_db_path)
@@ -680,19 +720,19 @@ class StructureSuperclass(object):
             self.run.info('modeller_executable', self.modeller_executable)
             for param, value in self.modeller_params.items():
                 self.run.info(param, value)
-            self.run.info('dump_dir', self.full_modeller_output, nl_after=1)
+            self.run.info('dump_dir', self.dump_dir, nl_after=1)
 
         if self.run_mode == 'colabfold':
             self.run.warning('', header='ColabFold parameters', nl_after=0, lc='green')
             for param, value in self.colabfold_params.items():
                 self.run.info(param, value)
-            self.run.info('dump_dir', self.full_modeller_output, nl_after=1)
+            self.run.info('dump_dir', self.dump_dir, nl_after=1)
 
         if not anvio.DEBUG:
             self.run.warning("Do you want live info about how the modelling procedure is going for "
                              "each gene? Then restart this process with the --debug flag", lc='yellow')
 
-        if self.run_mode == 'modeller' and not self.full_modeller_output:
+        if self.run_mode == 'modeller' and not self.dump_dir:
             self.run.warning("When this finishes, do you want a potentially massive folder that "
                              "contains a murder of unorganized data in volumes that far exceed what "
                              "you could possibly want? Perfect, then restart this process and "
@@ -738,41 +778,43 @@ class StructureSuperclass(object):
         Unlike MODELLER (one process per gene), ColabFold is run once over a multi-sequence FASTA. The
         predictor batches internally and reuses the compiled model across sequences, which is far more
         efficient on a GPU. Per-gene output files are then located, parsed, and stored.
+
+        The optional checkpoint flags split this into two resumable steps: --only-msa runs only the
+        (CPU-heavy, local) MSA step and stops, and --only-predict resumes from those MSAs to run the
+        (GPU-heavy) prediction step and build the database. Genes are sorted so the query FASTA is
+        byte-identical across the two runs, which is how --only-predict confirms it is resuming from the
+        right MSAs (see load_and_validate_colabfold_checkpoint).
         """
 
-        genes_of_interest = list(genes_of_interest)
+        # sort so the FASTA is deterministic: its content hash is the checkpoint's integrity guard
+        genes_of_interest = sorted(genes_of_interest)
 
-        # export all genes of interest to a single amino acid FASTA; the header of each sequence is its
-        # gene caller id, which becomes the ColabFold 'jobname' and thus the prefix of its output files
-        self.progress.new('ColabFold')
-        self.progress.update('Preparing amino acid sequences ...')
-        _, aa_sequences = self.contigs_super.get_sequences_for_gene_callers_ids(genes_of_interest, report_aa_sequences=True)
-        self.progress.end()
+        # ColabFold writes its output files here. For --only-msa / --only-predict this is the (required,
+        # already-validated) --dump-dir checkpoint; for a full run it is --dump-dir if given, else a
+        # temporary directory.
+        out_dir = self.dump_dir or filesnpaths.get_temp_directory_path()
+        filesnpaths.gen_output_directory(out_dir, delete_if_exists=False, dont_warn=True)
 
-        fasta_path = os.path.join(filesnpaths.get_temp_directory_path(), 'genes_of_interest.fa')
+        # the query FASTA is part of the checkpoint (so --only-predict can regenerate it and compare),
+        # so it lives inside out_dir rather than a throwaway temp directory
+        fasta_path = os.path.join(out_dir, 'genes_of_interest.fa')
+        clean_genes = self.export_clean_genes_to_fasta(genes_of_interest, fasta_path)
 
-        clean_genes = []
-        with open(fasta_path, 'w') as fasta:
-            for gene in genes_of_interest:
-                sequence = aa_sequences[gene]['aa_sequence']
-                if not sequence:
-                    self.run.warning("Anvi'o could not find an amino acid sequence for gene ID %d, so it will be "
-                                     "skipped." % gene)
-                    continue
-                if self.skip_gene_if_not_clean(gene, sequence=sequence):
-                    continue
-                fasta.write('>%d\n%s\n' % (gene, sequence))
-                clean_genes.append(gene)
+        if self.only_msa:
+            # generate the MSAs locally, record the checkpoint, and stop. No database is produced.
+            self.colabfold.process(fasta_path, out_dir)
+            self.write_colabfold_checkpoint_manifest(out_dir, clean_genes, fasta_path)
+            self.run.info_single("The MSA step is done. Anvi'o wrote the multiple sequence alignments and a checkpoint "
+                                 "manifest to '%s'. To predict structures from them, re-run this exact command with "
+                                 "--only-predict instead of --only-msa (and add -o for the output structure database)."
+                                 % out_dir, nl_before=1, nl_after=1, mc='green')
+            return
 
-        if not clean_genes:
-            raise ConfigError("None of your genes of interest passed anvi'o's 'clean gene' checks, so there is nothing "
-                              "for ColabFold to predict. Bye :'(")
+        if self.only_predict:
+            # make sure this checkpoint was built from exactly these sequences before predicting
+            self.load_and_validate_colabfold_checkpoint(out_dir, fasta_path)
 
-        # ColabFold writes its output files here. If the user provided a --dump-dir we use it so they
-        # can inspect the raw ColabFold output, otherwise a temporary directory is used
-        out_dir = self.full_modeller_output or filesnpaths.get_temp_directory_path()
-
-        # run ColabFold end-to-end (MSA + prediction) over all clean genes at once
+        # run ColabFold (a full run does MSA + prediction; --only-predict skips straight to prediction)
         self.colabfold.process(fasta_path, out_dir)
 
         # parse each gene's output and store it
@@ -809,18 +851,116 @@ class StructureSuperclass(object):
                               "there is nothing to do. Please check the ColabFold log file in the output directory to "
                               "find out what happened. Bye :'(")
 
-        # clean up temporary files, unless the user is debugging. The query FASTA always lives in a temp
-        # directory; the ColabFold output directory is temporary only when the user did not ask to keep
-        # it with --dump-dir
-        if not anvio.DEBUG:
-            fasta_tmp_dir = os.path.dirname(fasta_path)
-            if filesnpaths.is_file_exists(fasta_tmp_dir, dont_raise=True):
-                shutil.rmtree(fasta_tmp_dir, ignore_errors=True)
-            if not self.full_modeller_output and filesnpaths.is_file_exists(out_dir, dont_raise=True):
-                shutil.rmtree(out_dir, ignore_errors=True)
+        # clean up the ColabFold output directory (which now also holds the query FASTA) only when it was
+        # a temporary one -- i.e. when no --dump-dir was given -- and we are not debugging
+        if not anvio.DEBUG and not self.dump_dir and filesnpaths.is_file_exists(out_dir, dont_raise=True):
+            shutil.rmtree(out_dir, ignore_errors=True)
 
         self.structure_db.disconnect()
         self.run.info("Structure database", self.structure_db_path)
+
+
+    def export_clean_genes_to_fasta(self, genes_of_interest, fasta_path):
+        """Write the amino-acid FASTA of 'clean' genes of interest for ColabFold and return the list of
+        gene caller ids actually written.
+
+        Each FASTA header is a gene caller id, which becomes the ColabFold 'jobname' (and thus the prefix
+        of that gene's output files). This is shared by the full run, --only-msa, and --only-predict, so
+        all three produce an identical FASTA for the same inputs.
+        """
+
+        self.progress.new('ColabFold')
+        self.progress.update('Preparing amino acid sequences ...')
+        _, aa_sequences = self.contigs_super.get_sequences_for_gene_callers_ids(genes_of_interest, report_aa_sequences=True)
+        self.progress.end()
+
+        clean_genes = []
+        with open(fasta_path, 'w') as fasta:
+            for gene in genes_of_interest:
+                sequence = aa_sequences[gene]['aa_sequence']
+                if not sequence:
+                    self.run.warning("Anvi'o could not find an amino acid sequence for gene ID %d, so it will be "
+                                     "skipped." % gene)
+                    continue
+                if self.skip_gene_if_not_clean(gene, sequence=sequence):
+                    continue
+                fasta.write('>%d\n%s\n' % (gene, sequence))
+                clean_genes.append(gene)
+
+        if not clean_genes:
+            raise ConfigError("None of your genes of interest passed anvi'o's 'clean gene' checks, so there is nothing "
+                              "for ColabFold to predict. Bye :'(")
+
+        return clean_genes
+
+
+    def write_colabfold_checkpoint_manifest(self, out_dir, clean_genes, fasta_path):
+        """Write the --only-msa checkpoint manifest into out_dir.
+
+        The manifest lets a later --only-predict run confirm it is resuming from the right MSAs. Its
+        integrity guard is query_fasta_hash: --only-predict regenerates the FASTA from its own inputs and
+        refuses to continue unless the hash matches. The rest of the fields are diagnostics.
+        """
+
+        manifest = {
+            'anvio_version': anvio.__version__,
+            'structure_db_version': structure_db_version,
+            'contigs_db_hash': self.contigs_db_hash,
+            'clean_genes': sorted(clean_genes),
+            'query_fasta_hash': utils.get_file_md5(fasta_path),
+            'msa_source': 'local',
+            'colabfold_db': self.args.__dict__.get('colabfold_db'),
+            'num_threads': self.num_threads,
+            'created_at': datetime.datetime.now().isoformat(),
+            'command_line': ' '.join(sys.argv),
+        }
+
+        manifest_path = os.path.join(out_dir, self.COLABFOLD_CHECKPOINT_FILENAME)
+        with open(manifest_path, 'w') as manifest_file:
+            json.dump(manifest, manifest_file, indent=2)
+
+
+    def load_and_validate_colabfold_checkpoint(self, out_dir, fasta_path):
+        """Verify that an --only-predict run is resuming from a checkpoint built from exactly its inputs.
+
+        fasta_path is the FASTA just regenerated from the current --contigs-db and genes of interest.
+        Raises ConfigError (with no override) on any mismatch, since predicting against MSAs that belong
+        to different sequences would silently produce structures glued to the wrong genes.
+        """
+
+        manifest_path = os.path.join(out_dir, self.COLABFOLD_CHECKPOINT_FILENAME)
+        if not filesnpaths.is_file_exists(manifest_path, dont_raise=True):
+            raise ConfigError("Anvi'o could not find a ColabFold MSA checkpoint (a '%s' file) in the --dump-dir you "
+                              "provided ('%s'). --only-predict resumes from the MSAs that an earlier --only-msa run "
+                              "wrote there, so you need to run that step first." %
+                              (self.COLABFOLD_CHECKPOINT_FILENAME, out_dir))
+
+        with open(manifest_path) as manifest_file:
+            manifest = json.load(manifest_file)
+
+        # friendly, specific check first: is this even the same contigs database?
+        if manifest.get('contigs_db_hash') != self.contigs_db_hash:
+            raise ConfigError("The contigs database you gave --only-predict does not match the one the MSA checkpoint "
+                              "in '%s' was built from (checkpoint hash '%s', yours '%s'). --only-predict must be run "
+                              "with the same --contigs-db as the --only-msa step." %
+                              (out_dir, manifest.get('contigs_db_hash'), self.contigs_db_hash))
+
+        # the authoritative guard: the sequences to predict must be byte-identical to those the MSAs were
+        # generated from
+        if manifest.get('query_fasta_hash') != utils.get_file_md5(fasta_path):
+            raise ConfigError("The genes and sequences --only-predict is about to work on do not match the ones the MSA "
+                              "checkpoint in '%s' was built from. This usually means the genes of interest changed, the "
+                              "genes were re-called, or the contigs database was edited between the --only-msa and "
+                              "--only-predict steps. Because ColabFold's MSAs are tied to the exact sequences they were "
+                              "generated from, anvi'o will not predict structures against a mismatched checkpoint. If "
+                              "your input really has changed, re-run --only-msa to regenerate the MSAs." % out_dir)
+
+        # finally, make sure the MSAs are actually present
+        msa_dir = os.path.join(out_dir, 'msas')
+        if not os.path.isdir(msa_dir) or not len(glob.glob(os.path.join(msa_dir, '*.a3m'))):
+            raise ConfigError("The MSA checkpoint in '%s' does not contain any MSA (.a3m) files under a 'msas/' "
+                              "subdirectory. The --only-msa step may not have finished successfully. Please re-run it "
+                              "before --only-predict." % out_dir)
 
 
     def process_colabfold_gene(self, corresponding_gene_call, out_dir):
@@ -1244,15 +1384,15 @@ class StructureSuperclass(object):
 
 
     def dump_raw_results(self, structure_info):
-        """Dump all raw modeller output into output_gene_dir if self.full_modeller_output"""
+        """Dump all raw modeller output into output_gene_dir if a --dump-dir (self.dump_dir) was given"""
 
-        if not self.full_modeller_output:
+        if not self.dump_dir:
             return
 
         if 'results' not in structure_info:
             return
 
-        output_gene_dir = os.path.join(self.full_modeller_output, structure_info['results']['corresponding_gene_call'])
+        output_gene_dir = os.path.join(self.dump_dir, structure_info['results']['corresponding_gene_call'])
         shutil.move(structure_info['results']['directory'], output_gene_dir)
 
 

--- a/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
+++ b/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
@@ -10,7 +10,7 @@ make_structure_db() {
                                 --very-fast \
                                 --debug \
                                 --alignment-fraction-cutoff 0.7 \
-                                --num-threads 2 \
+                                $thread_controller \
                                 --num-models 1
 }
 # Predict structures with ColabFold instead of MODELLER. This is opt-in: it only runs when the
@@ -31,6 +31,7 @@ make_structure_db_colabfold() {
                                 --num-models 1 \
                                 --dump-dir test-output/RAW_COLABFOLD_OUTPUT \
                                 --output-db-path test-output/STRUCTURE_COLABFOLD.db \
+                                $thread_controller \
                                 --debug
 }
 # Exercise the --only-msa / --only-predict checkpoint that splits a ColabFold run into its (local,
@@ -53,6 +54,7 @@ make_structure_db_colabfold_checkpoint() {
                                 --num-models 1 \
                                 --dump-dir test-output/COLABFOLD_CHECKPOINT \
                                 --only-msa \
+                                $thread_controller \
                                 --debug
 
     for expected in test-output/COLABFOLD_CHECKPOINT/genes_of_interest.fa \
@@ -75,6 +77,7 @@ make_structure_db_colabfold_checkpoint() {
                                 --dump-dir test-output/COLABFOLD_CHECKPOINT \
                                 --only-predict \
                                 --output-db-path test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db \
+                                $thread_controller \
                                 --debug
 
     if [ ! -f "test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db" ]
@@ -206,6 +209,10 @@ then
         'make'    : make structure db, profile varability, open interactive.
         'display' : profile varability, open interactive.
 
+        You can pass the number of threads as an optional second argument (defaults to 1), e.g.:
+
+            bash run_component_tests_for_SCVs_SAAVs_structure.sh new 8
+
         To additionally exercise the ColabFold engine, set the COLABFOLD_CONDA_ENV environment
         variable to the name of a conda environment in which ColabFold is installed, e.g.:
 
@@ -222,12 +229,23 @@ then
         exit -1
 fi
 
-if [ $# -gt 1  ]
+if [ $# -gt 2  ]
 then
       echo "
-        This scripts expect only one argument ('new', or 'continue').
+        This script expects at most two arguments: the mode ('new', 'make', or 'display') and,
+        optionally, the number of threads to use (defaults to 1).
         "
         exit -1
+fi
+
+# optional second argument: how many threads the anvi-gen-structure-database steps should use. When it
+# is omitted the commands run single-threaded (see 00.sh for the same pattern in other component
+# tests). Threading mostly helps the MODELLER runs and ColabFold's (CPU-heavy) MSA step.
+if [ -z "$2" ]
+then
+    thread_controller=""
+else
+    thread_controller="--num-threads $2"
 fi
 
 if [ $1 = "new"  ]

--- a/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
+++ b/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
@@ -33,6 +33,53 @@ make_structure_db_colabfold() {
                                 --output-db-path test-output/STRUCTURE_COLABFOLD.db \
                                 --debug
 }
+# Exercise the --only-msa / --only-predict checkpoint that splits a ColabFold run into its (local,
+# CPU-heavy) MSA step and its (GPU-heavy) prediction step. This is a further opt-in on top of
+# COLABFOLD_CONDA_ENV: it also needs a *local* ColabFold database, because the MSA step cannot be split
+# out when using the public MSA server. Point COLABFOLD_DB at the directory you set up with ColabFold's
+# `setup_databases.sh`. When COLABFOLD_DB is unset, this routine is skipped.
+#
+# For example:
+#     COLABFOLD_CONDA_ENV=colabfold COLABFOLD_DB=/path/to/colabfold_db \
+#         bash run_component_tests_for_SCVs_SAAVs_structure.sh new
+make_structure_db_colabfold_checkpoint() {
+    # step 1: MSA only. Produces the .a3m files + a checkpoint manifest in --dump-dir, and no db.
+    anvi-gen-structure-database -c test-output/one_contig_five_genes.db \
+                                --engine colabfold \
+                                --colabfold-conda-env "$COLABFOLD_CONDA_ENV" \
+                                --colabfold-db "$COLABFOLD_DB" \
+                                --skip-DSSP \
+                                --gene-caller-ids 2 \
+                                --num-models 1 \
+                                --dump-dir test-output/COLABFOLD_CHECKPOINT \
+                                --only-msa \
+                                --debug
+
+    for expected in test-output/COLABFOLD_CHECKPOINT/genes_of_interest.fa \
+                    test-output/COLABFOLD_CHECKPOINT/colabfold_checkpoint.json
+    do
+        if [ ! -f "$expected" ]; then echo "FAIL: --only-msa did not produce $expected"; exit 1; fi
+    done
+    if ! ls test-output/COLABFOLD_CHECKPOINT/msas/*.a3m >/dev/null 2>&1
+    then echo "FAIL: --only-msa did not produce any MSA (.a3m) files"; exit 1; fi
+    if [ -f "test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db" ]
+    then echo "FAIL: --only-msa should not have produced a structure database"; exit 1; fi
+
+    # step 2: predict only, resuming from the checkpoint written above. Same contigs-db + genes.
+    anvi-gen-structure-database -c test-output/one_contig_five_genes.db \
+                                --engine colabfold \
+                                --colabfold-conda-env "$COLABFOLD_CONDA_ENV" \
+                                --skip-DSSP \
+                                --gene-caller-ids 2 \
+                                --num-models 1 \
+                                --dump-dir test-output/COLABFOLD_CHECKPOINT \
+                                --only-predict \
+                                --output-db-path test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db \
+                                --debug
+
+    if [ ! -f "test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db" ]
+    then echo "FAIL: --only-predict did not produce the structure database"; exit 1; fi
+}
 gen_var_profile1() {
     anvi-gen-variability-profile -p test-output/SAMPLES-MERGED/PROFILE.db \
                                  -c test-output/one_contig_five_genes.db \
@@ -110,6 +157,14 @@ EOF
     then
         INFO "anvi-gen-structure-database with ColabFold (conda env: $COLABFOLD_CONDA_ENV)"
         make_structure_db_colabfold
+
+        # exercise the --only-msa / --only-predict checkpoint only when a local ColabFold database is
+        # also available (the MSA step cannot be split out when using the public server)
+        if [ -n "$COLABFOLD_DB" ]
+        then
+            INFO "anvi-gen-structure-database ColabFold --only-msa / --only-predict checkpoint (local db: $COLABFOLD_DB)"
+            make_structure_db_colabfold_checkpoint
+        fi
     fi
 }
 
@@ -157,6 +212,12 @@ then
             COLABFOLD_CONDA_ENV=colabfold bash run_component_tests_for_SCVs_SAAVs_structure.sh new
 
         This requires internet access and is slow without a GPU (~10 min per protein on a CPU).
+
+        To also exercise the --only-msa / --only-predict checkpoint, additionally set COLABFOLD_DB to
+        the local ColabFold database directory you set up with ColabFold's setup_databases.sh, e.g.:
+
+            COLABFOLD_CONDA_ENV=colabfold COLABFOLD_DB=/path/to/colabfold_db \\
+                bash run_component_tests_for_SCVs_SAAVs_structure.sh new
         "
         exit -1
 fi
@@ -234,6 +295,8 @@ then
     rm -rf test-output/exported_pdbs
     rm -rf test-output/STRUCTURE_COLABFOLD.db
     rm -rf test-output/RAW_COLABFOLD_OUTPUT
+    rm -rf test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db
+    rm -rf test-output/COLABFOLD_CHECKPOINT
 
     make_routine
     display_routine


### PR DESCRIPTION
Third PR regarding the integration of ColabFold (follows #2755 and #2759).
Colabfold has two distinct halves: the MSA generation (CPU heavy) and the structure prediction with AlphaFold2 (GPU heavy). And when you scale to many protein prediction, you may want to run these two step separately on different machinery with dedicated resources. 

So we add two flags to `anvi-gen-structure-database`: 
- `--only-msa` runs the MSA step and stops. The intermediary files and a manifest json are stored in the --dump-dir (required flag in this mode). No structure generated here. Only work with a local colabfold database as the public MSA server is fused with the prediction and cannot be split.
- `--only-predict` resumes from `--only-msa` checkpoint, predict structure and generate the structure database.

The checkpoint guard:
`--only-predict` takes the same contigs.db and gene of interest as the `--only-msa` counterpart. Before the prediction, it checks the fasta and contigs.db hash against the manifest and any mismatch, like a different contigs.db, different gene selection, or even edited genes is a hard error. WE DON'T WANT TO SILENTLY PRODUCE GARBAGE.

Testing needed:
- [x] run on server with local colabfold database (untestable locally)
  - [x] --only-msa
  - [x] --only-predict