### PR TITLE
External structures pangenome input

### DIFF
--- a/anvio/cli/gen_structure_database.py
+++ b/anvio/cli/gen_structure_database.py
@@ -20,12 +20,12 @@ __resources__ = [("A conceptual tutorial on the structural biology capabilities 
                   "http://merenlab.org/2018/09/04/structural-biology-with-anvio/"),
                  ("A practical tutorial section in the infant gut tutorial",
                   "http://merenlab.org/tutorials/infant-gut/#chapter-vii-linking-genomic-heterogeneity-to-protein-structures")]
-__requires__ = ['contigs-db']
-__can_use__ = ['pdb-db', 'genes-of-interest-txt']
+__requires__ = ['contigs-db', 'pan-db', 'genomes-storage-db']
+__can_use__ = ['pdb-db', 'genes-of-interest-txt', 'external-structures']
 __provides__ = ['structure-db']
-__description__ = ("Creates a database of protein structures. Predict protein structures for genes in "
-                   "your contigs database using either template-based homology modelling (MODELLER) or "
-                   "AlphaFold2 (ColabFold), or import pre-computed PDB structures you already have.")
+__description__ = ("Creates a database of protein structures. Predict protein structures for the genes of a "
+                   "contigs database or a pangenome using either template-based homology modelling (MODELLER) "
+                   "or AlphaFold2 (ColabFold), or import pre-computed PDB structures you already have.")
 
 
 @terminal.time_program

--- a/anvio/cli/update_structure_database.py
+++ b/anvio/cli/update_structure_database.py
@@ -15,8 +15,9 @@ __credits__ = []
 __license__ = "GPL 3.0"
 __version__ = anvio.__version__
 __authors__ = ['ekiefl']
-__requires__ = ["contigs-db", "structure-db"]
-__can_use__ = ["genes-of-interest-txt"]
+__requires__ = ["contigs-db", "structure-db", "pan-db", "genomes-storage-db"]
+__can_use__ = ["genes-of-interest-txt", "external-structures"]
+__provides__ = ["structure-db"]
 __description__ = ("Add or re-run genes from an already existing structure database. All settings used "
                    "to generate your database will be used in this program")
 

--- a/anvio/docs/artifacts/external-structures.md
+++ b/anvio/docs/artifacts/external-structures.md
@@ -1,18 +1,42 @@
-By default, anvi'o predicts protein structures using MODELLER when creating a %(structure-db)s. Yet, if the user provides an external structures file, then anvi'o does not perform template-based homology modelling, and instead uses this file to obtain the structure information for the %(structure-db)s.
+By default, anvi'o predicts protein structures (with MODELLER or ColabFold) when creating a %(structure-db)s. Yet, if the user provides an external structures file, then anvi'o does not predict anything, and instead uses this file to import pre-computed structures into the %(structure-db)s. This is handy when you already have structures, or when you predicted them with another tool (e.g. AlphaFold3).
 
-External structures is a user-provided TAB-delimited file that should follow this format:
+External structures is a user-provided TAB-delimited file. Its header determines the format, and the format must match the input you are building the %(structure-db)s from (a %(contigs-db)s, or a pangenome). Anvi'o auto-detects which one you provided.
 
-|gene_callers_id|path|
-|:---:|:---|
+## File format
+
+### From a contigs database
+
+A two-column file mapping each gene caller id to a structure file:
+
+|**gene_callers_id**|**path**|
+|:--|:--|
 |1|path/to/gene1/structure.pdb|
 |2|path/to/gene2/structure.pdb|
-|3|path/to/gene3/structure.pdb|
-|4|path/to/gene4/structure.pdb|
-|7|path/to/gene5/structure.pdb|
-|8|path/to/gene6/structure.pdb|
 |(...)|(...)|
 
-Each path should point to a %(protein-structure-txt)s.
+where,
+
+* **gene_callers_id** is a gene call in the %(contigs-db)s,
+* **path** points to a %(protein-structure-txt)s for that gene.
+
+### From a pangenome
+
+When you build the %(structure-db)s from a pangenome (a %(pan-db)s plus its %(genomes-storage-db)s), a gene is identified by the genome it comes from *and* its gene caller id, so the file has a genome column:
+
+|**genome_name**|**gene_callers_id**|**path**|
+|:--|:--|:--|
+|G_01|1|path/to/structure_A.pdb|
+|G_01|42|path/to/structure_B.pdb|
+|G_02|17|path/to/structure_C.pdb|
+|(...)|(...)|(...)|
+
+where,
+
+* **genome_name** is a genome in the %(genomes-storage-db)s,
+* **gene_callers_id** is a gene call in that genome,
+* **path** points to a %(protein-structure-txt)s for that gene.
+
+You do not provide the gene cluster: anvi'o derives it from the %(pan-db)s for each gene. Each gene must therefore belong to a gene cluster in your pangenome.
 
 {:.notice}
-Please note that anvi'o will try its best to test the integrity of each file, and work with any limitations, however ultimately the user may be subject to the strict requirements set forth by anvi'o. For example, if a structure has a missing residue, you will hear about it.
+Anvi'o will test the integrity of each file, and ultimately you may be subject to the strict requirements anvi'o sets forth (for example, if a structure has a missing residue, you will hear about it). In particular, the amino acid sequence in each structure file must match the sequence anvi'o has for that gene (from the %(contigs-db)s, or from the %(genomes-storage-db)s for a pangenome).

--- a/anvio/docs/programs/anvi-gen-structure-database.md
+++ b/anvio/docs/programs/anvi-gen-structure-database.md
@@ -107,6 +107,17 @@ anvi-gen-structure-database -c %(contigs-db)s \
                             -o STRUCTURE.db
 {{ codestop }}
 
+You can also import structures for a pangenome, by pointing at a %(pan-db)s and its %(genomes-storage-db)s instead of a %(contigs-db)s:
+
+{{ codestart }}
+anvi-gen-structure-database --pan-db %(pan-db)s \
+                            -g %(genomes-storage-db)s \
+                            --external-structures %(external-structures)s \
+                            -o STRUCTURE.db
+{{ codestop }}
+
+The %(external-structures)s file format differs slightly between the two (a pangenome file names the genome each gene comes from); see %(external-structures)s for both layouts.
+
 {:.notice}
 Please avoid using any MODELLER-specific parameters when using this mode, as they will be silently ignored.
 

--- a/anvio/docs/programs/anvi-update-structure-database.md
+++ b/anvio/docs/programs/anvi-update-structure-database.md
@@ -27,4 +27,4 @@ Now, the program will rerun the analysis for gene 1 and will still add genes 4 a
 
 Both of these runs will have the same MODELLER parameters as your run of %(anvi-gen-structure-database)s. However, to get the raw outputs, you will need to use the parameter `--dump-dir`. You can also set a specific MODELLER program with `--modeller-executable`. Parameters for multi-threading would also have to be given again.
 {:.notice}
-Like %(anvi-gen-structure-database)s, this program also accepts %(external-structures)s.
+Like %(anvi-gen-structure-database)s, this program also accepts %(external-structures)s -- for a contigs-db or a pangenome structure database. When updating a pangenome structure database, anvi'o reconciles the surrogate protein ids by natural key, so adding or re-running structures never disturbs the ids already in the database.

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -397,9 +397,11 @@ class StructureInputSource(object):
     provenance (a "protein spec" dict), and hand back the amino-acid / nucleotide sequences anvi'o needs
     to model and annotate a structure.
 
-    Only ContigsDBSource is implemented today. New input types (e.g. pangenome, fasta) subclass this and
-    are dispatched in StructureSuperclass.__init__. A subclass must set `input_type` and implement every
-    method below.
+    Two sources exist: ContigsDBSource (a single contigs database) and PangenomeSource (a pan database
+    plus its genomes storage); they are dispatched in StructureSuperclass.__init__. A subclass sets
+    `input_type` and implements the abstract methods below; the external-structures hooks
+    (accepted_external_formats / load_external_rows) are only needed to support importing pre-computed
+    structures for that input type.
 
     A protein spec is a plain dict with the keys: 'protein_id' (int), 'input_type' (str), 'source_key'
     (str, a stable human-readable handle), and the nullable natural-identity fields 'gene_callers_id'
@@ -1295,16 +1297,17 @@ class StructureSuperclass(object):
             if self.dump_dir:
                 raise ConfigError("No sense providing a --dump-dir when --external-structures are provided.")
 
-            # the file is parsed and validated against whatever input source is active (contigs-db or
-            # pangenome); it hands its rows to the source, which will mint protein_ids at enumerate time
-            self.external_structures = ExternalStructuresFile(path=self.external_structures_path, input_source=self.input_source)
+            # constructed purely for its side effects: it parses and validates the file against whatever
+            # input source is active (contigs-db or pangenome) and hands its rows to that source, which
+            # mints protein_ids from them at enumerate time. The object itself is not needed afterwards.
+            ExternalStructuresFile(path=self.external_structures_path, input_source=self.input_source)
 
 
     def get_genes_of_interest(self, genes_of_interest_path=None, gene_caller_ids=None, raise_if_none=False):
-        """Nabs the genes of interest based on genes_of_interest_path, gene_caller_ids, and self.external_structures
+        """Nab the proteins of interest for this run.
 
-        If no genes of interest are provided through either genes_of_interest_path,
-        gene_caller_ids, or self.external_structures, all will be assumed
+        In external-structures mode the file (already parsed in sanity_check) is the selection. Otherwise
+        the input source enumerates them from its own selection flags; if none are given, all are assumed.
 
         Parameters
         ==========
@@ -3045,6 +3048,11 @@ class ExternalStructuresFile(object):
 
         filesnpaths.is_file_tab_delimited(self.path)
         self.content = pd.read_csv(self.path, sep='\t')
+
+        if not len(self.content):
+            raise ConfigError("Your external-structures file ('%s') has a header but no rows, so there are no "
+                              "structures to import and nothing for anvi'o to do. Please add at least one structure "
+                              "to it, or drop --external-structures." % self.path)
 
         self.format = self._detect_format()
         accepted = input_source.accepted_external_formats()

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -414,11 +414,59 @@ class StructureInputSource(object):
         self.run = run
         self.progress = progress
 
+        # populated only when structures are imported from an external-structures file (see
+        # load_external_rows / enumerate_candidate_proteins). external_rows holds the parsed, validated
+        # rows; external_path_map maps a minted protein_id to the PDB path to import for it.
+        self.external_rows = None
+        self.external_path_map = {}
+
 
     @property
     def hash(self):
         """A hash uniquely identifying the input; stored in the structure db to link the two."""
         raise NotImplementedError
+
+
+    def accepted_external_formats(self):
+        """Return the external-structures header layouts this source accepts (see ExternalStructuresFile)."""
+        raise NotImplementedError
+
+
+    def load_external_rows(self, external_format, content_df):
+        """Validate an external-structures file's rows against this input and stash them on the source.
+
+        Called once (from ExternalStructuresFile) before protein_ids are minted, so it must validate
+        natural-key existence only -- it must NOT call get_amino_acid_sequences, which needs the
+        protein_map that enumerate_candidate_proteins fills in later.
+        """
+        raise NotImplementedError
+
+
+    def get_external_structure_path(self, protein_id):
+        """Return the PDB path to import for a protein_id (external-structures mode only)."""
+        return self.external_path_map[protein_id]
+
+
+    def check_external_integrity(self, protein_ids):
+        """Verify each imported PDB's sequence matches this source's amino-acid sequence for that protein.
+
+        Source-agnostic: the reference sequences come from get_amino_acid_sequences, so it works for any
+        input type. Must run AFTER enumerate_candidate_proteins has populated the protein_map (that is
+        what get_amino_acid_sequences relies on for a pangenome).
+        """
+        reference_sequences = self.get_amino_acid_sequences(protein_ids)
+
+        self.progress.new('External structures', progress_total_items=len(protein_ids))
+        for protein_id in protein_ids:
+            self.progress.increment()
+            path = self.get_external_structure_path(protein_id)
+            structure_sequence = Structure(path).get_sequence()
+            if structure_sequence != reference_sequences[protein_id]:
+                self.progress.end()
+                raise ConfigError("The structure you provided at '%s' does not match the amino acid sequence anvi'o "
+                                  "has for this protein. The sequence in the structure file must be identical to the "
+                                  "sequence of the gene it is a structure for. This is a show stopper :/" % path)
+        self.progress.end()
 
 
     def get_self_provenance(self):
@@ -2880,128 +2928,80 @@ class Structure(object):
 
 
 class ExternalStructuresFile(object):
-    def __init__(self, path, contigs_db_path, lazy=False, p=terminal.Progress(), r=terminal.Run()):
-        """Check the integrity of an external structures file and provide contents as the attribute self.content
+    """Parse and validate a user-provided external-structures file for a given input source.
 
-        Parameters
-        ==========
-        contigs_db_path : str, None
-            The path to the corresponding contigs database.
-        lazy : bool, False
-            If false, each structure file will be opened and the sequence therein will be explicitly compared to
-            the amino acid of the gene callers id found in the contigs database. If True, only superficial checks
-            will be carried out, like making sure the file is tab-delimited and that all files pointed to actually
-            exist.
-        """
+    The file lists pre-computed structure (PDB) files to import instead of predicting structures. Its
+    header determines the format, and the format must be one the input source accepts:
+      - contigs-db:  gene_callers_id, path
+      - pangenome:   genome_name, gene_callers_id, path
 
+    This class is source-agnostic: it parses the TSV, auto-detects the format, checks for duplicates and
+    that every path exists, then hands the rows to the input source. The source validates natural-key
+    existence (and later mints protein_ids and checks each PDB's sequence via check_external_integrity).
+    This class reads no database itself.
+    """
+
+    # header layout -> ordered column names (the last column is always 'path'; the rest are the row's key)
+    FORMAT_HEADERS = {
+        'contigs':        ['gene_callers_id', 'path'],
+        'pangenome_gene': ['genome_name', 'gene_callers_id', 'path'],
+    }
+
+    def __init__(self, path, input_source, p=terminal.Progress(), r=terminal.Run()):
         self.run, self.progress = r, p
-
         self.path = path
-        self.contigs_db_path = contigs_db_path
+        self.input_source = input_source
 
-        utils.is_contigs_db(self.contigs_db_path)
         filesnpaths.is_file_tab_delimited(self.path)
-
         self.content = pd.read_csv(self.path, sep='\t')
 
-        self.is_header_ok()
+        self.format = self._detect_format()
+        accepted = input_source.accepted_external_formats()
+        if self.format not in accepted:
+            raise ConfigError("Your external-structures file is in the '%s' format, but a '%s' input expects one of "
+                              "these header layouts: %s. Please provide a file whose header matches your input type."
+                              % (self.format, input_source.input_type,
+                                 '; '.join('[%s]' % ', '.join(self.FORMAT_HEADERS[f]) for f in accepted)))
+
         self.is_duplicates()
-        self.is_gene_caller_ids_ok()
         self.is_files_exist()
-        if not lazy:
-            self.test_integrity()
+
+        # hand the validated rows to the source: it checks natural-key existence and stashes them for
+        # protein_id minting (see the source's load_external_rows / enumerate_candidate_proteins)
+        input_source.load_external_rows(self.format, self.content)
 
 
-    def get_structure(self, gene_callers_id):
-        """Return Structure object for given gene callers id"""
+    def _detect_format(self):
+        headers = list(self.content.columns)
+        for external_format, expected in self.FORMAT_HEADERS.items():
+            if headers == expected:
+                return external_format
 
-        path = self.get_path(gene_callers_id)
-        return Structure(path)
-
-
-    def get_path(self, gene_callers_id):
-        """Return Structure object for given gene callers id"""
-
-        result = self.content.loc[self.content['gene_callers_id'] == gene_callers_id, 'path']
-        if result.empty:
-            raise ConfigError(f"Structure.get_path :: Can't find gene callers id '{gene_callers_id}'.")
-        return result.iloc[0]
+        accepted = '; '.join('[%s]' % ', '.join(cols) for cols in self.FORMAT_HEADERS.values())
+        raise FilesNPathsError("Anvi'o could not recognize the header of your external-structures file. Its columns "
+                               "were '%s', but they must exactly match one of these layouts: %s."
+                               % (', '.join(str(h) for h in headers), accepted))
 
 
-    def is_header_ok(self):
-        headers_proper = ['gene_callers_id', 'path']
-        with open(self.path, 'r') as input_file:
-            headers = input_file.readline().strip().split('\t')
-            missing_headers = [h for h in headers_proper if h not in headers]
-
-            if len(headers) != 2:
-                raise FilesNPathsError("Your external structures file does not contain the right number of columns :/ Here are "
-                                       "what the header columns should be called, in this order: '%s'." % ', '.join(headers_proper))
-
-            if len(missing_headers):
-                raise FilesNPathsError("Your external structures file has the wrong headers. They should be: '%s', not '%s'." % (', '.join(headers_proper), ', '.join(headers)))
-
-        return True
+    def _key_columns(self):
+        # every column but 'path' identifies a row (the natural key for this format)
+        return [c for c in self.FORMAT_HEADERS[self.format] if c != 'path']
 
 
     def is_duplicates(self):
-        counts = self.content['gene_callers_id'].value_counts()
+        key_columns = self._key_columns()
+        counts = self.content.groupby(key_columns).size()
         multiple = counts[counts > 1].index.tolist()
         if len(multiple):
-            raise FilesNPathsError(f"Only one structure can be assigned to each gene callers id. But the following genes are present "
-                                   f"multiple times in your external structures file: {multiple}")
+            raise FilesNPathsError("Only one structure can be assigned to each %s. But the following are present multiple "
+                                   "times in your external-structures file: %s" % (' + '.join(key_columns), multiple))
 
 
     def is_files_exist(self):
         """Check that all files pointed to in the file actually exist"""
         for _, row in self.content.iterrows():
-            gene_callers_id, path = row['gene_callers_id'], row['path']
-            if not filesnpaths.is_file_exists(path, dont_raise=True):
-                raise FilesNPathsError(f"This is kind of an issue. Your external structures file points to the following path: {path}. "
-                                       f"for gene callers id {gene_callers_id}. Well that path is not a file :\\")
+            if not filesnpaths.is_file_exists(row['path'], dont_raise=True):
+                raise FilesNPathsError("Your external-structures file points to '%s', but that path is not a file :\\"
+                                       % row['path'])
 
-        return True
-
-
-    def is_gene_caller_ids_ok(self):
-        """Returns True if all gene_callers_ids in external structures file are in the contigs database and are coding"""
-
-        contigs_db = db.DB(self.contigs_db_path, client_version=None, ignore_version=True)
-        table = contigs_db.get_table_as_dataframe('gene_amino_acid_sequences')
-        genes_in_contigs_db_with_aa_seqs = table.loc[table['sequence'] != '', 'gene_callers_id'].tolist()
-        missing_in_contigs = [x for x in self.content['gene_callers_id'] if x not in genes_in_contigs_db_with_aa_seqs]
-
-        if len(missing_in_contigs):
-            raise ConfigError(f"Some gene caller ids in your external structures file are either missing from your contigs database "
-                              f"or are non-coding (they have no corresponding amino acid sequence). This is a show stopper. "
-                              f"Here are the gene caller ids: {missing_in_contigs}")
-
-
-    def test_integrity(self):
-        """Parse the sequence contents of each PDB and ensure it matches the sequences in the contigs database"""
-
-        # Fetch the amino acid sequences found in contigs database
-        contigs_db = db.DB(self.contigs_db_path, client_version=None, ignore_version=True)
-        table = contigs_db.get_table_as_dataframe('gene_amino_acid_sequences')
-        amino_acid_sequences = dict(zip(table['gene_callers_id'], table['sequence']))
-
-        self.progress.new('External structures', progress_total_items=self.content.shape[0])
-        self.progress.update('Testing personal integrity')
-
-        for _, row in self.content.iterrows():
-            gene_callers_id, path = row['gene_callers_id'], row['path']
-            s = Structure(path)
-            aa_seq_structure = s.get_sequence()
-            aa_seq_contigs = amino_acid_sequences[gene_callers_id]
-
-            if aa_seq_structure != aa_seq_contigs:
-                self.progress.end()
-                raise ConfigError(f"The sequence in the structure for gene callers id {gene_callers_id} ({path}) does not match the sequence "
-                                  f"found for this gene in the contigs database. Here is the sequence found in the structure: {aa_seq_structure}. "
-                                  f"And here is the sequence in the contigs database that anvi'o was expecting: {aa_seq_contigs}.")
-
-            self.progress.increment()
-            self.progress.update(self.progress.msg)
-
-        self.progress.end()
         return True

--- a/anvio/structureops.py
+++ b/anvio/structureops.py
@@ -550,7 +550,36 @@ class ContigsDBSource(StructureInputSource):
                 'gene_cluster_id': None}
 
 
+    def accepted_external_formats(self):
+        return ['contigs']
+
+
+    def load_external_rows(self, external_format, content_df):
+        # a contigs-db external-structures file lists gene caller ids; validate each exists in the contigs
+        # database (a non-coding gene with no amino-acid sequence is caught later by check_external_integrity)
+        genes_in_contigs_database = set(self.contigs_super.genes_in_contigs_dict.keys())
+
+        rows = []
+        for _, row in content_df.iterrows():
+            gene_callers_id = int(row['gene_callers_id'])
+            if gene_callers_id not in genes_in_contigs_database:
+                raise ConfigError("The gene caller id '%d' in your external-structures file is not known to this "
+                                  "contigs database." % gene_callers_id)
+            rows.append({'gene_callers_id': gene_callers_id, 'path': row['path']})
+
+        self.external_rows = rows
+
+
     def enumerate_candidate_proteins(self, existing_proteins=None, raise_if_none=False):
+        # external-structures mode: the file itself is the selection, and the protein_id is the gene
+        # caller id (identity), so there is nothing to reconcile against an existing structure db.
+        if self.external_rows is not None:
+            genes_of_interest = set()
+            for row in self.external_rows:
+                self.external_path_map[row['gene_callers_id']] = row['path']
+                genes_of_interest.add(row['gene_callers_id'])
+            return genes_of_interest
+
         # a contigs-db protein_id is the gene caller id itself (identity), so there is nothing to
         # reconcile against an existing structure db: existing_proteins is intentionally ignored.
         A = lambda x: self.args.__dict__[x] if x in self.args.__dict__ else None
@@ -742,20 +771,41 @@ class PangenomeSource(StructureInputSource):
         return targets
 
 
-    def enumerate_candidate_proteins(self, existing_proteins=None, raise_if_none=False):
-        if raise_if_none and not (self.gene_cluster_ids or self.gene_clusters_of_interest_path):
-            raise ConfigError("You gotta supply some gene clusters of interest (--gene-cluster-ids or "
-                              "--gene-clusters-of-interest) when updating a pangenome structure database.")
+    def accepted_external_formats(self):
+        return ['pangenome_gene']
 
-        gene_cluster_names = self._selected_gene_cluster_names()
-        targets = self._target_genes(gene_cluster_names)
 
-        if not targets:
-            raise ConfigError("Anvi'o could not find any genes to model for the gene clusters you selected. That is "
-                              "unexpected -- are these gene clusters empty?")
+    def load_external_rows(self, external_format, content_df):
+        # a pangenome external-structures file lists (genome_name, gene_callers_id); validate each gene
+        # exists in the genomes storage and DERIVE its gene cluster from the pangenome (the cluster is not
+        # in the file). Runs before ids are minted, so it validates by natural key -- never by sequence.
+        rows = []
+        for _, row in content_df.iterrows():
+            genome_name = str(row['genome_name'])
+            gene_callers_id = int(row['gene_callers_id'])
 
-        # On update, reconcile surrogate ids against the existing db by natural key so add/--rerun reuse the
-        # ids already assigned (and mint fresh, non-colliding ids only for genuinely new proteins).
+            self.pan_super.genomes_storage.is_known_genome(genome_name)
+            self.pan_super.genomes_storage.is_known_gene_call(genome_name, gene_callers_id)
+
+            gc_id = self.pan_super.gene_callers_id_to_gene_cluster.get(genome_name, {}).get(gene_callers_id)
+            if gc_id is None:
+                raise ConfigError("Gene caller id '%d' of genome '%s' (from your external-structures file) is not part "
+                                  "of any gene cluster in this pangenome, so anvi'o cannot associate a structure with it "
+                                  "here." % (gene_callers_id, genome_name))
+
+            rows.append((genome_name, gene_callers_id, gc_id, row['path']))
+
+        self.external_rows = rows
+
+
+    def _mint_protein_ids(self, targets, existing_proteins, paths_by_natural_key=None):
+        """Assign a surrogate protein_id to each (genome_name, gene_callers_id, gene_cluster_id) target.
+
+        On update, `existing_proteins` (the proteins-table dataframe) seeds the natural-key -> id map so
+        proteins already in the db keep their id and only new ones get fresh, non-colliding ids -- this is
+        what keeps add/--rerun idempotent. When `paths_by_natural_key` is given (external-structures mode),
+        each protein's PDB path is recorded in external_path_map so it can be imported later.
+        """
         natural_key_to_id = {}
         next_id = 0
         if existing_proteins is not None and len(existing_proteins):
@@ -787,9 +837,36 @@ class PangenomeSource(StructureInputSource):
                 'gene_cluster_id': gc_id,
                 'source_key': '%s:%s:%d' % (gc_id, genome_name, int(gene_callers_id)),
             }
+            if paths_by_natural_key is not None:
+                self.external_path_map[protein_id] = paths_by_natural_key[natural_key]
+
             protein_ids.add(protein_id)
 
         return protein_ids
+
+
+    def enumerate_candidate_proteins(self, existing_proteins=None, raise_if_none=False):
+        # external-structures mode: the file is the selection. Restrict targets to its rows, remember each
+        # row's PDB path, and mint ids by the same natural-key reconciliation as the predict path.
+        if self.external_rows is not None:
+            targets = [(genome_name, gene_callers_id, gc_id)
+                       for genome_name, gene_callers_id, gc_id, _ in self.external_rows]
+            paths_by_natural_key = {(genome_name, int(gene_callers_id)): path
+                                    for genome_name, gene_callers_id, _, path in self.external_rows}
+            return self._mint_protein_ids(targets, existing_proteins, paths_by_natural_key=paths_by_natural_key)
+
+        if raise_if_none and not (self.gene_cluster_ids or self.gene_clusters_of_interest_path):
+            raise ConfigError("You gotta supply some gene clusters of interest (--gene-cluster-ids or "
+                              "--gene-clusters-of-interest) when updating a pangenome structure database.")
+
+        gene_cluster_names = self._selected_gene_cluster_names()
+        targets = self._target_genes(gene_cluster_names)
+
+        if not targets:
+            raise ConfigError("Anvi'o could not find any genes to model for the gene clusters you selected. That is "
+                              "unexpected -- are these gene clusters empty?")
+
+        return self._mint_protein_ids(targets, existing_proteins)
 
 
     def get_protein_spec(self, protein_id):
@@ -886,11 +963,6 @@ class StructureSuperclass(object):
         self.pan_db_path = A('pan_db', null)
 
         if self.pan_db_path:
-            if self.external_structures_path:
-                raise ConfigError("You provided a pangenome (--pan-db) together with --external-structures. These are "
-                                  "mutually exclusive: a structure database is built either by predicting structures for "
-                                  "the genes of a pangenome, or by importing pre-computed structures for a single contigs "
-                                  "database, not both.")
             self.input_source = PangenomeSource(self.args, run=self.run, progress=self.progress)
         else:
             self.input_source = ContigsDBSource(self.args, run=self.run, progress=self.progress)
@@ -1216,7 +1288,9 @@ class StructureSuperclass(object):
             if self.dump_dir:
                 raise ConfigError("No sense providing a --dump-dir when --external-structures are provided.")
 
-            self.external_structures = ExternalStructuresFile(path=self.external_structures_path, contigs_db_path=self.contigs_db_path)
+            # the file is parsed and validated against whatever input source is active (contigs-db or
+            # pangenome); it hands its rows to the source, which will mint protein_ids at enumerate time
+            self.external_structures = ExternalStructuresFile(path=self.external_structures_path, input_source=self.input_source)
 
 
     def get_genes_of_interest(self, genes_of_interest_path=None, gene_caller_ids=None, raise_if_none=False):
@@ -1234,13 +1308,23 @@ class StructureSuperclass(object):
         genes_of_interest = None
 
         if self.run_mode == 'external':
-            if genes_of_interest_path or gene_caller_ids:
-                raise ConfigError("You can't provide a --gene-caller-ids or --genes-of-interest concurrently with --external-structures. "
-                                  "If you are trying to create a database from a subset of structures in your external structures file, "
-                                  "please instead create an external structures file containing only those structures and use that instead."
-                                  "Sorry for the inconvenience.")
+            # the external-structures file is itself the selection; it must not be combined with any
+            # gene/gene-cluster selection flag (of either input type)
+            A = lambda x: self.args.__dict__.get(x)
+            if genes_of_interest_path or gene_caller_ids or A('gene_cluster_ids') or \
+               A('gene_clusters_of_interest') or A('select_representative'):
+                raise ConfigError("You can't combine --external-structures with a gene or gene-cluster selection "
+                                  "(--gene-caller-ids / --genes-of-interest / --gene-cluster-ids / "
+                                  "--gene-clusters-of-interest / --select-representative). The external-structures file "
+                                  "is itself the selection: put exactly the structures you want into it.")
 
-            genes_of_interest = self.external_structures.content['gene_callers_id']
+            # the source already parsed the file (in sanity_check) and stashed its rows; enumerate mints
+            # the protein_ids (reconciling against the existing db on update) and records each PDB path
+            existing_proteins = None if self.create else self.structure_db.get_proteins_dataframe()
+            genes_of_interest = self.input_source.enumerate_candidate_proteins(existing_proteins=existing_proteins,
+                                                                               raise_if_none=raise_if_none)
+            # every imported PDB's sequence must match the sequence anvi'o has for that protein
+            self.input_source.check_external_integrity(genes_of_interest)
             return genes_of_interest
 
         # every other mode enumerates the proteins of interest through the input source. On update, the
@@ -1863,7 +1947,7 @@ class StructureSuperclass(object):
 
         elif self.run_mode == 'external':
 
-            structure = self.external_structures.get_structure(protein_id)
+            structure = Structure(self.input_source.get_external_structure_path(protein_id))
             if self.skip_gene_if_not_clean(protein_id, sequence=structure.get_sequence()):
                 return structure_info
 
@@ -1887,7 +1971,7 @@ class StructureSuperclass(object):
             'models': {'molpdf': [0], 'GA341_score': [0], 'DOPE_score': [0], 'picked_as_best': [True]},
             'protein_id': protein_id,
             'structure_exists': True,
-            'best_model_path': self.external_structures.get_path(protein_id),
+            'best_model_path': self.input_source.get_external_structure_path(protein_id),
             'best_score': None,
             'scoring_method': self.modeller_params['scoring_method'],
             'percent_cutoff': self.modeller_params['percent_cutoff'],

--- a/anvio/tests/run_component_tests_for_structure_pangenome.sh
+++ b/anvio/tests/run_component_tests_for_structure_pangenome.sh
@@ -172,4 +172,97 @@ if ! diff -u proteins_before_rerun.tsv proteins_after_rerun.tsv; then
 fi
 echo "  OK: rerun left the proteins table identical (idempotent)"
 
+# ===================================================================================================
+# TEST 4 -- external structures (by-gene) create: import pre-computed PDBs for a pangenome
+# ===================================================================================================
+# A round-trip: export the structures we just modelled, then re-import them as *external* structures via
+# the new by-gene format (genome_name, gene_callers_id, path). Because these PDBs were modelled from the
+# exact genomes-storage sequences, they pass anvi'o's PDB-vs-genomes-storage integrity check by
+# construction. anvi'o must derive each gene's gene_cluster_id from the pangenome (not in the file).
+INFO "Exporting the modelled structures so we can feed them back as external structures"
+anvi-export-structures -s STRUCTURE_PAN_ALL.db -o EXPORTED_ALL
+
+NUM_EXPORTED=$(sqlite3 STRUCTURE_PAN_ALL.db "SELECT COUNT(*) FROM proteins WHERE has_structure=1;")
+INFO "  exported $NUM_EXPORTED structures"
+
+# build a by-gene external-structures file pointing at the exported PDBs (gene_<protein_id>.pdb)
+{ echo -e "genome_name\tgene_callers_id\tpath"
+  sqlite3 -separator $'\t' STRUCTURE_PAN_ALL.db \
+      "SELECT genome_name, gene_callers_id, protein_id FROM proteins WHERE has_structure=1 ORDER BY protein_id;" \
+      | awk -F'\t' '{print $1"\t"$2"\tEXPORTED_ALL/gene_"$3".pdb"}'
+} > ext_by_gene.txt
+cat ext_by_gene.txt
+
+INFO "anvi-gen-structure-database from a pangenome with EXTERNAL structures (by-gene format)"
+anvi-gen-structure-database --pan-db TEST-PAN.db -g TEST-GENOMES.db \
+                            --external-structures ext_by_gene.txt \
+                            --debug \
+                            -o STRUCTURE_EXT_GENE.db
+
+assert_eq "$(input_type_of STRUCTURE_EXT_GENE.db)" "pangenome" \
+          "external pangenome db records input_type=pangenome"
+assert_eq "$(proteins_count STRUCTURE_EXT_GENE.db)" "$NUM_EXPORTED" \
+          "one protein per external-structures row"
+assert_eq "$(structures_count STRUCTURE_EXT_GENE.db)" "$NUM_EXPORTED" \
+          "every imported external structure is stored"
+assert_eq "$(proteins_fully_provenanced STRUCTURE_EXT_GENE.db)" "$NUM_EXPORTED" \
+          "every imported protein carries full provenance (gene_cluster_id derived from the pan)"
+
+# the provenance recorded on import (genome, gene_callers_id, and the DERIVED gene_cluster_id) must
+# match the source db these PDBs came from
+sqlite3 -separator $'\t' STRUCTURE_PAN_ALL.db \
+    "SELECT genome_name, gene_callers_id, gene_cluster_id FROM proteins WHERE has_structure=1 ORDER BY genome_name, gene_callers_id;" > prov_source.tsv
+sqlite3 -separator $'\t' STRUCTURE_EXT_GENE.db \
+    "SELECT genome_name, gene_callers_id, gene_cluster_id FROM proteins ORDER BY genome_name, gene_callers_id;" > prov_external.tsv
+if ! diff -u prov_source.tsv prov_external.tsv; then
+    echo ""
+    echo "ASSERTION FAILED: imported external provenance (incl. derived gene_cluster_id) does not match the source"
+    exit 1
+fi
+echo "  OK: imported provenance (incl. auto-derived gene_cluster_id) matches the predicted db"
+
+# ===================================================================================================
+# TEST 5 -- external structures update: adding rows reconciles ids by natural key (idempotent)
+# ===================================================================================================
+# Create a db from only GC_A's external structures, then ADD GC_B's. The GC_A ids must not move -- the
+# same natural-key reconciliation that governs the predict-update path must govern external-update too.
+INFO "Building per-cluster external-structures files from the exported PDBs"
+{ echo -e "genome_name\tgene_callers_id\tpath"
+  sqlite3 -separator $'\t' STRUCTURE_PAN_ALL.db \
+      "SELECT genome_name, gene_callers_id, protein_id FROM proteins WHERE has_structure=1 AND gene_cluster_id='$GC_A' ORDER BY protein_id;" \
+      | awk -F'\t' '{print $1"\t"$2"\tEXPORTED_ALL/gene_"$3".pdb"}'
+} > ext_gene_A.txt
+{ echo -e "genome_name\tgene_callers_id\tpath"
+  sqlite3 -separator $'\t' STRUCTURE_PAN_ALL.db \
+      "SELECT genome_name, gene_callers_id, protein_id FROM proteins WHERE has_structure=1 AND gene_cluster_id='$GC_B' ORDER BY protein_id;" \
+      | awk -F'\t' '{print $1"\t"$2"\tEXPORTED_ALL/gene_"$3".pdb"}'
+} > ext_gene_B.txt
+
+N_A=$(($(wc -l < ext_gene_A.txt) - 1))
+N_B=$(($(wc -l < ext_gene_B.txt) - 1))
+
+INFO "External create from GC_A structures only"
+anvi-gen-structure-database --pan-db TEST-PAN.db -g TEST-GENOMES.db \
+                            --external-structures ext_gene_A.txt --debug \
+                            -o STRUCTURE_EXT_UPD.db
+assert_eq "$(proteins_count STRUCTURE_EXT_UPD.db)" "$N_A" \
+          "external create imports GC_A structures"
+
+proteins_map STRUCTURE_EXT_UPD.db > ext_before_add.tsv
+
+INFO "anvi-update-structure-database: ADD GC_B external structures"
+anvi-update-structure-database --pan-db TEST-PAN.db -g TEST-GENOMES.db \
+                               -s STRUCTURE_EXT_UPD.db \
+                               --external-structures ext_gene_B.txt --debug
+assert_eq "$(proteins_count STRUCTURE_EXT_UPD.db)" "$((N_A + N_B))" \
+          "external update appends GC_B structures"
+
+proteins_map STRUCTURE_EXT_UPD.db | head -n $N_A > ext_after_add_head.tsv
+if ! diff -u ext_before_add.tsv ext_after_add_head.tsv; then
+    echo ""
+    echo "ASSERTION FAILED: external update re-minted or reshuffled existing protein_ids"
+    exit 1
+fi
+echo "  OK: external update left the pre-existing protein_id mapping unchanged (idempotent)"
+
 INFO "All pangenome structure-database assertions passed."


### PR DESCRIPTION
`anvi-gen-structure-database` / `anvi-update-structure-database` import pre-computed structures (`--external-structures`) for the genes of a pangenome, not just a contigs-db, if you already have them or want to use a different prediction software than MODELLER and ColabFold.

Biggest change on the side of the user is an updated external-structure file which needs "genome name" and "gene caller id" in addition to the path to a structure file. The gene cluster id is discovered by anvi'o with the pan db, and the same external structure can be used by pan db made using different clustering parameters.
Internally, ExternalStructureFile becomes a source-agnostic parser/validator (detects the valid format of the external structure, file exists, etc).

And we also have associated new tests.