### PR TITLE
fix non-deterministic protein id for pangenome

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -2185,7 +2185,9 @@ class PanSuperclass(object):
         representative_sequences = {}
 
         self.progress.new('Picking gene cluster representatives', progress_total_items=len(gene_cluster_names))
-        for gene_cluster_name in gene_cluster_names:
+        # sort so the returned dict order (and thus any FASTA written from it) is deterministic across
+        # processes; gene_cluster_names is a set, whose iteration order varies run-to-run
+        for gene_cluster_name in sorted(gene_cluster_names):
             self.progress.increment()
             self.progress.update("processing '%s' ..." % gene_cluster_name)
 

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -691,6 +691,13 @@ class PangenomeSource(StructureInputSource):
                 for genome_name in self.pan_super.gene_clusters[gc_id]:
                     for gene_callers_id in self.pan_super.gene_clusters[gc_id][genome_name]:
                         targets.append((genome_name, gene_callers_id, gc_id))
+
+        # sort into a deterministic, process-independent order before surrogate protein_ids are minted
+        # from this order in enumerate_candidate_proteins. Both branches above iterate a set of gene
+        # cluster names, whose order varies run-to-run (str hash randomization); without this, the same
+        # gene gets a different protein_id each run, which breaks the ColabFold --only-msa/--only-predict
+        # checkpoint (its FASTA-hash guard assumes a byte-identical regenerated FASTA).
+        targets.sort(key=lambda t: (t[2], t[0], int(t[1])))
         return targets
 
 


### PR DESCRIPTION
Small fix after #2766.
Protein id were non deterministic and break when you split `anvi-gen-structure-database` with the flags `--only-msa/--only-predict`.
Now is good :D 