### PR TITLE
Pangenome input structure database

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -1921,6 +1921,32 @@ D = {
             {'metavar': 'FILE_PATH',
              'help': "Text file for gene clusters (each line should contain be a unique gene cluster id)."}
                 ),
+    'gene-cluster-ids': (
+            ['--gene-cluster-ids'],
+            {'metavar': 'GENE_CLUSTER_IDS',
+             'type': str,
+             'help': "Gene cluster ids to focus on. Multiple of them can be declared, separated by a comma "
+                     "(e.g., --gene-cluster-ids GC_00000001,GC_00000002). This is the gene-cluster analogue of "
+                     "--gene-caller-ids. If you declare nothing, anvi'o may assume all of them, depending on the "
+                     "program."}
+                ),
+    'gene-clusters-of-interest': (
+            ['--gene-clusters-of-interest'],
+            {'metavar': 'FILE',
+             'help': "A file with anvi'o gene cluster ids. There should be only one column in the file, and each "
+                     "line should correspond to a unique gene cluster id (without a column header). This is the "
+                     "gene-cluster analogue of --genes-of-interest."}
+                ),
+    'select-representative': (
+            ['--select-representative'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Instead of selecting every gene in each gene cluster of interest, select a single "
+                     "representative gene per gene cluster. Anvi'o picks the representative using a medoid-based "
+                     "strategy over the aligned amino acid sequences (it discards length outliers and prefers "
+                     "complete gene calls), so this requires a pangenome for which gene-cluster alignments were "
+                     "computed. The representative is a real gene from the cluster (not a consensus sequence)."}
+                ),
     'split-output-per-gene-cluster': (
             ['--split-output-per-gene-cluster'],
             {'default': False,

--- a/anvio/cli/gen_structure_database.py
+++ b/anvio/cli/gen_structure_database.py
@@ -49,8 +49,14 @@ def main():
 def get_args():
     parser = ArgumentParser(description=__description__)
 
-    groupD = parser.add_argument_group('DATABASES', 'Declaring relevant anvi\'o databases. First things first.')
-    groupD.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+    groupD = parser.add_argument_group('DATABASES', 'Declaring relevant anvi\'o databases. First things first. Provide '
+                                       'EITHER a contigs database (structures for its genes) OR a pangenome (--pan-db '
+                                       'plus its --genomes-storage; structures for the genes of your gene clusters).')
+    groupD.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db', {'required': False}))
+    # --pan-db is declared without its usual '-p' short flag here because '-p' is already taken by
+    # MODELLER's --percent-cutoff in this program.
+    groupD.add_argument('--pan-db', **anvio.K('pan-db', {'required': False}))
+    groupD.add_argument(*anvio.A('genomes-storage'), **anvio.K('genomes-storage', {'required': False}))
     groupD.add_argument("--pdb-db", type=str, default=None, help =
                         """By default, this program accesses the structure files it needs from an
                         internal anvi'o database that can be set up with anvi-setup-pdb-database. If
@@ -59,9 +65,13 @@ def get_args():
                         created a database and b) it exists in a custom location. In this case,
                         please provide that path here. Otherwise we vibing.""")
 
-    groupG = parser.add_argument_group('GENES', 'Specifying which genes you want structures for.')
+    groupG = parser.add_argument_group('GENES', 'Specifying which genes you want structures for. The first two options '
+                                       'apply to a contigs-db input; the last three apply to a pangenome input.')
     groupG.add_argument(*anvio.A('genes-of-interest'), **anvio.K('genes-of-interest'))
     groupG.add_argument(*anvio.A('gene-caller-ids'), **anvio.K('gene-caller-ids'))
+    groupG.add_argument(*anvio.A('gene-clusters-of-interest'), **anvio.K('gene-clusters-of-interest'))
+    groupG.add_argument(*anvio.A('gene-cluster-ids'), **anvio.K('gene-cluster-ids'))
+    groupG.add_argument(*anvio.A('select-representative'), **anvio.K('select-representative'))
 
     groupO = parser.add_argument_group('OUTPUT', 'Output file and output style.')
     groupO.add_argument(*anvio.A('output-db-path'), **anvio.K('output-db-path'))

--- a/anvio/cli/update_structure_database.py
+++ b/anvio/cli/update_structure_database.py
@@ -54,10 +54,17 @@ def get_args():
                                        'machine-specific and so must be provided again here.')
     groupE = parser.add_argument_group('EXTRA', 'Everything else.')
 
-    groupD.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
+    groupD.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db', {'required': False}))
+    # --pan-db is declared without its usual '-p' short flag, mirroring anvi-gen-structure-database (where
+    # '-p' is taken by MODELLER's --percent-cutoff), so the two programs share the same spelling.
+    groupD.add_argument('--pan-db', **anvio.K('pan-db', {'required': False}))
+    groupD.add_argument(*anvio.A('genomes-storage'), **anvio.K('genomes-storage', {'required': False}))
     groupD.add_argument(*anvio.A('structure-db'), **anvio.K('structure-db'))
     groupG.add_argument(*anvio.A('genes-of-interest'), **anvio.K('genes-of-interest'))
     groupG.add_argument(*anvio.A('gene-caller-ids'), **anvio.K('gene-caller-ids'))
+    groupG.add_argument(*anvio.A('gene-clusters-of-interest'), **anvio.K('gene-clusters-of-interest'))
+    groupG.add_argument(*anvio.A('gene-cluster-ids'), **anvio.K('gene-cluster-ids'))
+    groupG.add_argument(*anvio.A('select-representative'), **anvio.K('select-representative'))
     groupG.add_argument(*anvio.A('external-structures'), **anvio.K('external-structures'))
     groupO.add_argument(*anvio.A('dump-dir'), **anvio.K('dump-dir'))
     groupM.add_argument('--list-modeller-params', action='store_true', help='Since you are updating an existing DB, modeller params are set in '

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -426,8 +426,15 @@ class StructureInputSource(object):
         raise NotImplementedError
 
 
-    def enumerate_candidate_proteins(self, genes_of_interest_path=None, gene_caller_ids=None, raise_if_none=False):
-        """Return the set of protein_ids to attempt structures for."""
+    def enumerate_candidate_proteins(self, existing_proteins=None, raise_if_none=False):
+        """Return the set of protein_ids to attempt structures for.
+
+        Each source reads its own selection flags from self.args. On update, `existing_proteins` is the
+        proteins-table dataframe of the structure database being updated: a source that mints surrogate
+        protein_ids uses it to reuse the ids already assigned to proteins it recognizes (and mint fresh
+        ids only for genuinely new ones), which is what keeps update/--rerun idempotent. Sources whose
+        protein_id is an identity mapping (e.g. contigs-db) ignore it.
+        """
         raise NotImplementedError
 
 
@@ -495,7 +502,13 @@ class ContigsDBSource(StructureInputSource):
                 'gene_cluster_id': None}
 
 
-    def enumerate_candidate_proteins(self, genes_of_interest_path=None, gene_caller_ids=None, raise_if_none=False):
+    def enumerate_candidate_proteins(self, existing_proteins=None, raise_if_none=False):
+        # a contigs-db protein_id is the gene caller id itself (identity), so there is nothing to
+        # reconcile against an existing structure db: existing_proteins is intentionally ignored.
+        A = lambda x: self.args.__dict__[x] if x in self.args.__dict__ else None
+        genes_of_interest_path = A('genes_of_interest')
+        gene_caller_ids = A('gene_caller_ids')
+
         genes_of_interest = None
 
         # identify the gene caller ids of all genes available
@@ -973,8 +986,11 @@ class StructureSuperclass(object):
             genes_of_interest = self.external_structures.content['gene_callers_id']
             return genes_of_interest
 
-        # every other mode enumerates the proteins of interest through the input source (contigs-db today)
-        genes_of_interest = self.input_source.enumerate_candidate_proteins(genes_of_interest_path, gene_caller_ids, raise_if_none=raise_if_none)
+        # every other mode enumerates the proteins of interest through the input source. On update, the
+        # existing proteins table lets a source with surrogate protein_ids (e.g. pangenome) reuse the ids
+        # it already assigned rather than minting fresh, colliding ones.
+        existing_proteins = None if self.create else self.structure_db.get_proteins_dataframe()
+        genes_of_interest = self.input_source.enumerate_candidate_proteins(existing_proteins=existing_proteins, raise_if_none=raise_if_none)
 
         # Finally, raise warning if number of genes is greater than 20 FIXME determine average time
         # per gene and describe here

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -35,7 +35,7 @@ import anvio.drivers.MODELLER as MODELLER
 import anvio.drivers.colabfold as colabfold
 
 from anvio.errors import ConfigError, FilesNPathsError
-from anvio.dbops import ContigsSuperclass
+from anvio.dbops import ContigsSuperclass, PanSuperclass
 from anvio.version import structure_db_version
 
 J = lambda x, y: os.path.join(x, y)
@@ -579,6 +579,204 @@ class ContigsDBSource(StructureInputSource):
         return gene_sequences[protein_id]['sequence']
 
 
+class PangenomeSource(StructureInputSource):
+    """A structure input source backed by a pangenome (a pan database + its genomes storage).
+
+    A pangenome gene is identified by a (genome_name, gene_callers_id) pair that is only unique *within* a
+    genome, so -- unlike the contigs-db source -- the gene caller id cannot double as the structure
+    database's protein_id. This source therefore mints a fresh surrogate integer protein_id per selected
+    protein and records the real provenance (genome_name, gene_callers_id, gene_cluster_id) in the
+    proteins table. Amino-acid and nucleotide sequences are fetched from the genomes storage.
+
+    Two selection modes (set on the command line):
+      - all members (default): every gene of every selected gene cluster becomes a protein.
+      - representative (--select-representative): a single medoid-like representative gene is picked per
+        gene cluster (see utils.get_representative_sequence_from_gene_cluster). The representative is a
+        real gene from the cluster, so it still resolves to a concrete (genome_name, gene_callers_id).
+
+    On update, protein_ids are reconciled against the existing proteins table by the natural key
+    (genome_name, gene_callers_id) -- which is populated in *both* modes -- so re-running or adding
+    clusters never re-mints or reshuffles ids already in the database.
+    """
+
+    input_type = 'pangenome'
+
+    def __init__(self, args, run=terminal.Run(), progress=terminal.Progress()):
+        StructureInputSource.__init__(self, args, run=run, progress=progress)
+
+        A = lambda x: args.__dict__[x] if x in args.__dict__ else None
+        self.pan_db_path = A('pan_db')
+        self.genomes_storage_path = A('genomes_storage')
+        self.select_representative = A('select_representative')
+        self.gene_cluster_ids = A('gene_cluster_ids')
+        self.gene_clusters_of_interest_path = A('gene_clusters_of_interest')
+
+        if not self.pan_db_path:
+            raise ConfigError("A pangenome input requires a pan database (--pan-db).")
+        utils.is_pan_db(self.pan_db_path)
+
+        if not self.genomes_storage_path:
+            raise ConfigError("A pangenome input requires the genomes storage (--genomes-storage / -g) that goes with "
+                              "your pan database. The pan database only stores gene-cluster membership; the amino acid "
+                              "and nucleotide sequences anvi'o needs to model structures live in the genomes storage.")
+        utils.is_genome_storage(self.genomes_storage_path)
+
+        # PanSuperclass reads gene-cluster membership from the pan db and sequences from the genomes storage.
+        # It is kept quiet; the source's own run/progress carry the user-facing messages.
+        self.pan_super = PanSuperclass(self.args, r=terminal.Run(verbose=False), p=terminal.Progress(verbose=False))
+        self.pan_super.init_gene_clusters()
+
+        if not self.pan_super.genomes_storage_is_available:
+            raise ConfigError("Anvi'o could not access the genomes storage for this pangenome, so it cannot recover the "
+                              "sequences it needs. Please double-check your --genomes-storage.")
+
+        if self.select_representative and not self.pan_super.gene_clusters_gene_alignments_available:
+            raise ConfigError("You asked for one representative gene per gene cluster (--select-representative), but this "
+                              "pangenome was created without gene-cluster alignments (most likely with --skip-alignments). "
+                              "The representative is picked from the aligned sequences, so there is nothing anvi'o can do "
+                              "without them. Either recompute the pangenome with alignments, or drop --select-representative "
+                              "to model every gene in each cluster.")
+
+        # surrogate protein_id -> provenance dict, filled by enumerate_candidate_proteins
+        self.protein_map = {}
+
+
+    @property
+    def hash(self):
+        # the genomes storage is where the sequences come from, so its hash identifies the input's provenance
+        return self.pan_super.p_meta['genomes_storage_hash']
+
+
+    def get_self_provenance(self):
+        return {'input_type': self.input_type, 'contigs_db_hash': self.hash}
+
+
+    def _selected_gene_cluster_names(self):
+        """Resolve the gene clusters of interest from the command line (or fall back to all of them)."""
+        all_gene_clusters = set(self.pan_super.gene_clusters.keys())
+
+        if self.gene_cluster_ids and self.gene_clusters_of_interest_path:
+            raise ConfigError("You can't provide gene cluster ids on the command line (--gene-cluster-ids) and a file of "
+                              "gene cluster ids (--gene-clusters-of-interest) at the same time. Pick one.")
+
+        gene_clusters_of_interest = None
+        if self.gene_cluster_ids:
+            gene_clusters_of_interest = set([x.strip() for x in self.gene_cluster_ids.split(',') if x.strip()])
+        elif self.gene_clusters_of_interest_path:
+            filesnpaths.is_file_tab_delimited(self.gene_clusters_of_interest_path, expected_number_of_fields=1)
+            gene_clusters_of_interest = set([s.strip() for s in open(self.gene_clusters_of_interest_path).readlines() if s.strip()])
+
+        if not gene_clusters_of_interest:
+            gene_clusters_of_interest = all_gene_clusters
+            self.run.warning("You did not specify any gene clusters of interest, so anvi'o will assume all %d of them are "
+                             "of interest." % len(all_gene_clusters))
+
+        bad = [gc for gc in gene_clusters_of_interest if gc not in all_gene_clusters]
+        if bad:
+            raise ConfigError("%d of the gene cluster ids you provided are not known to this pangenome. Here are a few: %s."
+                              % (len(bad), ", ".join(map(str, bad[:5]))))
+
+        return gene_clusters_of_interest
+
+
+    def _target_genes(self, gene_cluster_names):
+        """Return the list of (genome_name, gene_callers_id, gene_cluster_id) triples to model, per mode."""
+        targets = []
+        if self.select_representative:
+            reps = self.pan_super.get_gene_cluster_representative_sequences(gene_cluster_names=set(gene_cluster_names))
+            for gc_id, rep in reps.items():
+                targets.append((rep['genome_name'], rep['gene_callers_id'], gc_id))
+        else:
+            for gc_id in gene_cluster_names:
+                for genome_name in self.pan_super.gene_clusters[gc_id]:
+                    for gene_callers_id in self.pan_super.gene_clusters[gc_id][genome_name]:
+                        targets.append((genome_name, gene_callers_id, gc_id))
+        return targets
+
+
+    def enumerate_candidate_proteins(self, existing_proteins=None, raise_if_none=False):
+        if raise_if_none and not (self.gene_cluster_ids or self.gene_clusters_of_interest_path):
+            raise ConfigError("You gotta supply some gene clusters of interest (--gene-cluster-ids or "
+                              "--gene-clusters-of-interest) when updating a pangenome structure database.")
+
+        gene_cluster_names = self._selected_gene_cluster_names()
+        targets = self._target_genes(gene_cluster_names)
+
+        if not targets:
+            raise ConfigError("Anvi'o could not find any genes to model for the gene clusters you selected. That is "
+                              "unexpected -- are these gene clusters empty?")
+
+        # On update, reconcile surrogate ids against the existing db by natural key so add/--rerun reuse the
+        # ids already assigned (and mint fresh, non-colliding ids only for genuinely new proteins).
+        natural_key_to_id = {}
+        next_id = 0
+        if existing_proteins is not None and len(existing_proteins):
+            for _, row in existing_proteins.iterrows():
+                natural_key_to_id[(row['genome_name'], int(row['gene_callers_id']))] = int(row['protein_id'])
+            next_id = max(natural_key_to_id.values()) + 1
+
+        self.protein_map = {}
+        protein_ids = set()
+        seen_natural_keys = set()
+        for genome_name, gene_callers_id, gc_id in targets:
+            natural_key = (genome_name, int(gene_callers_id))
+
+            # the same gene can appear under more than one selected cluster only in pathological input;
+            # keep the first occurrence so a gene maps to exactly one protein_id
+            if natural_key in seen_natural_keys:
+                continue
+            seen_natural_keys.add(natural_key)
+
+            if natural_key in natural_key_to_id:
+                protein_id = natural_key_to_id[natural_key]
+            else:
+                protein_id = next_id
+                next_id += 1
+
+            self.protein_map[protein_id] = {
+                'genome_name': genome_name,
+                'gene_callers_id': int(gene_callers_id),
+                'gene_cluster_id': gc_id,
+                'source_key': '%s:%s:%d' % (gc_id, genome_name, int(gene_callers_id)),
+            }
+            protein_ids.add(protein_id)
+
+        return protein_ids
+
+
+    def get_protein_spec(self, protein_id):
+        info = self.protein_map[protein_id]
+        return {'protein_id': protein_id,
+                'input_type': self.input_type,
+                'source_key': info['source_key'],
+                'gene_callers_id': info['gene_callers_id'],
+                'genome_name': info['genome_name'],
+                'gene_cluster_id': info['gene_cluster_id']}
+
+
+    def _aa_sequence(self, protein_id):
+        info = self.protein_map[protein_id]
+        return self.pan_super.genomes_storage.get_gene_sequence(info['genome_name'], info['gene_callers_id'],
+                                                                report_DNA_sequences=False)
+
+
+    def write_amino_acid_fasta(self, protein_id, output_file_path, simple_headers=True):
+        sequence = self._aa_sequence(protein_id)
+        header = '%d' % protein_id if simple_headers else self.protein_map[protein_id]['source_key']
+        with open(output_file_path, 'w') as f:
+            f.write('>%s\n%s\n' % (header, sequence))
+
+
+    def get_amino_acid_sequences(self, protein_ids):
+        return {protein_id: self._aa_sequence(protein_id) for protein_id in protein_ids}
+
+
+    def get_nucleotide_sequence(self, protein_id):
+        info = self.protein_map[protein_id]
+        return self.pan_super.genomes_storage.get_gene_sequence(info['genome_name'], info['gene_callers_id'],
+                                                                report_DNA_sequences=True)
+
+
 class StructureSuperclass(object):
     """Structure operations
 
@@ -635,15 +833,26 @@ class StructureSuperclass(object):
         self.only_predict = A('only_predict', bool)
 
         # the input source owns everything about where the proteins to model come from: validating the
-        # input, enumerating proteins, per-protein provenance, and fetching sequences. contigs-db is the
-        # only implemented source today.
-        # future: dispatch on args (e.g. a --pan-db / --fasta flag) to PangenomeSource / FastaSource here.
-        self.input_source = ContigsDBSource(self.args, run=self.run, progress=self.progress)
+        # input, enumerating proteins, per-protein provenance, and fetching sequences. The source is picked
+        # from the arguments: a pangenome (--pan-db) uses PangenomeSource, otherwise it is a contigs db.
+        self.pan_db_path = A('pan_db', null)
+
+        if self.pan_db_path:
+            if self.external_structures_path:
+                raise ConfigError("You provided a pangenome (--pan-db) together with --external-structures. These are "
+                                  "mutually exclusive: a structure database is built either by predicting structures for "
+                                  "the genes of a pangenome, or by importing pre-computed structures for a single contigs "
+                                  "database, not both.")
+            self.input_source = PangenomeSource(self.args, run=self.run, progress=self.progress)
+        else:
+            self.input_source = ContigsDBSource(self.args, run=self.run, progress=self.progress)
+
         self.contigs_db_hash = self.input_source.hash
 
         # thin alias so the external-structures path and residue-identity annotation can reach the contigs
-        # superclass directly; all other sequence access goes through self.input_source.
-        self.contigs_super = self.input_source.contigs_super
+        # superclass directly; all other sequence access goes through self.input_source. It is None for
+        # input types (e.g. pangenome) that are not backed by a single contigs database.
+        self.contigs_super = getattr(self.input_source, 'contigs_super', None)
 
         # --only-msa stops after the MSA step and never produces a structure database, so it neither
         # requires nor creates one. Every other mode sets up the structure db here.
@@ -1022,13 +1231,22 @@ class StructureSuperclass(object):
         """Calls either run_multi_thread or run_single_thread"""
 
         self.run.warning('', header='General info', nl_after=0, lc='green')
-        self.run.info('contigs_db', self.contigs_db_path)
-        self.run.info('contigs_db_hash', self.contigs_db_hash)
+        self.run.info('input_type', self.input_source.input_type)
+        if self.input_source.input_type == 'pangenome':
+            self.run.info('pan_db', self.pan_db_path)
+            self.run.info('genomes_storage', self.input_source.genomes_storage_path)
+            self.run.info('genomes_storage_hash', self.contigs_db_hash)
+            self.run.info('gene_cluster_ids', self.input_source.gene_cluster_ids)
+            self.run.info('gene_clusters_of_interest', self.input_source.gene_clusters_of_interest_path)
+            self.run.info('select_representative', self.input_source.select_representative)
+        else:
+            self.run.info('contigs_db', self.contigs_db_path)
+            self.run.info('contigs_db_hash', self.contigs_db_hash)
+            self.run.info('genes_of_interest', self.genes_of_interest_path)
+            self.run.info('gene_caller_ids', self.gene_caller_ids)
         self.run.info('structure_db_path', self.structure_db_path)
         self.run.info('num_threads', self.num_threads)
         self.run.info('write_buffer_size', self.write_buffer_size)
-        self.run.info('genes_of_interest', self.genes_of_interest_path)
-        self.run.info('gene_caller_ids', self.gene_caller_ids)
         self.run.info('skip_DSSP', self.skip_DSSP)
         self.run.info('run_mode', self.run_mode)
 

--- a/anvio/tests/run_component_tests_for_structure_pangenome.sh
+++ b/anvio/tests/run_component_tests_for_structure_pangenome.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Component test for the PANGENOME input type of anvi-gen-structure-database and
+# anvi-update-structure-database.
+#
+# A structure database built from a pangenome keys every protein on a surrogate integer `protein_id`.
+# This is unlike the contigs-db input, where `protein_id == gene_callers_id` (identity), because a
+# pangenome gene id is only unique WITHIN a genome. The source therefore mints fresh surrogate ids and
+# records the real provenance -- genome_name, gene_callers_id, gene_cluster_id -- in the `proteins`
+# table. The assertions below focus on that bookkeeping and, above all, on protein_id STABILITY across
+# update/rerun, which is the one behavior where the pangenome path genuinely diverges from contigs-db.
+#
+# The default MODELLER engine is slow and may find no template for a given single-copy-core gene, so
+# the `proteins` table (rows, surrogate ids, provenance, idempotency) is asserted STRICTLY while
+# whether a structure was actually produced is treated softly.
+#
+# Run it with no arguments (output goes to a fresh sandbox/test-output), e.g.:
+#     bash run_component_tests_for_structure_pangenome.sh
+# Unlike the SCVs/SAAVs structure test, this one takes no 'new'/'make'/'display' mode argument; its
+# single optional first argument is an output directory (see SETUP_WITH_OUTPUT_DIR in 00.sh). It runs
+# the default MODELLER engine and needs internet, because MODELLER downloads the template structures it
+# finds from the RCSB PDB (there is no local --pdb-db).
+
+source 00.sh
+set -e
+
+# ---------------------------------------------------------------------------------------------------
+# assertion helpers
+# ---------------------------------------------------------------------------------------------------
+assert_eq() {
+    # assert_eq <actual> <expected> <message>
+    if [ "$1" != "$2" ]; then
+        echo ""
+        echo "ASSERTION FAILED: $3"
+        echo "  expected: '$2'"
+        echo "  actual:   '$1'"
+        exit 1
+    fi
+    echo "  OK: $3 (== '$2')"
+}
+
+# interrogate a structure db's proteins table / self table
+proteins_count() { sqlite3 "$1" "SELECT COUNT(*) FROM proteins;"; }
+input_type_of()  { sqlite3 "$1" "SELECT value FROM self WHERE key='input_type';"; }
+structures_count() { sqlite3 "$1" "SELECT COUNT(*) FROM structures;"; }
+# number of proteins rows whose provenance fields are fully populated (genome + gene call + cluster)
+proteins_fully_provenanced() {
+    sqlite3 "$1" "SELECT COUNT(*) FROM proteins \
+                  WHERE genome_name IS NOT NULL \
+                    AND gene_callers_id IS NOT NULL \
+                    AND gene_cluster_id IS NOT NULL;"
+}
+# stable protein_id <-> natural-key mapping, sorted, for before/after diffs
+proteins_map() {
+    sqlite3 -separator $'\t' "$1" \
+        "SELECT protein_id, genome_name, gene_callers_id, gene_cluster_id \
+         FROM proteins ORDER BY protein_id;"
+}
+
+# ---------------------------------------------------------------------------------------------------
+# setup: build a small pangenome (genomes storage + pan db WITH alignments) from the mock genomes
+# ---------------------------------------------------------------------------------------------------
+SETUP_WITH_OUTPUT_DIR $1 $2 $3
+
+INFO "Setting up the pangenome for the structure test"
+mkdir -p $output_dir/
+cp $files/mock_data_for_pangenomics/*.db                 $output_dir/
+cp $files/mock_data_for_pangenomics/external-genomes.txt $output_dir/
+cd $output_dir/
+
+INFO "Migrating the mock genome databases"
+anvi-migrate *.db --migrate-quickly
+
+INFO "Generating an anvi'o genomes storage"
+anvi-gen-genomes-storage -e external-genomes.txt -o TEST-GENOMES.db --no-progress
+
+# Alignments are ON (the default) because representative-picking relies on the aligned sequences.
+INFO "Running the pangenome analysis (with gene-cluster alignments)"
+anvi-pan-genome -g TEST-GENOMES.db -n TEST --use-ncbi-blast --no-progress $thread_controller
+
+# Two deterministic single-copy-core gene clusters of this pangenome. Each occurs exactly once in all
+# five genomes (so all-members mode yields five proteins per cluster and representative mode yields one),
+# and both have a high-identity, high-coverage template in MODELLER's pdb_95 search database (~98-99%
+# identity over ~99% of the gene), so MODELLER reliably models their structures and the create step is
+# not left empty. The ids are stable for these mock genomes and the default clustering, exactly as the
+# pangenomics component test relies on hard-coded gene cluster ids for the same data.
+GC_A=GC_00000068
+GC_B=GC_00000088
+NUM_GENOMES=5
+
+# common, engine-agnostic knobs -- keep MODELLER fast; ColabFold is a separate opt-in path elsewhere.
+GEN_COMMON="--pan-db TEST-PAN.db -g TEST-GENOMES.db --very-fast --num-models 1 --num-threads 1 --debug"
+
+# ===================================================================================================
+# TEST 1 -- create, all-members mode: every gene of the selected cluster becomes a protein
+# ===================================================================================================
+INFO "anvi-gen-structure-database from a pangenome (all members of one gene cluster)"
+anvi-gen-structure-database $GEN_COMMON \
+                            --gene-cluster-ids $GC_A \
+                            -o STRUCTURE_PAN_ALL.db
+
+assert_eq "$(input_type_of STRUCTURE_PAN_ALL.db)" "pangenome" \
+          "structure db records input_type=pangenome"
+assert_eq "$(proteins_count STRUCTURE_PAN_ALL.db)" "$NUM_GENOMES" \
+          "one protein per member gene of $GC_A"
+assert_eq "$(proteins_fully_provenanced STRUCTURE_PAN_ALL.db)" "$NUM_GENOMES" \
+          "every protein carries genome_name + gene_callers_id + gene_cluster_id"
+assert_eq "$(sqlite3 STRUCTURE_PAN_ALL.db "SELECT COUNT(DISTINCT protein_id) FROM proteins;")" "$NUM_GENOMES" \
+          "surrogate protein_ids are distinct"
+assert_eq "$(sqlite3 STRUCTURE_PAN_ALL.db "SELECT COUNT(DISTINCT gene_cluster_id) FROM proteins;")" "1" \
+          "all members trace back to the single selected gene cluster"
+# soft: structures may be fewer than proteins if MODELLER found no template for some SCG
+INFO "  (soft) structures produced for all-members db: $(structures_count STRUCTURE_PAN_ALL.db)/$NUM_GENOMES"
+
+# ===================================================================================================
+# TEST 2 -- create, representative mode: one picked protein per gene cluster
+# ===================================================================================================
+INFO "anvi-gen-structure-database from a pangenome (representative of two gene clusters)"
+anvi-gen-structure-database $GEN_COMMON \
+                            --gene-cluster-ids $GC_A,$GC_B \
+                            --select-representative \
+                            -o STRUCTURE_PAN_REP.db
+
+assert_eq "$(proteins_count STRUCTURE_PAN_REP.db)" "2" \
+          "exactly one representative protein per selected gene cluster"
+assert_eq "$(proteins_fully_provenanced STRUCTURE_PAN_REP.db)" "2" \
+          "each representative resolves to a real (genome, gene_callers_id) and its cluster"
+assert_eq "$(sqlite3 STRUCTURE_PAN_REP.db "SELECT COUNT(DISTINCT gene_cluster_id) FROM proteins;")" "2" \
+          "the two representatives come from the two distinct clusters"
+
+# ===================================================================================================
+# TEST 3 -- update idempotency: the crux. Surrogate ids must be STABLE across add and rerun.
+# ===================================================================================================
+INFO "Snapshotting the all-members proteins table before update"
+proteins_map STRUCTURE_PAN_ALL.db > proteins_before_update.tsv
+cat proteins_before_update.tsv
+
+INFO "anvi-update-structure-database: ADD a second gene cluster to the pangenome structure db"
+anvi-update-structure-database --pan-db TEST-PAN.db -g TEST-GENOMES.db \
+                               -s STRUCTURE_PAN_ALL.db \
+                               --gene-cluster-ids $GC_B \
+                               --num-threads 1 --debug
+
+# after adding GC_B we expect the original members PLUS the new cluster's members
+assert_eq "$(proteins_count STRUCTURE_PAN_ALL.db)" "$((NUM_GENOMES * 2))" \
+          "adding a second cluster appends its members"
+
+INFO "Verifying the pre-existing protein_id <-> natural-key mapping was NOT disturbed"
+proteins_map STRUCTURE_PAN_ALL.db | head -n $NUM_GENOMES > proteins_after_update_head.tsv
+# the first NUM_GENOMES rows (lowest protein_ids) must be byte-identical to the pre-update snapshot
+if ! diff -u proteins_before_update.tsv proteins_after_update_head.tsv; then
+    echo ""
+    echo "ASSERTION FAILED: update re-minted or reshuffled existing protein_ids"
+    exit 1
+fi
+echo "  OK: existing protein_id <-> (genome, gene_callers_id, gene_cluster_id) mapping unchanged after add"
+
+INFO "anvi-update-structure-database: RERUN the original cluster -- must NOT duplicate proteins"
+proteins_map STRUCTURE_PAN_ALL.db > proteins_before_rerun.tsv
+anvi-update-structure-database --pan-db TEST-PAN.db -g TEST-GENOMES.db \
+                               -s STRUCTURE_PAN_ALL.db \
+                               --gene-cluster-ids $GC_A \
+                               --rerun \
+                               --num-threads 1 --debug
+proteins_map STRUCTURE_PAN_ALL.db > proteins_after_rerun.tsv
+
+assert_eq "$(proteins_count STRUCTURE_PAN_ALL.db)" "$((NUM_GENOMES * 2))" \
+          "rerun adds no new protein rows"
+if ! diff -u proteins_before_rerun.tsv proteins_after_rerun.tsv; then
+    echo ""
+    echo "ASSERTION FAILED: rerun changed the proteins table"
+    exit 1
+fi
+echo "  OK: rerun left the proteins table identical (idempotent)"
+
+INFO "All pangenome structure-database assertions passed."

--- a/anvio/variabilityops.py
+++ b/anvio/variabilityops.py
@@ -1193,6 +1193,19 @@ class VariabilitySuper(VariabilityFilter, object):
         self.progress.update('Reading the structure database ...')
         structure_db = structureops.StructureDatabase(self.structure_db_path)
 
+        # variability is computed against a single contigs database, so overlaying it onto a structure db
+        # only makes sense when that db was built from the same contigs database. A pangenome (or other)
+        # structure db keys its structures on surrogate protein_ids that are not the gene caller ids of any
+        # one contigs db, so the merge below would be meaningless. Refuse it clearly.
+        if structure_db.input_type != 'contigs_db':
+            structure_db.disconnect()
+            self.progress.end()
+            raise ConfigError("The structure database you provided was built from a '%s' input, not a single contigs "
+                              "database. Anvi'o can only overlay per-residue variability onto a structure database whose "
+                              "structures correspond to the genes of the contigs database your variability was computed "
+                              "from. Structure databases built from a pangenome (or other non-contigs inputs) are not "
+                              "compatible with the variability overlay." % structure_db.input_type)
+
         self.structure_residue_info = structure_db.get_residue_info_for_all()
 
         # the structure database keys residue info on `protein_id`. For a contigs-db-derived structure db


### PR DESCRIPTION
We're getting there. 6th PR related to the integration of ColabFold (#2754).
This time we introduce a big new change: pangenome as a new input type!
Why? To later compute structure-based pangenome, and to visualize prot structure in the pangenome interactive interface.

Here is how it looks like:
```bash
# every gene of the selected clusters
anvi-gen-structure-database --pan-db PAN.db -g GENOMES.db \
    --gene-cluster-ids GC_00000068,GC_00000088 -o STRUCTURE.db

# a single representative gene per cluster
anvi-gen-structure-database --pan-db PAN.db -g GENOMES.db \
    --gene-cluster-ids GC_00000068 --select-representative -o STRUCTURE.db
```

Here we have a new PangenomeSource in structureops.py. With contigs.db, the protein id == gene caller id; here the protein id is a integer and the protein table links it to a genome name, gene caller id and gene cluster id.

AA sequence come from the genomes-storage db (therefore required input).

Two selection modes: all proteins of selected gene clusters, or representative sequence (#2765, a protein pick not a consensus prot).

Works with `anvi-gen-structure-database` and `anvi-update-structure-database`.

My only issue is that the flag `-p` was already used by MODELLER's parameter `--percent-cutoff`. So right now you need to use `--pan-db` full flag to pass a pan db. A bit annoying. I haven't decided if I can/should retire `-p` from `--percent-cutoff` into the short flag for pangenome. I cannot find any reproducible workflow or documentation that uses the original `-p`, so I think I could be safe replacing it, but it feels wrong too. I'll ask the wiser people when I get the chance.

We also have a new test! Mirroring the unusual test `run_component_tests_for_SCVs_SAAVs_structure.sh`, meaning you run it directly in the `tests` dir, not as part of the self tests. Debatable I agree and I'm ready to hear opinions.

Also, right now you cannot bring external structures when in pangenome mode. I think we should be able. But for now, we will be happy with what we have. The tests are running but I want to run it on a real pangenome first. Then we'll see if we allow external structures.
