### PR TITLE
Update structure db colabfold

### DIFF
--- a/anvio/cli/update_structure_database.py
+++ b/anvio/cli/update_structure_database.py
@@ -46,6 +46,12 @@ def get_args():
                                                 'Otherwise, an error will be raised.')
     groupO = parser.add_argument_group('OUTPUT', 'Output file and output style.')
     groupM = parser.add_argument_group('MODELLER PARAMS', 'Parameters for MODELLER\'s homology modeling.')
+    groupC = parser.add_argument_group('COLABFOLD PARAMS', 'Parameters for structure prediction with ColabFold '
+                                       '(AlphaFold2). These only apply when the structure database you are updating '
+                                       'was created with the ColabFold engine. The scientific parameters (number of '
+                                       'models, recycles, Amber relaxation, etc.) are read back from the database so '
+                                       'the update stays consistent with how it was created; the parameters below are '
+                                       'machine-specific and so must be provided again here.')
     groupE = parser.add_argument_group('EXTRA', 'Everything else.')
 
     groupD.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
@@ -56,6 +62,35 @@ def get_args():
     groupO.add_argument(*anvio.A('dump-dir'), **anvio.K('dump-dir'))
     groupM.add_argument('--list-modeller-params', action='store_true', help='Since you are updating an existing DB, modeller params are set in '
                                                                             'place. You can have this program list them by providing this flag')
+
+    groupC.add_argument("--colabfold-conda-env", type=str, default=None, metavar='ENV_NAME', help =
+                        """The name of the conda environment in which ColabFold (colabfold_batch /
+                        colabfold_search) is installed. Anvi'o will run every ColabFold command via
+                        `conda run -n ENV_NAME`. If you leave this blank, anvi'o will assume the ColabFold
+                        programs are directly available (e.g. on your $PATH).""")
+    groupC.add_argument("--colabfold-msa-server", action='store_true', help =
+                        """Use the public MMseqs2 MSA server hosted by the ColabFold team to generate the
+                        multiple sequence alignment (MSA) step online. Provide this if the database you are
+                        updating was created this way. Mutually exclusive with --colabfold-db.""")
+    groupC.add_argument("--colabfold-db", type=str, default=None, metavar='DB_DIR', help =
+                        """Generate the MSA step locally by searching a local ColabFold database in this
+                        directory (the one you set up with ColabFold's `setup_databases.sh`). Provide this
+                        if the database you are updating was created this way. This path is machine-specific,
+                        so it is not stored in the structure database and must be given again here. Mutually
+                        exclusive with --colabfold-msa-server.""")
+    groupC.add_argument("--only-msa", action='store_true', help =
+                        """Run only ColabFold's multiple sequence alignment (MSA) step for the genes you are
+                        adding and stop, writing the MSAs and a small checkpoint manifest into --dump-dir. This
+                        creates a resumable checkpoint so you can run the CPU-heavy MSA step and the GPU-heavy
+                        prediction step separately (e.g. on different cluster nodes). This only works with a
+                        local ColabFold database (--colabfold-db). No genes are added to the database in this
+                        mode; you finish the job later with --only-predict. Requires --dump-dir.""")
+    groupC.add_argument("--only-predict", action='store_true', help =
+                        """Skip the MSA step and predict structures from an MSA checkpoint that an earlier
+                        --only-msa run wrote to --dump-dir, then add the resulting structures to the database.
+                        You must provide the SAME --contigs-db and genes of interest as the --only-msa run.
+                        Requires --dump-dir (pointing at the --only-msa output). Mutually exclusive with
+                        --only-msa.""")
 
     groupE.add_argument("--rerun-genes", action='store_true', help =
                         """Supply if you would like to rerun structural modelling for your genes of

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -109,6 +109,23 @@ class StructureDatabase(object):
         return run_params_dict
 
 
+    def get_colabfold_run_params_dict(self):
+        """Return the ColabFold run parameters that were stored during the creation of this DB.
+
+        These mirror the scientific-provenance parameters written by StructureSuperclass.get_colabfold_params.
+        The machine-specific parameters (conda env, local database path, MSA-server flag) are intentionally
+        not stored, so they are absent here and must be re-supplied on the command line during an update.
+        """
+
+        return {
+            'num_models': self.db.get_meta_value('num_models', try_as_type_int=True),
+            'num_recycle': self.db.get_meta_value('num_recycle', try_as_type_int=True, return_none_if_not_in_table=True),
+            'amber': bool(self.db.get_meta_value('amber', try_as_type_int=True)),
+            'colabfold_msa_source': self.db.get_meta_value('colabfold_msa_source', try_as_type_int=False),
+            'colabfold_additional_parameters': self.db.get_meta_value('colabfold_additional_parameters', try_as_type_int=False, return_none_if_not_in_table=True),
+        }
+
+
     def get_genes_with_structure(self):
         """Returns set of gene caller ids that have a structure in the DB, queried from self table"""
 
@@ -396,8 +413,11 @@ class StructureSuperclass(object):
 
             filesnpaths.is_output_file_writable(self.structure_db_path)
 
-        # init StructureDatabase (skipped for --only-msa, which produces no database)
-        self.structure_db = None if self.only_msa else \
+        # init StructureDatabase. In create mode, --only-msa produces no database, so none is opened.
+        # In update mode the database already exists and we always open it, even for --only-msa, because
+        # we need to read back the engine and run parameters it was created with (--only-msa still writes
+        # nothing to it: run_colabfold_batch returns before the storing step).
+        self.structure_db = None if (self.create and self.only_msa) else \
             StructureDatabase(self.structure_db_path, self.contigs_db_hash, create_new=create)
 
         # determine the engine and the resulting run mode
@@ -415,25 +435,29 @@ class StructureSuperclass(object):
                 self.run_mode = 'modeller'
             self.engine = self.run_mode
         else:
-            # updating an existing db: honor whatever engine it was created with
+            # updating an existing db: honor whatever engine it was created with (unless the user is
+            # importing external structures, which bypasses the prediction engine entirely)
             self.engine = self.structure_db.db.get_meta_value('engine', return_none_if_not_in_table=True) or 'modeller'
+            self.run_mode = 'external' if self.external_structures_path else self.engine
 
-            if self.engine == 'colabfold':
-                raise ConfigError("This structure database was created with the ColabFold engine. Updating ColabFold "
-                                  "structure databases (adding or re-running genes) is not supported yet. Please create "
-                                  "a new database with anvi-gen-structure-database instead.")
-
-            self.run_mode = 'external' if self.external_structures_path else 'modeller'
+            # ColabFold parameters only make sense when updating a ColabFold database. Flag them clearly
+            # rather than silently ignoring them (e.g. if the user aimed a ColabFold command at a MODELLER db)
+            if self.run_mode != 'colabfold' and (A('colabfold_conda_env', null) or A('colabfold_db', null) or A('colabfold_msa_server', bool)):
+                raise ConfigError("You provided ColabFold parameters, but this structure database was created with the "
+                                  "'%s' engine, not ColabFold. Anvi'o updates a database with the same engine it was "
+                                  "created with, so these parameters do not apply here." % self.engine)
 
         # the checkpoint flags only make sense for ColabFold, which is the only engine with a splittable
         # MSA / prediction pipeline
         if (self.only_msa or self.only_predict) and self.run_mode != 'colabfold':
+            engine_hint = ("this structure database was created with the '%s' engine, not ColabFold" % self.engine) \
+                          if not self.create else "please add '--engine colabfold', or drop these flags"
             raise ConfigError("--only-msa and --only-predict are specific to the ColabFold engine: they split "
-                              "ColabFold's MSA and prediction steps into a resumable checkpoint. Please add "
-                              "'--engine colabfold', or drop these flags.")
+                              "ColabFold's MSA and prediction steps into a resumable checkpoint. But %s." % engine_hint)
 
         if self.list_modeller_params:
-            params_dict = self.structure_db.get_run_params_dict()
+            params_dict = self.structure_db.get_colabfold_run_params_dict() if self.engine == 'colabfold' \
+                          else self.structure_db.get_run_params_dict()
             for param, value in params_dict.items():
                 self.run.info(param, value)
             import sys; sys.exit()
@@ -508,15 +532,30 @@ class StructureSuperclass(object):
 
         The conda environment name and local database path are intentionally not stored: they are
         machine-specific and not part of the scientific provenance of the structures.
+
+        Notes
+        =====
+        - If self.create=False, the scientific parameters accessed by this function are first restored
+          from the database into self.args via self.set_prior_colabfold_params (mirroring how
+          get_modeller_params relies on self.set_prior_modeller_params).
         """
+
+        if not self.create:
+            # updating an existing db: restore the scientific params it was created with, and reconcile
+            # the machine-specific MSA source the user supplied on the command line with the stored one
+            self.set_prior_colabfold_params()
 
         A = lambda x, t: t(self.args.__dict__[x]) if x in self.args.__dict__ and self.args.__dict__[x] is not None else None
         null = lambda x: x
 
-        # --only-predict resumes from an --only-msa checkpoint, whose MSAs are always generated locally
-        # (the public server cannot be split), so the source is 'local' even though --colabfold-db is
-        # not re-supplied at prediction time
-        msa_source = 'local' if (A('colabfold_db', null) or self.only_predict) else 'server'
+        if not self.create:
+            # the MSA source was fixed when the db was created; it is authoritative on update
+            msa_source = self.structure_db.db.get_meta_value('colabfold_msa_source', try_as_type_int=False)
+        else:
+            # --only-predict resumes from an --only-msa checkpoint, whose MSAs are always generated
+            # locally (the public server cannot be split), so the source is 'local' even though
+            # --colabfold-db is not re-supplied at prediction time
+            msa_source = 'local' if (A('colabfold_db', null) or self.only_predict) else 'server'
 
         return {
             'num_models': A('num_models', null),
@@ -539,6 +578,55 @@ class StructureSuperclass(object):
         run_params_dict = self.structure_db.get_run_params_dict()
         for param, value in run_params_dict.items():
             setattr(self.args, param, value)
+
+
+    def set_prior_colabfold_params(self):
+        """Restore the ColabFold run parameters from the database into self.args, and reconcile the
+        machine-specific MSA source the user supplied on the command line with the one stored in the db.
+
+        Like set_prior_modeller_params, this keeps an update consistent with how the database was
+        created: the scientific parameters (num_models, num_recycle, amber, additional parameters) come
+        from the db. The MSA source location, however, is machine-specific and was not stored, so the
+        user must re-supply it on the command line -- and anvi'o refuses to switch the source (local vs.
+        server) an existing database was built with, since that would mix provenance within one db.
+        """
+
+        run_params_dict = self.structure_db.get_colabfold_run_params_dict()
+        stored_source = run_params_dict.pop('colabfold_msa_source')
+
+        for param, value in run_params_dict.items():
+            setattr(self.args, param, value)
+
+        A = lambda x, t: t(self.args.__dict__[x]) if x in self.args.__dict__ and self.args.__dict__[x] is not None else None
+        null = lambda x: x
+
+        # --only-predict resumes from a local MSA checkpoint on disk regardless of how the db was built,
+        # so it needs no MSA source and there is nothing to reconcile here
+        if self.only_predict:
+            return
+
+        user_local_db = A('colabfold_db', null)
+        user_msa_server = A('colabfold_msa_server', bool)
+
+        if stored_source == 'local':
+            if user_msa_server:
+                raise ConfigError("This structure database was created by generating the MSA step locally (with a "
+                                  "local ColabFold database), but you asked to update it with the public MSA server "
+                                  "(--colabfold-msa-server). Anvi'o will not mix MSA sources within a single database. "
+                                  "Please update it with --colabfold-db pointing to a local ColabFold database instead.")
+            if not user_local_db:
+                raise ConfigError("This structure database was created by generating the MSA step locally, so updating "
+                                  "it also requires a local ColabFold database. The database path is machine-specific "
+                                  "and is not stored in the structure database, so you must provide it now with "
+                                  "--colabfold-db (the directory you set up with ColabFold's `setup_databases.sh`).")
+        else:
+            # stored_source == 'server'
+            if user_local_db:
+                raise ConfigError("This structure database was created using the public MSA server, but you provided a "
+                                  "local ColabFold database (--colabfold-db) to update it. Anvi'o will not mix MSA "
+                                  "sources within a single database. Please update it with --colabfold-msa-server instead.")
+            # the source is fixed by the db, so anvi'o sets the server flag for the user
+            self.args.colabfold_msa_server = True
 
 
     def sanity_check(self):

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -443,6 +443,10 @@ class StructureSuperclass(object):
             # ColabFold parameters only make sense when updating a ColabFold database. Flag them clearly
             # rather than silently ignoring them (e.g. if the user aimed a ColabFold command at a MODELLER db)
             if self.run_mode != 'colabfold' and (A('colabfold_conda_env', null) or A('colabfold_db', null) or A('colabfold_msa_server', bool)):
+                if self.external_structures_path:
+                    raise ConfigError("You provided ColabFold parameters, but you also passed --external-structures, "
+                                      "which imports pre-computed structures and bypasses ColabFold (and any prediction "
+                                      "engine) entirely. Please drop the ColabFold parameters.")
                 raise ConfigError("You provided ColabFold parameters, but this structure database was created with the "
                                   "'%s' engine, not ColabFold. Anvi'o updates a database with the same engine it was "
                                   "created with, so these parameters do not apply here." % self.engine)
@@ -450,10 +454,14 @@ class StructureSuperclass(object):
         # the checkpoint flags only make sense for ColabFold, which is the only engine with a splittable
         # MSA / prediction pipeline
         if (self.only_msa or self.only_predict) and self.run_mode != 'colabfold':
-            engine_hint = ("this structure database was created with the '%s' engine, not ColabFold" % self.engine) \
-                          if not self.create else "please add '--engine colabfold', or drop these flags"
+            if self.external_structures_path:
+                reason = "you also passed --external-structures, which imports pre-computed structures and bypasses ColabFold entirely"
+            elif not self.create:
+                reason = "this structure database was created with the '%s' engine, not ColabFold" % self.engine
+            else:
+                reason = "please add '--engine colabfold', or drop these flags"
             raise ConfigError("--only-msa and --only-predict are specific to the ColabFold engine: they split "
-                              "ColabFold's MSA and prediction steps into a resumable checkpoint. But %s." % engine_hint)
+                              "ColabFold's MSA and prediction steps into a resumable checkpoint. But %s." % reason)
 
         if self.list_modeller_params:
             params_dict = self.structure_db.get_colabfold_run_params_dict() if self.engine == 'colabfold' \

--- a/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
+++ b/anvio/tests/run_component_tests_for_SCVs_SAAVs_structure.sh
@@ -83,6 +83,47 @@ make_structure_db_colabfold_checkpoint() {
     if [ ! -f "test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db" ]
     then echo "FAIL: --only-predict did not produce the structure database"; exit 1; fi
 }
+# Add a new gene to a ColabFold structure database with anvi-update-structure-database. The scientific
+# parameters are read back from the database; only the machine-specific ones are re-supplied. This db
+# was built with the public MSA server (see make_structure_db_colabfold), so we re-supply
+# --colabfold-msa-server to match. Gene 4 is not yet in the db, so this exercises the 'add' path.
+update_structure_db_colabfold() {
+    anvi-update-structure-database -c test-output/one_contig_five_genes.db \
+                                   -s test-output/STRUCTURE_COLABFOLD.db \
+                                   --colabfold-conda-env "$COLABFOLD_CONDA_ENV" \
+                                   --colabfold-msa-server \
+                                   --gene-caller-ids 4 \
+                                   $thread_controller \
+                                   --debug
+}
+# Add a new gene to the local-sourced ColabFold checkpoint database using the same --only-msa /
+# --only-predict split as creation. The db was built against a local ColabFold database, so we re-supply
+# --colabfold-db for the (local) MSA step. Gene 4 is not yet in the db, so this exercises the 'add' path.
+update_structure_db_colabfold_checkpoint() {
+    # step 1: MSA only for the new gene. Produces .a3m files + a checkpoint manifest, adds nothing to the db.
+    anvi-update-structure-database -c test-output/one_contig_five_genes.db \
+                                   -s test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db \
+                                   --colabfold-conda-env "$COLABFOLD_CONDA_ENV" \
+                                   --colabfold-db "$COLABFOLD_DB" \
+                                   --gene-caller-ids 4 \
+                                   --dump-dir test-output/COLABFOLD_CHECKPOINT_UPDATE \
+                                   --only-msa \
+                                   $thread_controller \
+                                   --debug
+
+    if ! ls test-output/COLABFOLD_CHECKPOINT_UPDATE/msas/*.a3m >/dev/null 2>&1
+    then echo "FAIL: --only-msa (update) did not produce any MSA (.a3m) files"; exit 1; fi
+
+    # step 2: predict only, resuming from the checkpoint above, and add the new gene to the db.
+    anvi-update-structure-database -c test-output/one_contig_five_genes.db \
+                                   -s test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db \
+                                   --colabfold-conda-env "$COLABFOLD_CONDA_ENV" \
+                                   --gene-caller-ids 4 \
+                                   --dump-dir test-output/COLABFOLD_CHECKPOINT_UPDATE \
+                                   --only-predict \
+                                   $thread_controller \
+                                   --debug
+}
 gen_var_profile1() {
     anvi-gen-variability-profile -p test-output/SAMPLES-MERGED/PROFILE.db \
                                  -c test-output/one_contig_five_genes.db \
@@ -161,12 +202,18 @@ EOF
         INFO "anvi-gen-structure-database with ColabFold (conda env: $COLABFOLD_CONDA_ENV)"
         make_structure_db_colabfold
 
+        INFO "anvi-update-structure-database with ColabFold"
+        update_structure_db_colabfold
+
         # exercise the --only-msa / --only-predict checkpoint only when a local ColabFold database is
         # also available (the MSA step cannot be split out when using the public server)
         if [ -n "$COLABFOLD_DB" ]
         then
             INFO "anvi-gen-structure-database ColabFold --only-msa / --only-predict checkpoint (local db: $COLABFOLD_DB)"
             make_structure_db_colabfold_checkpoint
+
+            INFO "anvi-update-structure-database ColabFold --only-msa / --only-predict checkpoint (local db: $COLABFOLD_DB)"
+            update_structure_db_colabfold_checkpoint
         fi
     fi
 }
@@ -315,6 +362,7 @@ then
     rm -rf test-output/RAW_COLABFOLD_OUTPUT
     rm -rf test-output/STRUCTURE_COLABFOLD_CHECKPOINT.db
     rm -rf test-output/COLABFOLD_CHECKPOINT
+    rm -rf test-output/COLABFOLD_CHECKPOINT_UPDATE
 
     make_routine
     display_routine


### PR DESCRIPTION
Now the 4th PR after #2755 (colabfold driver + minimum integration), #2759 (update display), #2760 (add --only-msa/--only-predict checkpoints) regarding the integration of colabfold in anvi'o.
This time, it is about adding colabfold into the program `anvi-update-structure-database`.

What it does: mirror the way MODELLER update already work. The parameters (num models, num recycle, ambler, colabfold msa source, colabfold additional parameters) are read from the structure database itself and reused, so an update stays consistent with the original run. Only the 'machine' specific parameters needs to be resupply like colabfold conda env, colabfold database and the optional checkpoints.

Right now it refuses to change the MSA source. If the user used a local colabfold database, they cannot update the structure db by asking to use the public MSA server. I understand that this could be a debatable choice. I went conservative here, although i cannot check if a local colabfold database it the same as in the original run.

Updated the test as well, which now takes a really long time to run (>30 min on the HPC, with 100 CPU to test the checkpoints, and with GPU).

