### PR TITLE
Contig export with genes of interest

### DIFF
--- a/anvio/cli/export_contigs.py
+++ b/anvio/cli/export_contigs.py
@@ -5,11 +5,16 @@ import sys
 from anvio.argparse import ArgumentParser
 
 import anvio
+import anvio.dbops as dbops
 import anvio.utils as utils
 import anvio.terminal as terminal
 import anvio.filesnpaths as filesnpaths
 
 from anvio.errors import ConfigError, FilesNPathsError
+
+
+pp = terminal.pretty_print
+P = terminal.pluralize
 
 
 __copyright__ = "Copyleft 2015-2024, The Anvi'o Project (http://anvio.org/)"
@@ -19,6 +24,7 @@ __version__ = anvio.__version__
 __authors__ = ['meren']
 __requires__ = ['contigs-db']
 __provides__ = ['contigs-fasta']
+__can_use__ = ['genes-of-interest-txt']
 __description__ = "Export contigs (or splits) from an anvi'o contigs database"
 
 
@@ -27,9 +33,16 @@ def main():
     run = terminal.Run()
 
     try:
+        if args.contigs_of_interest and args.genes_of_interest:
+            raise ConfigError("You can use either --contigs-of-interest or --genes-of-interest to limit the "
+                              "sequences anvi'o will export, but not both of them at the same time. Please remove "
+                              "one of these parameters from your command and try again.")
+
         if args.contigs_of_interest:
             filesnpaths.is_file_tab_delimited(args.contigs_of_interest, expected_number_of_fields=1)
             seq_names_to_export = [line.strip() for line in open(args.contigs_of_interest).readlines()]
+        elif args.genes_of_interest:
+            seq_names_to_export = get_seq_names_for_gene_caller_ids_of_interest(args, run=run)
         else:
             seq_names_to_export = None
 
@@ -51,11 +64,71 @@ def main():
         sys.exit(-1)
 
 
+def get_seq_names_for_gene_caller_ids_of_interest(args, run=terminal.Run()):
+    """Resolves a file of gene caller ids into the names of sequences that contain them.
+
+    Depending on whether the user is in splits mode or not, the resulting names will be
+    split names or contig names.
+
+    Parameters
+    ==========
+    args : argparse.Namespace
+        Must contain `contigs_db`, `genes_of_interest`, and `splits_mode`.
+
+    Returns
+    =======
+    seq_names_to_export : list
+        Sorted list of unique contig (or split) names that contain the gene calls of interest.
+    """
+
+    filesnpaths.is_file_tab_delimited(args.genes_of_interest, expected_number_of_fields=1)
+
+    gene_caller_ids_of_interest = set([line.strip() for line in open(args.genes_of_interest).readlines() if line.strip()])
+
+    if not len(gene_caller_ids_of_interest):
+        raise ConfigError(f"The file you have provided via --genes-of-interest at '{args.genes_of_interest}' "
+                          f"seems to be empty :/")
+
+    try:
+        gene_caller_ids_of_interest = set([int(g) for g in gene_caller_ids_of_interest])
+    except ValueError:
+        raise ConfigError(f"At least one of the entries in your genes of interest file at "
+                          f"'{args.genes_of_interest}' does not look like an anvi'o gene caller id (which are "
+                          f"always integers). Please make sure the file has a single column of gene caller ids and "
+                          f"no column header.")
+
+    contigs_db = dbops.ContigsSuperclass(args, r=terminal.Run(verbose=False))
+
+    missing_gene_caller_ids = gene_caller_ids_of_interest.difference(set(contigs_db.genes_in_contigs_dict.keys()))
+    if len(missing_gene_caller_ids):
+        raise ConfigError(f"Anvi'o is having a hard time here: {P('gene call', len(missing_gene_caller_ids))} in your "
+                          f"genes of interest file {P('is', len(missing_gene_caller_ids), alt='are')} not in the "
+                          f"contigs database at '{args.contigs_db}'. Here "
+                          f"{P('it is', len(missing_gene_caller_ids), alt='are some of them')}: "
+                          f"{', '.join([str(g) for g in sorted(missing_gene_caller_ids)[:10]])}.")
+
+    if args.splits_mode:
+        # a single gene call may be spread across more than one split, and the `genes_in_splits`
+        # table has one entry per gene call per split, so we collect every split a gene appears in
+        seq_names_to_export = set([])
+        for entry in contigs_db.genes_in_splits.values():
+            if entry['gene_callers_id'] in gene_caller_ids_of_interest:
+                seq_names_to_export.add(entry['split'])
+    else:
+        seq_names_to_export = set([contigs_db.genes_in_contigs_dict[g]['contig'] for g in gene_caller_ids_of_interest])
+
+    run.info('Genes of interest', f"{pp(len(gene_caller_ids_of_interest))} gene calls found in the input file")
+    run.info('Sequences that match', f"{pp(len(seq_names_to_export))} {'splits' if args.splits_mode else 'contigs'}")
+
+    return sorted(seq_names_to_export)
+
+
 def get_args():
     parser = ArgumentParser(description=__description__)
 
     parser.add_argument(*anvio.A('contigs-db'), **anvio.K('contigs-db'))
     parser.add_argument(*anvio.A('contigs-of-interest'), **anvio.K('contigs-of-interest'))
+    parser.add_argument(*anvio.A('genes-of-interest'), **anvio.K('genes-of-interest'))
     parser.add_argument('--splits-mode', default=False, action="store_true", help="Export split\
                         sequences instead.")
     parser.add_argument(*anvio.A('output-file'), **anvio.K('output-file', {'required': True}))

--- a/anvio/docs/programs/anvi-export-contigs.md
+++ b/anvio/docs/programs/anvi-export-contigs.md
@@ -1,13 +1,13 @@
 This program **exports the contig sequences from a %(contigs-db)s**, outputting them as a %(contigs-fasta)s. It also has the ability to output the sequences of your splits instead.
 
-You can run this program as follows:
+You can run this program as follows, which will return ALL contigs in a given %(contigs-db)s file:
 
 {{ codestart }}
 anvi-export-contigs -c %(contigs-db)s \
                     -o path/to/%(contigs-fasta)s
 {{ codestop }}
 
-To run it on only a named subset of your contigs, you can provide a list of contigs as a separate file (in the same format as a %(splits-txt)s). For example:
+You can also limit the contigs you may be interested in to a subset by providing the list of contig names you wish to export in a file. For example:
 
 {{ codestart }}
 anvi-export-contigs -c %(contigs-db)s \
@@ -17,9 +17,29 @@ anvi-export-contigs -c %(contigs-db)s \
 
 where `my_favorite_contigs.txt` looks like this:
 
-    contig_0001
-    contig_0005
-    contig_0035
+```
+contig_0001
+contig_0005
+contig_0035
+```
+
+Alternatively, you may be interested in contigs that include one or more *genes* you are interested. In that case you can use `--genes-of-interest` with a %(genes-of-interest-txt)s, and anvi'o will export only those contigs that contain at least one of the gene calls you listed:
+
+{{ codestart }}
+anvi-export-contigs -c %(contigs-db)s \
+                    -o path/to/%(contigs-fasta)s \
+                    --genes-of-interest my_favorite_genes.txt
+{{ codestop }}
+
+where `my_favorite_genes.txt` looks like this:
+
+```
+5
+13
+206
+```
+
+Please note that `--contigs-of-interest` and `--genes-of-interest` are mutually exclusive: you can use one or the other in a given command, but not both at the same time.
 
 ### Splits mode
 


### PR DESCRIPTION
This PR introduces a new flag to `anvi-export-contigs` so it can export sequences of contigs (or splits) from a `contigs-db` file that encode one or more of the gene calls the user declares with the new flag `--gene-calls-of-interest`.