### PR TITLE
new utils: picking GC representatives + flag to export them

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1928,6 +1928,20 @@ D = {
              'help': "If/when there are more than one gene clusters to report, put each gene cluster into a "
                      "separate FASTA file."}
                 ),
+    'representative-sequences': (
+            ['--representative-sequences'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Instead of reporting every gene sequence in each gene cluster, report a single "
+                     "representative amino acid sequence per gene cluster. Anvi'o picks the representative "
+                     "using a medoid-based strategy: it discards length outliers, prefers complete "
+                     "(non-partial) gene calls, and selects the sequence that is most similar to the others "
+                     "in the cluster. The resulting FASTA uses gene cluster names as deflines and contains "
+                     "no gap characters, so it is ready to be fed to protein structure predictors such as "
+                     "ColabFold. This flag requires a pangenome for which gene alignments were computed "
+                     "(i.e., not created with `--skip-alignments`), and cannot be combined with "
+                     "`--concatenate-gene-clusters` or `--report-DNA-sequences`."}
+                ),
     'bin-id': (
             ['-b', '--bin-id'],
             {'metavar': 'BIN_NAME',

--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1937,8 +1937,7 @@ D = {
                      "using a medoid-based strategy: it discards length outliers, prefers complete "
                      "(non-partial) gene calls, and selects the sequence that is most similar to the others "
                      "in the cluster. The resulting FASTA uses gene cluster names as deflines and contains "
-                     "no gap characters, so it is ready to be fed to protein structure predictors such as "
-                     "ColabFold. This flag requires a pangenome for which gene alignments were computed "
+                     "no gap characters. This flag requires a pangenome for which gene alignments were computed "
                      "(i.e., not created with `--skip-alignments`), and cannot be combined with "
                      "`--concatenate-gene-clusters` or `--report-DNA-sequences`."}
                 ),

--- a/anvio/cli/get_sequences_for_gene_clusters.py
+++ b/anvio/cli/get_sequences_for_gene_clusters.py
@@ -96,7 +96,16 @@ def run_program():
         run.info_single("Dry run, eh? Well. Your dry run is done!")
         sys.exit(0)
 
-    if args.output_file:
+    if args.representative_sequences:
+        if args.split_output_per_gene_cluster:
+            for gene_cluster_name in filtered_gene_clusters_dict:
+                output_file_path = f"{args.output_file_prefix}{gene_cluster_name}.fa"
+                pan.write_gene_cluster_representative_sequences_to_file(gene_clusters_dict={gene_cluster_name: filtered_gene_clusters_dict[gene_cluster_name]},
+                                                                       output_file_path=output_file_path)
+        else:
+            pan.write_gene_cluster_representative_sequences_to_file(gene_clusters_dict=filtered_gene_clusters_dict,
+                                                                    output_file_path=args.output_file)
+    elif args.output_file:
         if args.concatenate_gene_clusters:
             pan.write_sequences_in_gene_clusters_for_phylogenomics(gene_clusters_dict=filtered_gene_clusters_dict,
                                                                    output_file_path=args.output_file,
@@ -127,6 +136,16 @@ def run_program():
 
 
 def sanity_check(args):
+    if args.representative_sequences and args.concatenate_gene_clusters:
+        raise ConfigError("The flag `--representative-sequences` reports a single sequence per gene cluster, so it makes "
+                          "no sense to also ask for concatenated gene clusters with `--concatenate-gene-clusters`. Please "
+                          "remove one of these flags and try again.")
+
+    if args.representative_sequences and args.report_DNA_sequences:
+        raise ConfigError("The flag `--representative-sequences` only reports amino acid sequences (the representative-picking "
+                          "strategy relies on the aligned amino acid sequences), so it cannot be combined with "
+                          "`--report-DNA-sequences`. Please remove one of these flags and try again.")
+
     if args.gene_cluster_id and args.gene_cluster_ids_file:
         raise ConfigError('You should either declare a single gene cluster name or a set of gene cluster names in a file, but not both :/')
 
@@ -167,7 +186,8 @@ def sanity_check(args):
         filesnpaths.is_output_dir_writable(os.path.dirname(args.output_file_prefix))
     else:
         if not args.output_file:
-            args.output_file = os.path.join(os.path.abspath(os.getcwd()), 'GENE-CLUSTER-ALIGNMENTS.fa')
+            default_output_file_name = 'GENE-CLUSTER-REPRESENTATIVES.fa' if args.representative_sequences else 'GENE-CLUSTER-ALIGNMENTS.fa'
+            args.output_file = os.path.join(os.path.abspath(os.getcwd()), default_output_file_name)
 
         filesnpaths.is_output_file_writable(args.output_file, ok_if_exists=False)
 
@@ -237,6 +257,11 @@ def get_args():
     groupG.add_argument(*anvio.A('separator'), **anvio.K('separator'))
     groupG.add_argument(*anvio.A('align-with'), **anvio.K('align-with'))
     groupG.add_argument(*anvio.A('list-aligners'), **anvio.K('list-aligners'))
+
+    groupR = parser.add_argument_group('REPRESENTATIVE SEQUENCES', "Rather than reporting every gene in a gene cluster, "
+                                       "report a single representative amino acid sequence per gene cluster (handy for "
+                                       "feeding gene cluster representatives to protein structure predictors like ColabFold).")
+    groupR.add_argument(*anvio.A('representative-sequences'), **anvio.K('representative-sequences'))
 
     groupH = parser.add_argument_group('LIFE SAVERS', "Just when you need them.")
     groupH.add_argument(*anvio.A('report-DNA-sequences'), **anvio.K('report-DNA-sequences'))

--- a/anvio/cli/get_sequences_for_gene_clusters.py
+++ b/anvio/cli/get_sequences_for_gene_clusters.py
@@ -259,8 +259,7 @@ def get_args():
     groupG.add_argument(*anvio.A('list-aligners'), **anvio.K('list-aligners'))
 
     groupR = parser.add_argument_group('REPRESENTATIVE SEQUENCES', "Rather than reporting every gene in a gene cluster, "
-                                       "report a single representative amino acid sequence per gene cluster (handy for "
-                                       "feeding gene cluster representatives to protein structure predictors like ColabFold).")
+                                       "report a single representative amino acid sequence per gene cluster.")
     groupR.add_argument(*anvio.A('representative-sequences'), **anvio.K('representative-sequences'))
 
     groupH = parser.add_argument_group('LIFE SAVERS', "Just when you need them.")

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2213,7 +2213,7 @@ class PanSuperclass(object):
         """Write one representative amino acid sequence per gene cluster to a FASTA file.
 
         The FASTA deflines are the gene cluster names, and the sequences are reported WITHOUT gap
-        characters, so the output is ready to be fed to protein structure predictors such as ColabFold.
+        characters.
         """
 
         if output_file_path:

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2144,8 +2144,8 @@ class PanSuperclass(object):
 
         For each gene cluster this recovers the aligned amino acid sequences of its member genes and
         hands them to `utils.get_representative_sequence_from_gene_cluster` to pick a medoid-like
-        representative. This is the exact same selection logic anvi'o uses internally when it builds a
-        structural pangenome (see `anvio.panops.Pangenome.get_gene_cluster_representative_sequences`).
+        representative. The selection logic lives in that shared utils function so that anvi'o's
+        structural-pangenome build path can reuse it and pick representatives identically.
 
         You can call this function either with a `gene_clusters_dict`, or with a `gene_cluster_names`
         set (see `get_sequences_for_gene_clusters` for the reasoning behind this design).

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2139,6 +2139,102 @@ class PanSuperclass(object):
         return sequences
 
 
+    def get_gene_cluster_representative_sequences(self, gene_clusters_dict=None, gene_cluster_names=set([])):
+        """Return a single representative amino acid sequence per gene cluster.
+
+        For each gene cluster this recovers the aligned amino acid sequences of its member genes and
+        hands them to `utils.get_representative_sequence_from_gene_cluster` to pick a medoid-like
+        representative. This is the exact same selection logic anvi'o uses internally when it builds a
+        structural pangenome (see `anvio.panops.Pangenome.get_gene_cluster_representative_sequences`).
+
+        You can call this function either with a `gene_clusters_dict`, or with a `gene_cluster_names`
+        set (see `get_sequences_for_gene_clusters` for the reasoning behind this design).
+
+        Returns
+        =======
+        representative_sequences : dict
+            A dictionary of the form `{gene_cluster_name: {'sequence': <aligned AA sequence with gaps>}}`.
+            Strip the gap characters if you want the raw amino acid sequence.
+        """
+
+        if gene_clusters_dict and gene_cluster_names:
+            raise ConfigError("get_gene_cluster_representative_sequences is speaking: You can call this function either "
+                              "with a `gene_clusters_dict`, or with a `gene_cluster_names` set, but not both.")
+
+        if not self.genomes_storage_is_available:
+            raise ConfigError("You are asking anvi'o for gene cluster representative sequences, but there is no genomes "
+                              "storage available to recover the amino acid sequences from :/")
+
+        if not self.gene_clusters_gene_alignments_available:
+            raise ConfigError("Anvi'o can't pick representative sequences for your gene clusters because the gene "
+                              "alignments were not computed for this pangenome (it was most likely created with the "
+                              "flag `--skip-alignments`). The representative-picking strategy relies on the aligned "
+                              "sequences to find the one that best represents each gene cluster, so there is nothing "
+                              "anvi'o can do here without them. Sorry :/")
+
+        if gene_clusters_dict is None:
+            if not self.gene_clusters_initialized:
+                self.init_gene_clusters()
+            gene_clusters_dict = self.gene_clusters
+
+        if not gene_cluster_names:
+            gene_cluster_names = set(list(gene_clusters_dict.keys()))
+
+        representative_sequences = {}
+
+        self.progress.new('Picking gene cluster representatives', progress_total_items=len(gene_cluster_names))
+        for gene_cluster_name in gene_cluster_names:
+            self.progress.increment()
+            self.progress.update("processing '%s' ..." % gene_cluster_name)
+
+            sequence_entries = []
+            for genome_name in gene_clusters_dict[gene_cluster_name]:
+                for gene_callers_id in gene_clusters_dict[gene_cluster_name][genome_name]:
+                    aa_sequence = self.genomes_storage.get_gene_sequence(genome_name, gene_callers_id)
+                    alignment_summary = self.gene_clusters_gene_alignments[genome_name][gene_callers_id]
+                    sequence = utils.restore_alignment(aa_sequence, alignment_summary)
+                    is_partial = self.genomes_storage.is_partial_gene_call(genome_name, gene_callers_id)
+
+                    sequence_entries.append({
+                        'sequence': sequence,
+                        'length': len(aa_sequence),
+                        'gap_count': sequence.count('-'),
+                        'is_partial': bool(is_partial)
+                    })
+
+            representative_sequences[gene_cluster_name] = {'sequence': utils.get_representative_sequence_from_gene_cluster(sequence_entries)}
+
+        self.progress.end()
+
+        return representative_sequences
+
+
+    def write_gene_cluster_representative_sequences_to_file(self, gene_clusters_dict=None, gene_cluster_names=set([]), output_file_path=None):
+        """Write one representative amino acid sequence per gene cluster to a FASTA file.
+
+        The FASTA deflines are the gene cluster names, and the sequences are reported WITHOUT gap
+        characters, so the output is ready to be fed to protein structure predictors such as ColabFold.
+        """
+
+        if output_file_path:
+            filesnpaths.is_output_file_writable(output_file_path)
+
+        representative_sequences = self.get_gene_cluster_representative_sequences(gene_clusters_dict=gene_clusters_dict,
+                                                                                 gene_cluster_names=gene_cluster_names)
+
+        output_file = open(output_file_path, 'w')
+        for gene_cluster_name in representative_sequences:
+            sequence = representative_sequences[gene_cluster_name]['sequence'].replace('-', '')
+            output_file.write('>%s\n%s\n' % (gene_cluster_name, sequence))
+        output_file.close()
+
+        if len(representative_sequences) == 1:
+            self.run.info('Gene cluster name', list(representative_sequences.keys())[0])
+        self.run.info('Sequence type', 'Amino acid (gene cluster representatives)')
+        self.run.info('Num representative sequences reported', len(representative_sequences))
+        self.run.info('Output FASTA file', output_file_path, mc='green', nl_after=1)
+
+
     def compute_AAI_for_gene_cluster(self, gene_cluster):
         """Simple AAI calculator for sequences in a gene cluster"""
 

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2153,8 +2153,10 @@ class PanSuperclass(object):
         Returns
         =======
         representative_sequences : dict
-            A dictionary of the form `{gene_cluster_name: {'sequence': <aligned AA sequence with gaps>}}`.
-            Strip the gap characters if you want the raw amino acid sequence.
+            A dictionary of the form
+            `{gene_cluster_name: {'align_sequence': <aligned AA sequence with gaps>, 'genome_name': <str>, 'gene_callers_id': <int>}}`,
+            where 'genome_name' and 'gene_callers_id' identify the source gene the representative was
+            picked from. Strip the gap characters from 'align_sequence' if you want the raw amino acid sequence.
         """
 
         if gene_clusters_dict and gene_cluster_names:
@@ -2196,13 +2198,20 @@ class PanSuperclass(object):
                     is_partial = self.genomes_storage.is_partial_gene_call(genome_name, gene_callers_id)
 
                     sequence_entries.append({
-                        'sequence': sequence,
+                        'align_sequence': sequence,
                         'length': len(aa_sequence),
                         'gap_count': sequence.count('-'),
-                        'is_partial': bool(is_partial)
+                        'is_partial': bool(is_partial),
+                        'genome_name': genome_name,
+                        'gene_callers_id': gene_callers_id
                     })
 
-            representative_sequences[gene_cluster_name] = {'sequence': utils.get_representative_sequence_from_gene_cluster(sequence_entries)}
+            representative_entry = utils.get_representative_sequence_from_gene_cluster(sequence_entries)
+            representative_sequences[gene_cluster_name] = {
+                'align_sequence': representative_entry['align_sequence'],
+                'genome_name': representative_entry['genome_name'],
+                'gene_callers_id': representative_entry['gene_callers_id']
+            }
 
         self.progress.end()
 
@@ -2224,7 +2233,7 @@ class PanSuperclass(object):
 
         output_file = open(output_file_path, 'w')
         for gene_cluster_name in representative_sequences:
-            sequence = representative_sequences[gene_cluster_name]['sequence'].replace('-', '')
+            sequence = representative_sequences[gene_cluster_name]['align_sequence'].replace('-', '')
             output_file.write('>%s\n%s\n' % (gene_cluster_name, sequence))
         output_file.close()
 

--- a/anvio/docs/programs/anvi-get-sequences-for-gene-clusters.md
+++ b/anvio/docs/programs/anvi-get-sequences-for-gene-clusters.md
@@ -30,7 +30,7 @@ anvi-get-sequences-for-gene-clusters -g %(genomes-storage-db)s \
                                      -o %(genes-fasta)s
 {{ codestop }}
 
-Anvi'o picks the representative using a medoid-based strategy: it discards length outliers, prefers complete (non-partial) gene calls, and selects the sequence that is most similar to the others in the gene cluster. The resulting %(fasta)s uses the gene cluster names as deflines and contains no gap characters, so it is ready to be fed to protein structure predictors such as ColabFold.
+Anvi'o picks the representative using a medoid-based strategy: it discards length outliers, prefers complete (non-partial) gene calls, and selects the sequence that is most similar to the others in the gene cluster. The resulting %(fasta)s uses the gene cluster names as deflines and contains no gap characters.
 
 This flag requires a pangenome for which gene alignments were computed (i.e., **not** created with `--skip-alignments`), and it cannot be combined with `--concatenate-gene-clusters` or `--report-DNA-sequences`. It honors all the same selection and filtering options described below, as well as `--split-output-per-gene-cluster`.
 

--- a/anvio/docs/programs/anvi-get-sequences-for-gene-clusters.md
+++ b/anvio/docs/programs/anvi-get-sequences-for-gene-clusters.md
@@ -19,6 +19,21 @@ anvi-get-sequences-for-gene-clusters -g %(genomes-storage-db)s \
 {:.notice}
 The program will report the DNA sequences if the flag `--report-DNA-sequences` is used.
 
+### Reporting a single representative sequence per gene cluster
+
+By default this program reports every gene sequence in each gene cluster. If instead you want a single representative amino acid sequence per gene cluster, use the flag `--representative-sequences`:
+
+{{ codestart }}
+anvi-get-sequences-for-gene-clusters -g %(genomes-storage-db)s \
+                                     -p %(pan-db)s \
+                                     --representative-sequences \
+                                     -o %(genes-fasta)s
+{{ codestop }}
+
+Anvi'o picks the representative using a medoid-based strategy: it discards length outliers, prefers complete (non-partial) gene calls, and selects the sequence that is most similar to the others in the gene cluster. The resulting %(fasta)s uses the gene cluster names as deflines and contains no gap characters, so it is ready to be fed to protein structure predictors such as ColabFold.
+
+This flag requires a pangenome for which gene alignments were computed (i.e., **not** created with `--skip-alignments`), and it cannot be combined with `--concatenate-gene-clusters` or `--report-DNA-sequences`. It honors all the same selection and filtering options described below, as well as `--split-output-per-gene-cluster`.
+
 ### Splitting gene clusters into their own files
 
 The command above will put all gene cluster sequences in a single output %(fasta)s file. If you would like to report each gene cluster in a separate FASTA file, it is also an option thanks to the flag `--split-output-per-gene-cluster`. This optional reporting throught this flag applies to all commands shown on this page. For instance, the following command will report every gene cluster as a separate FASTA file in your directory,

--- a/anvio/tests/run_component_tests_for_pangenomics.sh
+++ b/anvio/tests/run_component_tests_for_pangenomics.sh
@@ -104,11 +104,34 @@ anvi-get-sequences-for-gene-clusters -p TEST-PAN.db \
                                      --report-DNA-sequences \
                                      --no-progress
 
+INFO "Exporting a representative amino acid sequence per gene cluster"
+anvi-get-sequences-for-gene-clusters -p TEST-PAN.db \
+                                     -g TEST-GENOMES.db \
+                                     -C test_collection \
+                                     -b GENE_CLUSTER_BIN_1_CORE \
+                                     --representative-sequences \
+                                     -o representative_gene_sequences_in_GENE_CLUSTER_BIN_1_CORE.fa \
+                                     --no-progress
+
+mkdir SPLIT_GENE_CLUSTER_REPRESENTATIVES
+INFO "Exporting representative sequences as individual files, one per gene cluster"
+anvi-get-sequences-for-gene-clusters -p TEST-PAN.db \
+                                     -g TEST-GENOMES.db \
+                                     -C test_collection \
+                                     -b GENE_CLUSTER_BIN_1_CORE \
+                                     --representative-sequences \
+                                     --split-output-per-gene-cluster \
+                                     -O SPLIT_GENE_CLUSTER_REPRESENTATIVES/MY_PROJECT \
+                                     --no-progress
+
 INFO "First five line from the AA output"
 head -n 5 aligned_gene_sequences_in_GENE_CLUSTER_BIN_1_CORE_AA.fa
 
 INFO "First five line from the DNA output"
 head -n 5 aligned_gene_sequences_in_GENE_CLUSTER_BIN_1_CORE_DNA.fa
+
+INFO "First five lines from the representative-sequences output"
+head -n 5 representative_gene_sequences_in_GENE_CLUSTER_BIN_1_CORE.fa
 
 INFO "Importing group information as misc data for layers"
 anvi-import-misc-data -p TEST-PAN.db \

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -1450,10 +1450,10 @@ def restore_alignment(sequence, alignment_summary, from_aa_alignment_summary_to_
 def get_representative_sequence_from_gene_cluster(sequence_entries):
     """Select a single representative amino acid sequence for a gene cluster.
 
-    This is the shared implementation used both while a structural pangenome is being computed
-    (`anvio.panops.Pangenome.get_gene_cluster_representative_sequences`) and when a user asks
-    for representatives from an existing pan database (`anvio.dbops.PanSuperclass.get_gene_cluster_representative_sequences`),
-    so that both code paths pick representatives identically.
+    This is the shared implementation behind `anvio.dbops.PanSuperclass.get_gene_cluster_representative_sequences`
+    (the user-facing path, reached via `anvi-get-sequences-for-gene-clusters --representative-sequences`).
+    It is deliberately kept as a standalone function so that anvi'o's structural-pangenome build path can
+    reuse the exact same selection logic and both routes pick representatives identically.
 
     Strategy
     ========

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -1465,17 +1465,21 @@ def get_representative_sequence_from_gene_cluster(sequence_entries):
     Parameters
     ==========
     sequence_entries : list of dict
-        One dict per gene in the cluster, each with the following keys:
-          'sequence'   : str, the ALIGNED amino acid sequence (i.e., with gap characters).
-          'length'     : int, the ungapped amino acid sequence length.
-          'gap_count'  : int, the number of gap characters in 'sequence'.
-          'is_partial' : bool, whether the gene call is partial.
+        One dict per gene in the cluster, each with AT LEAST the following keys:
+          'align_sequence' : str, the ALIGNED amino acid sequence (i.e., with gap characters).
+          'length'         : int, the ungapped amino acid sequence length.
+          'gap_count'      : int, the number of gap characters in 'align_sequence'.
+          'is_partial'     : bool, whether the gene call is partial.
+        Any additional keys (e.g., 'genome_name', 'gene_callers_id') are ignored by the
+        selection logic but preserved, since the winning entry is returned as-is.
 
     Returns
     =======
-    representative_sequence : str
-        The aligned amino acid sequence (still with gaps) selected as the representative. Callers
-        that want the raw sequence should strip the gap characters themselves.
+    representative_entry : dict
+        The winning entry from `sequence_entries`, returned unchanged. Its 'align_sequence' value is
+        the aligned amino acid sequence (still with gaps); callers that want the raw sequence should
+        strip the gap characters themselves. Any identity keys the caller included (e.g.,
+        'genome_name', 'gene_callers_id') are carried through untouched.
     """
 
     if not len(sequence_entries):
@@ -1484,7 +1488,7 @@ def get_representative_sequence_from_gene_cluster(sequence_entries):
 
     # short-circuit: single-member cluster
     if len(sequence_entries) == 1:
-        return sequence_entries[0]['sequence']
+        return sequence_entries[0]
 
     # compute median length excluding partials if possible
     non_partial_lengths = [e['length'] for e in sequence_entries if not e['is_partial']]
@@ -1519,25 +1523,26 @@ def get_representative_sequence_from_gene_cluster(sequence_entries):
         for other in entries:
             if other is entry:
                 continue
-            sim = pairwise_similarity(entry['sequence'], other['sequence'])
+            sim = pairwise_similarity(entry['align_sequence'], other['align_sequence'])
             total += (1 - sim)
         return total / (len(entries) - 1)
 
-    # rank candidates by average distance, then gaps, then length (longer preferred)
+    # rank candidates by average distance, then gaps, then length (longer preferred). The trailing
+    # index is a deterministic tiebreaker that also keeps the sort from ever comparing the entries.
     ranked = []
-    for entry in filtered_entries:
+    for idx, entry in enumerate(filtered_entries):
         avg_dist = average_distance(entry, filtered_entries)
-        ranked.append((avg_dist, entry['gap_count'], -entry['length'], entry['is_partial'], entry['sequence']))
+        ranked.append((avg_dist, entry['gap_count'], -entry['length'], entry['is_partial'], entry['align_sequence'], idx))
 
     ranked.sort()
 
     # prefer non-partial medoid if available
-    for _, _, _, is_partial, seq in ranked:
+    for _, _, _, is_partial, _, idx in ranked:
         if not is_partial:
-            return seq
+            return filtered_entries[idx]
 
     # all sequences are partial
-    return ranked[0][4]
+    return filtered_entries[ranked[0][5]]
 
 
 def get_column_data_from_TAB_delim_file(input_file_path, column_indices=[], expected_number_of_fields=None, separator='\t'):

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -1447,6 +1447,99 @@ def restore_alignment(sequence, alignment_summary, from_aa_alignment_summary_to_
         return alignment
 
 
+def get_representative_sequence_from_gene_cluster(sequence_entries):
+    """Select a single representative amino acid sequence for a gene cluster.
+
+    This is the shared implementation used both while a structural pangenome is being computed
+    (`anvio.panops.Pangenome.get_gene_cluster_representative_sequences`) and when a user asks
+    for representatives from an existing pan database (`anvio.dbops.PanSuperclass.get_gene_cluster_representative_sequences`),
+    so that both code paths pick representatives identically.
+
+    Strategy
+    ========
+    1) exclude length outliers using the median length of non-partial genes (fall back to all genes).
+    2) compute a medoid based on pairwise similarity of the aligned sequences.
+    3) prefer non-partial genes; if all are partial, fall back to the best partial medoid.
+    4) if only one sequence exists, return it.
+
+    Parameters
+    ==========
+    sequence_entries : list of dict
+        One dict per gene in the cluster, each with the following keys:
+          'sequence'   : str, the ALIGNED amino acid sequence (i.e., with gap characters).
+          'length'     : int, the ungapped amino acid sequence length.
+          'gap_count'  : int, the number of gap characters in 'sequence'.
+          'is_partial' : bool, whether the gene call is partial.
+
+    Returns
+    =======
+    representative_sequence : str
+        The aligned amino acid sequence (still with gaps) selected as the representative. Callers
+        that want the raw sequence should strip the gap characters themselves.
+    """
+
+    if not len(sequence_entries):
+        raise ConfigError("get_representative_sequence_from_gene_cluster :: was called with an empty list of "
+                          "sequence entries, which should never happen.")
+
+    # short-circuit: single-member cluster
+    if len(sequence_entries) == 1:
+        return sequence_entries[0]['sequence']
+
+    # compute median length excluding partials if possible
+    non_partial_lengths = [e['length'] for e in sequence_entries if not e['is_partial']]
+    lengths_for_median = non_partial_lengths if len(non_partial_lengths) else [e['length'] for e in sequence_entries]
+    median_length = np.median(lengths_for_median) if len(lengths_for_median) else 0
+
+    # exclude length outliers (+/-20% of median). If everything is excluded, fall back to all.
+    filtered_entries = sequence_entries
+    if median_length:
+        lower, upper = 0.8 * median_length, 1.2 * median_length
+        filtered_entries = [e for e in sequence_entries if lower <= e['length'] <= upper]
+        if not len(filtered_entries):
+            filtered_entries = sequence_entries
+
+    # compute pairwise similarities (identity over aligned positions without gaps)
+    def pairwise_similarity(seq_a, seq_b):
+        matches, positions = 0, 0
+        for aa, bb in zip(seq_a, seq_b):
+            if aa == '-' or bb == '-':
+                continue
+            positions += 1
+            if aa == bb:
+                matches += 1
+        if positions == 0:
+            return 0
+        return matches / positions
+
+    def average_distance(entry, entries):
+        if len(entries) == 1:
+            return 0
+        total = 0
+        for other in entries:
+            if other is entry:
+                continue
+            sim = pairwise_similarity(entry['sequence'], other['sequence'])
+            total += (1 - sim)
+        return total / (len(entries) - 1)
+
+    # rank candidates by average distance, then gaps, then length (longer preferred)
+    ranked = []
+    for entry in filtered_entries:
+        avg_dist = average_distance(entry, filtered_entries)
+        ranked.append((avg_dist, entry['gap_count'], -entry['length'], entry['is_partial'], entry['sequence']))
+
+    ranked.sort()
+
+    # prefer non-partial medoid if available
+    for _, _, _, is_partial, seq in ranked:
+        if not is_partial:
+            return seq
+
+    # all sequences are partial
+    return ranked[0][4]
+
+
 def get_column_data_from_TAB_delim_file(input_file_path, column_indices=[], expected_number_of_fields=None, separator='\t'):
     """Returns a dictionary where keys are the column indices, and items are the list of entries
     found in that that column"""


### PR DESCRIPTION
A little utils function to get representative sequences from gene clusters. This was originally implemented in another branch #2364, but should be its own PR and merged to master instead.

Includes a new flag for `anvi-get-sequences-for-gene-clusters`: `--representative-sequences`.

Anvi'o picks the represetative using a medoid-based strategy. It discards length outliers and prefers complete (non-partial) gene calls, and select the sequence that is the most similar to the others in the cluster. 