### PR TITLE
A new run function: 'section'

### DIFF
--- a/anvio/terminal.py
+++ b/anvio/terminal.py
@@ -533,6 +533,46 @@ class Run:
             self.write(message_line, overwrite_verbose=overwrite_verbose)
 
 
+    def section(self, section_header, lc='green', bgc=Back.GREY_93, fgc=Fore.BLACK, overwrite_verbose=False, nl_before=2, nl_after=1, progress=None):
+        """Print a major section header to help the user distinguish major steps of an analysis.
+
+        When `bgc` is set (a background color from `colored.Back`), the header is drawn as a filled
+        block of color, where `fgc` (from `colored.Fore`) sets the text color, and `lc` is ignored.
+        Setting `bgc` to None falls back to drawing the header between two colored `=` rules using
+        the tty color `lc`.
+        """
+
+        if isinstance(section_header, str):
+            section_header = remove_spaces(section_header)
+
+        terminal_width = get_terminal_width()
+
+        # the text of the header is wrapped at a comfortable reading width regardless of how wide the
+        # terminal is, but a block of background color is filled all the way to the edge of it
+        wrap_width = min(terminal_width, 80)
+        separator = '=' * wrap_width
+        header_lines = ['  %s' % line for line in textwrap.fill(str(section_header), wrap_width - 4, subsequent_indent='  ').split('\n')]
+
+        if bgc and sys.stdout.isatty():
+            # each line is padded to the full width of the terminal and reset individually so the
+            # block spans the entire line, and does not bleed into anything that comes after it
+            block = ['', *header_lines, '']
+            output = '%s%s\n%s' % ('\n' * nl_before,
+                                   '\n'.join([bgc + fgc + line.ljust(terminal_width) + Style.RESET for line in block]),
+                                   '\n' * nl_after)
+        else:
+            output = c("%s%s\n\n%s\n\n%s\n%s" % ('\n' * nl_before, separator, '\n'.join(header_lines),
+                                                separator, '\n' * nl_after), lc)
+
+        if progress:
+            progress.clear()
+            self.write(output, overwrite_verbose=overwrite_verbose)
+            if progress.msg and progress.pid:
+                progress.update(progress.msg)
+        else:
+            self.write(output, overwrite_verbose=overwrite_verbose)
+
+
     def warning(self, message, header='WARNING', lc='red', raw=False, overwrite_verbose=False, nl_before=0, nl_after=0, progress=None):
         if isinstance(message, str):
             message = remove_spaces(message)


### PR DESCRIPTION
So far we have been using `run.warning(None, header="SOME KEY ANALYSIS STEP")` to help user figure out what is going on in analyses that had multiple major steps. This PR finally adds something that addresses that. Instead of overloading `run.warning` for something that was not designed for, we will simply say `run.section("SOME KEY ANALYSIS STEP")`.

With this minor addition, what previously looked like this in the terminal,

<img width="2150" height="2077" alt="image" src="https://github.com/user-attachments/assets/f26fd566-fb43-431b-8437-684db60b345d" />

Will now look like this:

<img width="2150" height="2077" alt="image" src="https://github.com/user-attachments/assets/ef9c0274-3416-4caa-8de9-59bfdf40827b" />
