### PR TITLE
Fix race condition for MODELLER database build

### DIFF
--- a/anvio/drivers/MODELLER.py
+++ b/anvio/drivers/MODELLER.py
@@ -644,8 +644,11 @@ class MODELLER:
         self.copy_script_to_directory(script_name)
 
         input_pir_path = J(self.database_dir, self.modeller_database + '.pir')
-        fasta_path = J(self.database_dir, self.modeller_database + '.fa')
-        dmnd_path = J(self.database_dir, self.modeller_database)
+
+        # use a process-unique intermediate FASTA so that concurrent gen-structure-database workers
+        # never read or delete one another's file (a shared path here previously raised
+        # FileNotFoundError when one worker removed the FASTA while another was still reading it)
+        fasta_path = filesnpaths.get_temp_file_path()
 
         command = [self.executable,
                    script_name,
@@ -667,14 +670,24 @@ class MODELLER:
         fasta.close()
         temp.close()
 
+        # build the DIAMOND db under a process-unique base in the same directory as the final db,
+        # then move it into place with an atomic (same-filesystem) rename so that any other process
+        # only ever observes a complete .dmnd file
+        dmnd_build_base = J(self.database_dir, "%s.%d" % (self.modeller_database, os.getpid()))
+
         driver = diamond.Diamond(
             query_fasta=fasta_path,
             run=terminal.Run(verbose=False),
             progress=terminal.Progress(verbose=False),
         )
-        driver.makedb(output_file_path=dmnd_path)
 
-        os.remove(fasta_path)
+        try:
+            driver.makedb(output_file_path=dmnd_build_base)
+            os.rename(dmnd_build_base + '.dmnd', dmnd_db_path)
+        finally:
+            for leftover in (fasta_path, dmnd_build_base + '.dmnd'):
+                if os.path.exists(leftover):
+                    os.remove(leftover)
 
 
     def run_binarize_database(self, pir_db_path, bin_db_path):
@@ -697,15 +710,25 @@ class MODELLER:
         # check script exists, then copy the script into the working directory
         self.copy_script_to_directory(script_name)
 
+        # binarize into a process-unique path in the destination directory, then move it into place
+        # with an atomic (same-filesystem) rename so that concurrent gen-structure-database workers
+        # never observe a partially written .bin
+        bin_build_path = "%s.%d" % (bin_db_path, os.getpid())
+
         command = [self.executable,
                    script_name,
                    pir_db_path,
-                   bin_db_path]
+                   bin_build_path]
 
-        self.run_command(command,
-                         script_name=script_name,
-                         check_output=[bin_db_path],
-                         rename_log=False)
+        try:
+            self.run_command(command,
+                             script_name=script_name,
+                             check_output=[bin_build_path],
+                             rename_log=False)
+            os.rename(bin_build_path, bin_db_path)
+        finally:
+            if os.path.exists(bin_build_path):
+                os.remove(bin_build_path)
 
         self.run.info("New database", bin_db_path)
 

--- a/anvio/drivers/diamond.py
+++ b/anvio/drivers/diamond.py
@@ -112,6 +112,12 @@ class Diamond:
 
         expected_output = (output_file_path or self.target_fasta) + '.dmnd'
 
+        if not os.path.exists(expected_output):
+            raise ConfigError("Something went wrong while anvi'o was trying to build a DIAMOND search database: the "
+                              "expected output file '%s' is not there after running `%s`. Please take a look at the "
+                              "log file '%s' for clues about what may have gone wrong." \
+                                    % (expected_output, ' '.join([str(x) for x in cmd_line]), self.run.log_file_path))
+
         self.run.info('Command line', ' '.join([str(x) for x in cmd_line]), quiet=True)
         self.run.info('Diamond search DB', expected_output)
 

--- a/anvio/drivers/diamond.py
+++ b/anvio/drivers/diamond.py
@@ -115,7 +115,7 @@ class Diamond:
         if not os.path.exists(expected_output):
             raise ConfigError("Something went wrong while anvi'o was trying to build a DIAMOND search database: the "
                               "expected output file '%s' is not there after running `%s`. Please take a look at the "
-                              "log file '%s' for clues about what may have gone wrong." \
+                              "log file '%s' for clues about what may have gone wrong."
                                     % (expected_output, ' '.join([str(x) for x in cmd_line]), self.run.log_file_path))
 
         self.run.info('Command line', ' '.join([str(x) for x in cmd_line]), quiet=True)

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -535,8 +535,21 @@ class StructureSuperclass(object):
             self.modeller_executable = self.args.modeller_executable
             self.run.info_single("Anvi'o found the MODELLER executable %s, so will use it" % self.modeller_executable, nl_after=1, nl_before=1, mc='green')
 
-            # Check and populate modeller databases if required
+            # Check and populate modeller databases if required. This builds the databases once, in
+            # the main thread, so that the parallel workers spawned later find them ready and never
+            # race to build them concurrently.
             MODELLER.MODELLER(self.args, filesnpaths.get_temp_file_path(), check_db_only=True)
+
+            # Verify the pre-build above actually left a complete database in place. If a build step
+            # (binarization or DIAMOND makedb) failed silently, surface it here as a clear error
+            # instead of letting the parallel workers re-enter the build and fail obscurely.
+            modeller_database = self.modeller_params['modeller_database']
+            for db_file in [J(constants.default_modeller_database_dir, modeller_database + ext) for ext in ['.bin', '.dmnd']]:
+                if not os.path.exists(db_file):
+                    raise ConfigError("Anvi'o tried to set up the MODELLER database before modelling structures, but "
+                                      "the expected file '%s' is not there afterwards. This usually means the database "
+                                      "build (binarization or DIAMOND makedb) did not complete. Please take a look at "
+                                      "the binarize_database / diamond makedb output above for clues." % db_file)
         elif self.run_mode == 'colabfold':
             # refuse to overwrite an existing --dump-dir (it is where ColabFold's raw output will go)
             if self.full_modeller_output and filesnpaths.is_file_exists(self.full_modeller_output, dont_raise=True):


### PR DESCRIPTION
While working on #2760, ran into this error (component test):

```
:: anvi-gen-structure-database with DSSP ...


CITATION
===============================================
Anvi'o will use 'MODELLER' by Webb and Sali (DOI: 10.1002/cpbi.3) to model
protein structures. If you publish your findings, please do not forget to
properly credit their work.


* Anvi'o found the MODELLER executable mod10.8, so will use it


WARNING
===============================================
Your database is not in binary format. That means accessing its contents is
slower than it could be. Anvi'o is going to make a binary format. Just FYI

Log of binarize_database.py ..................: binarize_database.log
New database .................................: /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95.bin

WARNING
===============================================
Your diamond database does not exist. It will be created.

Log of pir_to_fasta.py .......................: pir_to_fasta.log

[DEBUG] `run_command` is running .............: diamond makedb --in /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95.fa -d
                                                /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95 -p 1


General info
===============================================
contigs_db ...................................: test-output/one_contig_five_genes.db
contigs_db_hash ..............................: hash67c4a1fa
structure_db_path ............................: test-output/STRUCTURE.db
num_threads ..................................: 2
write_buffer_size ............................: 25
genes_of_interest ............................: None
gene_caller_ids ..............................: 2,4
skip_DSSP ....................................: False
run_mode .....................................: modeller

Modeller parameters
===============================================
modeller_executable ..........................: mod10.8
modeller_database ............................: pdb_95
scoring_method ...............................: DOPE_score
max_number_templates .........................: 5
percent_cutoff ...............................: 30
alignment_fraction_cutoff ....................: 0.7
num_models ...................................: 1
deviation ....................................: 4.0
very_fast ....................................: True
dump_dir .....................................: test-output/RAW_MODELLER_OUTPUT

Log of fasta_to_pir.py .......................: gene_4_fasta_to_pir.log
Target alignment file ........................: 4.pir

WARNING
===============================================
Your diamond database does not exist. It will be created.

Log of fasta_to_pir.py .......................: gene_2_fasta_to_pir.log
Target alignment file ........................: 2.pir

WARNING
===============================================
Your diamond database does not exist. It will be created.

Log of pir_to_fasta.py .......................: pir_to_fasta.log
Log of pir_to_fasta.py .......................: pir_to_fasta.log

[DEBUG] `run_command` is running .............: diamond makedb --in /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95.fa -d
                                                /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95 -p 1


[DEBUG] `run_command` is running .............: diamond makedb --in /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95.fa -d
                                                /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95 -p 1


[DEBUG] `run_command` is running .............: diamond blastp -q /tmp/tmp9u260z2b -d /fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95.dmnd -o
                                                diamond-search-results.txt -t /tmp -p 1 --outfmt 6 qseqid sseqid pident length mismatch gaps gapopen qstart qend sstart send evalue bitscore
                                                --max-target-seqs 100000 --evalue 1e-05



ID 2 Time Report
===============================================
PDB DB loaded ................................: +0:00:42.183783
Converted gene FASTA to PIR ..................: +0:00:00.207136
Total elapsed ................................: =0:00:42.390919

✖ gen_structure_database.py encountered an error after 0:02:22.137324
Traceback (most recent call last):
  File "/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/VIRTUAL_ENVS/anvio-flo/bin/anvi-gen-structure-database", line 6, in <module>
    sys.exit(main())
  File "/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/terminal.py", line 930, in wrapper
    program_method(*args, **kwargs)
  File "/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/cli/gen_structure_database.py", line 37, in main
    structops.StructureSuperclass(args, create=True)._run()
  File "/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/structureops.py", line 777, in _run
    self.run_multi_thread(genes_of_interest) if self.num_threads > 1 else self.run_single_thread(genes_of_interest)
  File "/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/structureops.py", line 1166, in run_multi_thread
    raise worker_error
  File "/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/structureops.py", line 1118, in run_multi_thread
    raise structure_info
FileNotFoundError: [Errno 2] No such file or directory: '/fs/s6k/groups/agecodatasci/PEOPLE/FlorianTrigodet/SOFTWARE/anvio/anvio/data/misc/MODELLER/db/pdb_95.fa'
```

Turns out it was a race issue where workers build concurrently and delete the file too. Diamond was never checking if the .dmd was actually there after building (fixed that too).