### PR TITLE
Fix spelling typos in code comments

### DIFF
--- a/anvio/contigops.py
+++ b/anvio/contigops.py
@@ -121,7 +121,7 @@ class Contig:
         if len(self.splits) == 1:
             # Coverage.process_c is a potentially expensive operation (taking up ~90% of the time of
             # analyze_coverage when coverage is low (but when coverage is >500X, the time taken is
-            # ~1%)). Regardless, this clause exists to catch the somewhat common occurence when a
+            # ~1%)). Regardless, this clause exists to catch the somewhat common occurrence when a
             # contig only has one split. In this case, the contig _is_ the split, and so all of the
             # split.coverage attributes can simply be referenced directly from contig.coverage
             split = self.splits[0]

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3347,7 +3347,7 @@ class PanSuperclass(object):
                                                                       min_combined_homogeneity_index,
                                                                       max_combined_homogeneity_index)
 
-        # this is where we add the items in the resulting filtered dict into the items additonal data
+        # this is where we add the items in the resulting filtered dict into the items additional data
         # table:
         if add_into_items_additional_data_table:
             data_key = add_into_items_additional_data_table

--- a/anvio/inversions.py
+++ b/anvio/inversions.py
@@ -289,7 +289,7 @@ class Inversions:
             if not max(contig_coverage) > 0:
                 continue
 
-            # if we are here, we're good to go. let's keep the contig lenght in a separate variable:
+            # if we are here, we're good to go. let's keep the contig length in a separate variable:
             contig_length = len(contig_coverage)
 
             # to find regions of high coverage, we first need to 'pad' our array to ensure it always
@@ -305,7 +305,7 @@ class Inversions:
             cov_stretch_end_positions = np.where(regions_of_contig_covered_enough_diff == -1)[0]
 
             # at this stage, `cov_stretch_start_positions` and `cov_stretch_end_positions` contain pairs of
-            # positions that match to the begining and end of stretches. we will remove those that are too
+            # positions that match to the beginning and end of stretches. we will remove those that are too
             # short to be considered, and store the start/end positions for the remaining stretches of
             # high coverage into the dictionary `coverage_stretches_in_contigs`
             for i in range(0, len(cov_stretch_start_positions)):

--- a/anvio/mcgclassifier.py
+++ b/anvio/mcgclassifier.py
@@ -429,7 +429,7 @@ class MetagenomeCentricGeneClassifier:
 
 
     def get_gene_coverage_consistency(self, gene_id):
-        """ return true if the gene's coverage is consistent accross positive samples, False otherwise."""
+        """ return true if the gene's coverage is consistent across positive samples, False otherwise."""
 
         # TODO: make sure coverage_consistency_dict has been initiated
         if self.gene_class_df.loc[gene_id, 'occurence_in_positive_samples'] == 0:

--- a/anvio/utils.py
+++ b/anvio/utils.py
@@ -4491,7 +4491,7 @@ def get_pruned_HMM_hits_dict(hmm_hits_dict):
                 shortest_of_the_two = min(hits[i][0], hits[j][0])
 
                 if alignment_end - alignment_start > shortest_of_the_two / 2:
-                    # the overlap between these two is more than the half of the lenght of the
+                    # the overlap between these two is more than the half of the length of the
                     # shorter one. this is done
                     overlapping_hits_indices.add(i)
                     overlapping_hits_indices.add(j)


### PR DESCRIPTION
Fixes spelling typos in code comments and a docstring. No code change.

- `lenght` should be `length` (inversions.py, utils.py)
- `begining` should be `beginning` (inversions.py)
- `occurence` should be `occurrence` (contigops.py)
- `additonal` should be `additional` (dbops.py)
- `accross` should be `across` (mcgclassifier.py)
