### PR TITLE
Much more stringent consideration of reference genomes

### DIFF
--- a/anvio/cli/reorient_genomes.py
+++ b/anvio/cli/reorient_genomes.py
@@ -45,11 +45,27 @@ def get_args():
     groupA.add_argument(*anvio.A('output-dir'), **anvio.K('output-dir', {'required': True}))
 
     groupRef = parser.add_argument_group('SELECTION & PROCESSING OF REFERENCE',
-                                         "If you do not set --reference, the program will auto-select a reference by "
-                                         "choosing the genome with the fewest contigs; ties are broken by the largest "
-                                         "total length. This mirrors how anvi'o tools often prioritize more complete assemblies.")
+                                         "IMPORTANT: the reference MUST be a single contig, since orienting and ordering "
+                                         "contigs requires a single continuous coordinate system to work against, and "
+                                         "coordinates from different contigs of a fragmented reference do not form one "
+                                         "axis. The program will STOP WITH AN ERROR otherwise. Please note that this is a "
+                                         "separate matter from circularity: the reference additionally needs to be a "
+                                         "COMPLETE, CIRCULAR sequence if anvi'o is going to ROTATE it, which happens when "
+                                         "the reference is auto-selected, or when --use-dnaa-for-reference-orientation is "
+                                         "used, since rotating a linear sequence or a fragment of a chromosome is "
+                                         "biologically meaningless. If your reference is a genomic locus rather than a "
+                                         "complete chromosome, name it explicitly with --reference, which never rotates "
+                                         "anything. If you do not set --reference, the program will auto-select a reference "
+                                         "by choosing the genome with the fewest contigs (ties are broken by the largest "
+                                         "total length), and it will refuse to continue if even that genome turns out to "
+                                         "have more than one contig. The only way to work with a fragmented reference is "
+                                         "--use-auto-reference-as-is, which skips all steps of rotation over the reference, "
+                                         "and uses it as is.")
     groupRef.add_argument('--reference', required=False,
-                          help="Genome name in fasta-txt to use as the reference orientation. If omitted, auto-selection applies.")
+                          help="Name of the entry in fasta-txt to use as the reference orientation. It must be a single "
+                               "contig, but it does not have to be a complete circular genome: a single contig covering a "
+                               "genomic locus of interest works just as well, since anvi'o never rotates a reference you "
+                               "name explicitly here. If omitted, auto-selection applies.")
     groupRef.add_argument('--use-auto-reference-as-is', action='store_true',
                           help="When anvi'o selects the reference genome automatically (i.e., when `--reference` parameter is not "
                                "used) it first chooses the genome with the fewest contigs and then longest among those that have "
@@ -58,14 +74,21 @@ def get_args():
                                "tinker with the auto-picked reference orientation. This is most useful when the collection of "
                                "genomes (or contigs) all start with an evolutionarily meaningful positions, and all you want to "
                                "do is to reverse complement those that need it so all genomes (or contigs) have the same "
-                               "orientation. This flag is obviously not compatible with `--reference` and "
+                               "orientation. This is ALSO the only supported way to move forward when none of the genomes in "
+                               "your fasta-txt file is a single contig -- but please be aware of what you are giving up: since "
+                               "coordinates that come from different contigs of a fragmented reference do not form a single "
+                               "continuous axis, the contig ordering, the scaffolding output, and the reported start positions "
+                               "will not be trustworthy. This flag is obviously not compatible with `--reference` and "
                                "`--use-dnaa-for-reference-orientation`.")
     groupRef.add_argument('--use-dnaa-for-reference-orientation', action='store_true',
                           help="Use DnaA gene location to orient the reference genome. The program will identify the DnaA "
                                "gene using an HMM profile (Bac_DnaA_C from Pfam), and rotate the reference to start near "
-                               "the DnaA gene, which typically marks the origin of replication in bacterial genomes. This "
+                               "the DnaA gene, which typically marks the origin of replication in bacterial genomes. Since "
+                               "this rotates the reference, it requires the reference genome to be a single contig. This "
                                "option is useful for bacterial genomes but may not work well for plasmids or viral genomes "
-                               "without DnaA.")
+                               "without DnaA, or fragments from genomes such as specific genomic loci you are interested in "
+                               "(for such cases you should certainly consider naming your reference explicitly with "
+                               "`--reference`, which never rotates it, or using `--use-auto-reference-as-is`).")
 
     groupScaffold = parser.add_argument_group('SCAFFOLDING OPTIONS',
                                               "These options control how multi-contig (fragmented) genomes are ordered "

--- a/anvio/docs/programs/anvi-reorient-genomes.md
+++ b/anvio/docs/programs/anvi-reorient-genomes.md
@@ -2,6 +2,28 @@
 
 It reports (1) alignment quality between each pair of genomes (coverage between the two genomes and very crappy approximate ANI that no one should trust), (2) what actions were taken to reach a consensus (reverse-complement, rotations, contig ordering, etc), and (3) a final determination of the level of trust one should have for outcomes. The program also generates synteny ribbon plots to visualize the alignment patterns between each genome and the reference before and after reorientation.
 
+### Critical considerations of 'reference'
+
+How to treat your reference is the **single most important thing to know about this program**, and there are a few considerations to keep in mind.
+
+Does your reference have to be a single-contig? Short answer: yes, it must be. But it doesn't necessarily be a complete, circular genome. It has to be that way only if you will let/ask anvi'o to rotate it. Here is a longer why:
+
+* **The reference must always be a single contig.** Orienting contigs, ordering them, and scaffolding them all require a single, continuous coordinate system different contigs from a fragmented reference cannot offer. Anvi'o will stop with an error if the reference (whether you passed it explicitly or it is auto-selected by anvi'o for you) contains more than one contig. The *only way* around this error is to use `--use-auto-reference-as-is`, which comes with other caveats you must consdier (explained below).
+
+* **The reference must *additionally* be complete and circular if anvi'o IS going to ROTATE it.** Rotation of the reference happens in two cases. If the reference is auto-selected (anvi'o rotates it to a conserved start position that all input genomes share), or when you ask anvi'o to use DnaA gene to orient the reference. But you have to keep in mind that rotating a linear sequence or a fragment of a chromosome is a biologically meaningless operation (since a fragment does not capture the entirety of a circular chromosome, so there is no coordinate to 'rotate around'). But anvi'o cannot know this since it cannot know what kind of sequences you are working with. **This requirement does not apply if nothing is being rotated**, so if you have sequences that shouldn't be rotated, you either name a reference explicitly `--reference` or tell anvi'o to use the reference it automatically choses as is with `--use-auto-reference-as-is`.
+
+So, does your reference have to be a complete circular genome? Not necessarily. But the answer really depends on what you are planning to do with it. Here are some more ideas for you to think about before running this tool:
+
+* **If you are working with complete bacterial or archaeal chromosomes** (or circular plasmids or viral genomes) and you care about where each genome *starts* (so that the origin of replication .. or another evolutionary meaningful and/or conserved region lines up nicely across your collection), then yes, rotation is the whole point, and both your reference and your parameters matter a great deal. Let anvi'o auto-select and rotate the reference, or reach for `--use-dnaa-for-reference-orientation`.
+
+* **If you are working with a genomic locus**, such as a genomic region of interest, a prophage, an operon and its neighborhood, and all your other sequences are fragmented versions of that same region, then rotation is neither needed nor meaningful. All you want is for the contigs to be reverse-complemented and ordered carefully so they follow the reference as closely as possible. A single contig covering your locus is a perfectly good reference here. Just name it with `--reference` and anvi'o will leave it exactly as it is.
+
+Finally, please note that all of this applies **only to the reference**. Every *other* entry in your %(fasta-txt)s file is free to be as fragmented as they come.
+
+If this is confusing please reach out to us, and we will try to make it less confusing (*I will take "unfulfillable promises" for $200* (well, yes, but you can't know until we/you try)).
+
+### Default usage
+
 The default usage is simple, which will simply instruct anvi'o to **take care of everything *de novo***,
 
 {{ codestart }}
@@ -30,12 +52,12 @@ anvi-reorient-genomes --fasta-txt %(fasta-txt)s \
 {:.notice}
 TL;DR: Best for any set of highly similar genomes - whether circular (viral, plasmids, complete bacterial genomes) or fragmented (MAGs, draft assemblies). For circular genomes, uses secondary alignments from `minimap2` to find the most conserved position across all genomes in a data-driven manner. For fragmented genomes, orders and orients contigs based on their alignment to the reference.
 
-If the user does not explicitly mention a reference genome, **the program will auto-select the genome with the fewest contigs as reference** (ties broken by longest total length), preferring complete circular genomes over fragmented ones. It will then rotate the reference genome to an optimal starting position that is conserved across most of the input genomes mentioned in the %(fasta-txt)s file in a *mindful* fashion. It is 'mindful' because %(anvi-reorient-genomes)s does this step by first aligning each genome to the reference **using all possible good alignments (primary + secondary alignments)** to get a true picture of conserved regions across all genomes, and then using a 1,000 bp sliding window to search for a region that is shared between all genomes in a greedy fashion (once it finds a region that works for all genomes, it stops).
+If the user does not explicitly mention a reference genome, **the program will auto-select the genome with the fewest contigs as reference** (ties broken by longest total length), preferring complete circular genomes over fragmented ones. If the winner of that contest *still* has more than one contig, the program will stop with an error rather than rotate a fragment (see 'What if none of my sequences is a single contig?' below). Otherwise, it will rotate the reference genome to an optimal starting position that is conserved across most of the input genomes mentioned in the %(fasta-txt)s file in a *mindful* fashion. It is 'mindful' because %(anvi-reorient-genomes)s does this step by first aligning each genome to the reference **using all possible good alignments (primary + secondary alignments)** to get a true picture of conserved regions across all genomes, and then using a 1,000 bp sliding window to search for a region that is shared between all genomes in a greedy fashion (once it finds a region that works for all genomes, it stops).
 
 {:.notice}
 Please note that when a reference genome is chosen automatically, the program will likely end up rotating the automatically chosen reference genome to a more meaningful and conserved start position to maximize agreements across all genomes.
 
-If you have a reference genome that you trust (downloaded from a reliable source or manually circularized), you can ask the program to use that as a reference. In which case the program will not be tinkering with the reference, and do its best to match every other genome to it.
+If you have a reference sequence that you trust (downloaded from a reliable source, manually circularized, or simply the locus you happen to care about), you can ask the program to use that as a reference with `--reference`. In which case the program will not be tinkering with the reference (unless you also use `--use-dnaa-for-reference-orientation`, which will rotate it to the DnaA gene), and do its best to match everything else to it. It must be a single contig, or the program will stop with an error -- but since nothing is being rotated, it does *not* need to be a complete circular genome.
 
 If you want anvi'o to still auto-select the reference (fewest contigs, longest total length) but use it **without any rotation**, you can use `--use-auto-reference-as-is`:
 
@@ -46,6 +68,22 @@ anvi-reorient-genomes --fasta-txt %(fasta-txt)s \
 {{ codestop }}
 
 This flag is incompatible with `--reference` (you cannot specify a reference and also ask for auto-selection) and with `--use-dnaa-for-reference-orientation` (which would rotate the reference, defeating the purpose of using it as-is).
+
+### What if none of my sequences is a single contig?
+
+Since the reference must be a single contig, a %(fasta-txt)s file in which *every* entry is fragmented (a set of MAGs, say) will make the program stop with an error. You have two options.
+
+**The good option** is to add a single-contig reference to your %(fasta-txt)s file and point anvi'o to it:
+
+{{ codestart }}
+anvi-reorient-genomes --fasta-txt %(fasta-txt)s \
+                      --reference MY-SINGLE-CONTIG-REFERENCE \
+                      --output-dir REORIENTED-FASTA-FILES/
+{{ codestop }}
+
+Remember that this reference does not have to be a complete circular genome. If you are working with whole chromosomes, a complete isolate genome from a public database is the natural choice. But if your genomes are really fragmented versions of one genomic region, then a single contig covering that region is just as good -- anvi'o will not rotate a reference you name explicitly, so circularity never enters the picture.
+
+**The limited option** is `--use-auto-reference-as-is`, which lets anvi'o pick the least fragmented entry and use it exactly as it is. Since nothing gets rotated, nothing biologically meaningless happens to the reference, and the program will still put everything on a consistent strand. But please be clear-eyed about what you are giving up: coordinates that come from *different contigs* of a fragmented reference do not form a single continuous axis, so the contig ordering, the `--scaffold-fragmented` output, and the reported 'Start in reference' / 'Start in query' values will not be trustworthy, and the trust labels in the final report are correspondingly much weaker statements. The program will remind you of all this with a big warning when you take this route.
 
 ### Using DnaA gene for biologically meaningful reference orientation
 
@@ -128,12 +166,12 @@ Please don't do it, though -- don't 'scaffold' your MAGs based on a reference an
 
 Here is a more detailed description of what is going on behind the scenes when you press ENTER:
 
-1. **Parse inputs and pick a reference**. Reads %(fasta-txt)s, and if `--reference` is not set, the program picks the genome with the fewest contigs (ties broken by longest total length). All FASTAs are sanity-checked (existence, FASTA format). The reference must be a single-contig circular genome.
+1. **Parse inputs and pick a reference**. Reads %(fasta-txt)s, and if `--reference` is not set, the program picks the genome with the fewest contigs (ties broken by longest total length). All FASTAs are sanity-checked (existence, FASTA format). The reference must be a single contig, and this is **enforced with an error**: no matter whether the reference came from `--reference` or from auto-selection, the program refuses to continue if it has more than one contig. The single exception is `--use-auto-reference-as-is`, which proceeds with a big warning instead of an error. An auto-selected reference additionally needs to be a complete, circular genome, since it is about to be rotated -- a reference named with `--reference` does not, since it never is.
 
 2. **Determine reference orientation**. The program uses one of three strategies to orient the reference genome:
-   - **DnaA-based orientation** (if `--use-dnaa-for-reference-orientation` is set): Calls genes with `prodigal`, searches for the DnaA gene using `hmmsearch` with the Bac_DnaA_C HMM profile, and rotates the reference to start at the DnaA gene position. This provides biologically meaningful orientation for bacterial genomes.
+   - **DnaA-based orientation** (if `--use-dnaa-for-reference-orientation` is set): Calls genes with `prodigal`, searches for the DnaA gene using `hmmsearch` with the Bac_DnaA_C HMM profile, and rotates the reference to start at the DnaA gene position. This provides biologically meaningful orientation for bacterial genomes. This strategy takes precedence over the two below, and applies to a user-specified reference just as much as to an auto-selected one.
    - **De novo optimal position** (if reference is auto-selected without DnaA flag): Aligns each genome to the reference using minimap2 with `--secondary=yes -N 100 -p 0.5` to capture **all possible good alignments** (not just the best one). Builds a coverage map using 1,000 bp bins showing which positions are covered by alignments from each genome. Identifies the position with maximum coverage across all genomes (stopping early if it finds 100%% coverage). The reference is then rotated to start at this optimal position, ensuring all genomes will start at a conserved region that is genuinely shared across the dataset.
-   - **User-specified reference** (if `--reference` is set): Uses the reference genome as-is without rotation.
+   - **User-specified reference** (if `--reference` is set without the DnaA flag): Uses the reference genome as-is without rotation.
    - **Auto-selected reference used as-is** (if `--use-auto-reference-as-is` is set): Auto-selects the reference (fewest contigs, longest total length) but skips any rotation, treating the auto-chosen genome exactly like a user-specified one.
 
 **For circular genomes (single-contig):**
@@ -175,7 +213,7 @@ Here is a more detailed description of what is going on behind the scenes when y
 
 * **Scaffolding fragmented genomes**: By default, fragmented genomes are written with contigs as separate sequences (ordered and oriented). Use `--scaffold-fragmented` to concatenate them into a single sequence with N-padding representing gaps. While this maximizes gene synteny for comparative analyses, **do not submit N-scaffolded MAGs as complete genomes** to public databases. The scaffolding is reference-based and may not represent the true genomic structure.
 
-* **Auto-selected reference and optimal start**: When you don't specify `--reference`, the program picks the genome with the fewest contigs (ties broken by longest total length), preferring complete circular genomes over fragmented ones. It then rotates the reference to a conserved position across your dataset using secondary alignments to capture all conserved regions (not just the single best alignment). This is especially useful for sets of closely related genomes where you want them all to start at a biologically meaningful position. For bacterial genomes, consider using `--use-dnaa-for-reference-orientation` for even more consistent results based on the replication origin. If you want a specific genome or starting position, use `--reference` to override this behavior. If you want anvi'o to auto-select the reference but skip the rotation step (i.e., keep it exactly as it appears in the input FASTA), use `--use-auto-reference-as-is`.
+* **Auto-selected reference and optimal start**: When you don't specify `--reference`, the program picks the genome with the fewest contigs (ties broken by longest total length), preferring complete circular genomes over fragmented ones -- and stops with an error if even the best candidate is not a single contig (use `--use-auto-reference-as-is` to proceed anyway, without any rotation). Since anvi'o is about to rotate this auto-selected reference, it should really be a complete circular genome -- if your sequences are linear loci rather than whole chromosomes, rotating them is meaningless, so name your reference explicitly with `--reference` instead. It then rotates the reference to a conserved position across your dataset using secondary alignments to capture all conserved regions (not just the single best alignment). This is especially useful for sets of closely related genomes where you want them all to start at a biologically meaningful position. For bacterial genomes, consider using `--use-dnaa-for-reference-orientation` for even more consistent results based on the replication origin. If you want a specific genome or starting position, use `--reference` to override this behavior. If you want anvi'o to auto-select the reference but skip the rotation step (i.e., keep it exactly as it appears in the input FASTA), use `--use-auto-reference-as-is`.
 
 * **DnaA-based orientation benefits**: When working with bacterial genomes, the `--use-dnaa-for-reference-orientation` flag typically produces highly consistent alignments (e.g., all genomes starting within a few base pairs of each other) because it uses biological knowledge (the replication origin) rather than purely sequence-based heuristics. This can be particularly valuable for downstream synteny analyses or when comparing gene order across closely related strains.
 

--- a/anvio/genomereorientation.py
+++ b/anvio/genomereorientation.py
@@ -25,6 +25,8 @@ __maintainer__ = "A. Murat Eren"
 __email__ = "a.murat.eren@gmail.com"
 __status__ = "Development"
 
+P = terminal.pluralize
+
 
 class PafRecord:
     def __init__(self, qname, qlen, qstart, qend, strand, tname, tlen, tstart, tend, nmatch, alen, mapq, tags):
@@ -279,13 +281,9 @@ class GenomeReorienter:
                               "not compatible with one another. The former keeps the auto-selected reference untouched. "
                               "The latter rotates it. Incompatible stuff.")
 
-        # Validate reference is single-contig if user-specified
-        if self.reference_name:
-            ref_contigs = self.genomes[self.reference_name]['num_contigs']
-            if ref_contigs != 1:
-                raise ConfigError(f"Reference genome '{self.reference_name}' must be a single-contig "
-                                  f"circular genome, but it has {ref_contigs} contigs. Please choose a "
-                                  f"different reference or let anvi'o auto-select one.")
+        # please note that whether the reference genome is a single contig or not is checked in
+        # `check_reference_is_single_contig`, which is called by `select_reference_genome` so the
+        # very same rule applies to user-specified and auto-selected references alike.
 
         self.output_dir = filesnpaths.check_output_directory(self.output_dir, ok_if_exists=False)
 
@@ -1619,27 +1617,125 @@ class GenomeReorienter:
     def select_reference_genome(self):
         """Determine the reference genome whether it is from the user or de novo"""
 
-        if self.reference_name:
+        user_specified = self.reference_name is not None
+
+        if user_specified:
             self.run.info("Reference genome", f"'{self.reference_name}' (specified by the user)")
             self.reference_path = self.genomes[self.reference_name]['path']
+        else:
+            candidate_stats = []
+            for genome_name, entry in self.genomes.items():
+                # `num_contigs` is already in `self.genomes` thanks to `sanity_check`, so there is no
+                # need to go through every FASTA file one more time here just to count sequences.
+                candidate_stats.append((entry['num_contigs'], -self._get_total_length(entry['path']), genome_name, entry['path']))
+
+            candidate_stats.sort()
+            chosen = candidate_stats[0]
+            self.reference_name = chosen[2]
+            self.reference_path = chosen[3]
+            chosen_contigs = chosen[0]
+            chosen_len = -chosen[1]
+            self.run.info("Reference genome", f"'{self.reference_name}' (selected by anvi'o)")
+            self.run.info("Reference contigs", chosen_contigs)
+            self.run.info("Reference length", chosen_len)
+
+        # everything this program does to the reference that involves 'rotations' assumes
+        # that the reference is a complete circular sequence. we can't really be 100% sure
+        # it the sequence is circular, but we can make sure at least some part of it (i.e.,
+        # being a single contig actually holds:
+        self.check_reference_is_single_contig(user_specified)
+
+
+    def check_reference_is_single_contig(self, user_specified):
+        """Make sure the reference genome is a single contig, and complain loudly if it is not.
+
+           This program needs the reference to be a single contig, since everything it does for the
+           user, such as orienting contigs, ordering them, scaffolding them, requires a single continuous
+           coordinate system to work against. Coordinates that come from different contigs of a
+           fragmented reference simply do not form one axis.
+
+           Please note that this is a separate concern from *circularity*. A reference must also be
+           a complete, circular sequence if (and only if) anvi'o is going to ROTATE it, which happens
+           when the reference is auto-selected, or when `--use-dnaa-for-reference-orientation` is
+           used. Rotating a linear sequence or a fragment of a chromosome is obviously meaningless.
+           But a single-contig genomic locus that is not circular at all is a perfectly good reference
+           for someone who only wants to orient/order other contigs against it, and in that case anvi'o
+           will not rotate anything (which is why `--reference` alone never triggers a rotation).
+
+           The only way out of the single-contig requirement is `--use-auto-reference-as-is`, which
+           also skips every rotation step. Even then the user gets a warning, since a multi-contig
+           reference still does not offer that single continuous coordinate system.
+
+        Parameters
+        ==========
+        user_specified : bool
+            Whether the reference genome was set by the user through `--reference`, or was chosen
+            by anvi'o automatically. This only influences which error message the user gets.
+        """
+
+        num_contigs = self.genomes[self.reference_name]['num_contigs']
+
+        if num_contigs == 1:
             return
 
-        candidate_stats = []
-        for genome_name, entry in self.genomes.items():
-            path = entry['path']
-            num_sequences = utils.get_num_sequences_in_fasta(path)
-            total_len = self._get_total_length(path)
-            candidate_stats.append((num_sequences, -total_len, genome_name, path))
+        if self.use_auto_reference_as_is:
+            # the user explicitly asked anvi'o to not tinker with the reference, so there will be no
+            # rotation, and thus nothing biologically meaningless will happen to the reference. but
+            # they still deserve to know what they are getting (and what they are not getting):
+            self.run.warning(f"The reference genome anvi'o selected for you, '{self.reference_name}', is not a single "
+                             f"contig :/ It is composed of {P('contig', num_contigs)}, and normally anvi'o would have "
+                             f"refused to work with it. But since you used the flag `--use-auto-reference-as-is`, anvi'o "
+                             f"will use it but NOT rotate it to any start position (which is exactly what that "
+                             f"flag asks for), so nothing biologically meaningless will be done to it. That said, "
+                             f"please keep the following in mind while you are interpreting the results: (1) the only "
+                             f"thing anvi'o is really doing for you here is putting all your sequences on a consistent "
+                             f"strand, (2) alignment coordinates that come from different contigs of the reference do "
+                             f"NOT form a single continuous axis, so the contig ordering, the output of "
+                             f"`--scaffold-fragmented`, and the 'Start in reference' / 'Start in query' numbers you "
+                             f"will see below should not be trusted, and (3) the trust labels in the final report are "
+                             f"computed on that same shaky basis, so they are much weaker statements than they would "
+                             f"be with a single-contig reference. In an ideal world you would add a single-contig "
+                             f"reference to your fasta-txt file and point anvi'o to it with `--reference`. That "
+                             f"reference does not have to be a complete circular genome, by the way. If you are "
+                             f"working with a genomic region rather than whole chromosomes, a single contig that "
+                             f"covers the locus of interest will do just fine.",
+                             header="YOUR REFERENCE IS NOT A SINGLE CONTIG", lc='yellow')
+            return
 
-        candidate_stats.sort()
-        chosen = candidate_stats[0]
-        self.reference_name = chosen[2]
-        self.reference_path = chosen[3]
-        chosen_contigs = chosen[0]
-        chosen_len = -chosen[1]
-        self.run.info("Reference genome", f"'{self.reference_name}' (selected by anvi'o)")
-        self.run.info("Reference contigs", chosen_contigs)
-        self.run.info("Reference length", chosen_len)
+        if user_specified:
+            raise ConfigError(f"The reference must be a single contig, but the one you chose with `--reference`, "
+                              f"'{self.reference_name}', is composed of {P('contig', num_contigs)} :/ This will "
+                              f"not work as everything this program does for you needs a single, continuous "
+                              f"coordinate system to work against, and coordinates that come from different contigs "
+                              f"of a fragmented reference can't offer that. IS THERE A SOLUTION? There is no "
+                              f"solution that will maek a multi-contig reference work for most applications, but "
+                              f"please look at the online help for this program anyway.")
+
+        genomes_with_a_single_contig = [g for g in self.genomes if self.genomes[g]['num_contigs'] == 1]
+
+        if not len(genomes_with_a_single_contig):
+            raise ConfigError(f"Anvi'o auto-selected '{self.reference_name}' as your reference since it had the fewest "
+                              f"contigs of the bunch, but it still is composed of {P('contig', num_contigs)}. In fact, "
+                              f"not a single one of the {P('entr', len(self.genomes), sfp='ies', sfs='y')} in your "
+                              f"fasta-txt file is a single contig, so there is nothing anvi'o can use here as a "
+                              f"reference :( Two things are going wrong at once here. First, anvi'o needs the reference to be a single "
+                              f"contig, since orienting and ordering contigs requires a single, continuous coordinate "
+                              f"system to work against. Second, when anvi'o auto-selects a reference it also ROTATES it "
+                              f"to a start position that is conserved across your dataset, and rotating a fragment of a "
+                              f"chromosome is a biologically meaningless operation. Your options: (1) add a "
+                              f"single-contig reference to your fasta-txt file and point anvi'o to it with "
+                              f"`--reference` (this can be a complete circular genome if you are working with whole "
+                              f"chromosomes, but it can just as well be a single contig covering a genomic locus of "
+                              f"interest, since anvi'o never rotates a reference you name explicitly), or (2) if all you "
+                              f"want is for everything to end up on the same strand with no rotation whatsoever, use "
+                              f"the flag `--use-auto-reference-as-is` (and please do read what it does first, since the "
+                              f"results will be much more limited, and for that kind of reading, the online help is likely "
+                              f"much more useful here than the program help menu).")
+
+        # if we are here, anvi'o somehow managed to pick a multi-contig reference even though there were
+        # single-contig genomes to choose from. so, if this is happening, someone changed something
+        # somehwere they shouldn't have and we need to take a look:
+        raise ConfigError(f"Something unexpected happened, and anvi'o needs a visit from its programmers :(")
 
 
     def _get_total_length(self, fasta_path):

--- a/anvio/genomereorientation.py
+++ b/anvio/genomereorientation.py
@@ -1735,7 +1735,7 @@ class GenomeReorienter:
         # if we are here, anvi'o somehow managed to pick a multi-contig reference even though there were
         # single-contig genomes to choose from. so, if this is happening, someone changed something
         # somehwere they shouldn't have and we need to take a look:
-        raise ConfigError(f"Something unexpected happened, and anvi'o needs a visit from its programmers :(")
+        raise ConfigError("Something unexpected happened, and anvi'o needs a visit from its programmers :(")
 
 
     def _get_total_length(self, fasta_path):


### PR DESCRIPTION
This PR forces `anvi-reorient-genomes` and its user to be much more careful about the reference genome selection.

Essentially multi-contig references should never be 'rotated' since rotations are basically meaningless if we don't have a biologically meaningful coordinate system, or non-circular genomes :/

Luckily we got a coordinate system error, and this fixes it by not attempting to rotate anything the reference.

I will look into the rotation of the genomes compared to the reference next, which will be a more involved set of changes, but this is pretty safe to merge as it doesn't really do anything (its power is coming from not doing anything :p).