### PR TITLE
Codon stats fixes

### DIFF
--- a/anvio/__init__.py
+++ b/anvio/__init__.py
@@ -4222,6 +4222,21 @@ D = {
                      "rather than genes, this filter is applied to genes before grouping them as "
                      "functions."}
         ),
+    'ignore-start-codons': (
+            ['--ignore-start-codons'],
+            {'default': False,
+             'action': 'store_true',
+             'help': "Ignore start codons in the analysis. Besides ATG, GTG and TTG are notable minority "
+                     "start codons in bacteria and archaea. With start codons removed, frequencies only "
+                     "represent elongation codons. This makes codon usage bias calculations more accurate, "
+                     "because initiation GTG and TTG, like ATG, encode fMet in bacteria and Met in archaea "
+                     "and eukaryotes, but anvi'o treats them like elongation codons encoding Val and Leu, "
+                     "respectively, in the standard genetic code. ATG does not contribute to codon usage "
+                     "bias given the standard genetic code, because it lacks synonymous codons, being the "
+                     "only Met codon. Note that `--ignore-start-codons` removes start codons from genes in "
+                     "the earliest steps of the analysis, which influences `--gene-min-codons`: the number "
+                     "of codons in a gene never counts the start codon."}
+        ),
     'relative': (
             ['--relative'],
             {'default': False,

--- a/anvio/cli/get_codon_frequencies.py
+++ b/anvio/cli/get_codon_frequencies.py
@@ -321,6 +321,7 @@ def get_args():
     groupF.add_argument(*anvio.A('sequence-min-amino-acids'), **anvio.K('sequence-min-amino-acids'))
     groupF.add_argument(*anvio.A('pansequence-min-amino-acids'), **anvio.K('pansequence-min-amino-acids'))
     groupF.add_argument(*anvio.A('min-codon-filter'), **anvio.K('min-codon-filter'))
+    groupF.add_argument(*anvio.A('ignore-start-codons'), **anvio.K('ignore-start-codons'))
     groupF.add_argument(*anvio.A('skip-checking-genome-hashes'), **anvio.K('skip-checking-genome-hashes'))
 
     return parser.get_args(parser)

--- a/anvio/cli/get_codon_usage_bias.py
+++ b/anvio/cli/get_codon_usage_bias.py
@@ -556,6 +556,7 @@ def get_args():
         help="Only allow CUB to calculated for a query if it has at least this number of "
              "synonymous codons that will be analyzed. For reference-dependent CUB metrics, "
              "analyzed codons are those with reference compositions.")
+    groupG.add_argument(*anvio.A('ignore-start-codons'), **anvio.K('ignore-start-codons'))
 
     groupH = parser.add_argument_group(
         'FILTER REFERENCE',

--- a/anvio/codonusage.py
+++ b/anvio/codonusage.py
@@ -1032,7 +1032,7 @@ class SingleGenomeCodonUsage(object):
 
         gene_function_df = gene_function_df.reset_index()
 
-        def select_keys(gene_function_df, requested_keys):
+        def select_exact_keys(gene_function_df, requested_keys):
             gene_function_df = gene_function_df.set_index(['function_source', 'function_name'])
             if expect_functions:
                 available_keys = set(gene_function_df.index)
@@ -1065,46 +1065,43 @@ class SingleGenomeCodonUsage(object):
                 else:
                     nonbrite_requested_keys.append(requested_key)
 
-            gene_brite_df = gene_brite_df.set_index('function_name')
             brite_select_keys = []
             brite_found_keys = []
-            for available_key in gene_brite_df.index:
+            for available_key in set(gene_brite_df['function_name']):
                 for requested_key in brite_requested_keys:
-                    try:
-                        position = available_key.index(requested_key)
-                    except ValueError:
-                        continue
-                    if position == 0 and available_key[
-                        len(requested_key): len(requested_key) + 3] == '>>>':
-                        brite_select_keys.append(available_key)
+                    # The requested category is either the category annotating the gene or a higher
+                    # level of the same hierarchy.
+                    if (available_key == requested_key or
+                        available_key.startswith(requested_key + '>>>')):
+                        brite_select_keys.append(('KEGG_BRITE', available_key))
                         brite_found_keys.append(requested_key)
-            brite_select_keys = set(
-                [('KEGG_BRITE', function_name) for function_name in set(brite_select_keys)])
-            brite_found_keys = set(brite_found_keys)
-            brite_missing_keys = brite_found_keys.difference(brite_select_keys)
+            brite_select_keys = set(brite_select_keys)
             brite_missing_keys = set(
-                [('KEGG_BRITE', function_name) for function_name in set(brite_missing_keys)])
+                [('KEGG_BRITE', requested_key) for requested_key in
+                 set(brite_requested_keys).difference(set(brite_found_keys))])
 
+            if nonbrite_requested_keys:
+                nonbrite_select_keys, nonbrite_missing_keys = select_exact_keys(
+                    gene_nonbrite_df, set(nonbrite_requested_keys))
 
-            raise
-            # FIXME: The select_keys issue below
-            if len(gene_nonbrite_df) > 0:
-                nonbrite_select_keys, nonbrite_missing_keys = select_keys(
-                    gene_nonbrite_df, nonbrite_requested_keys)
-
-                select_keys = brite_select_keys.union(nonbrite_select_keys)
-                missing_keys = brite_missing_keys.union(nonbrite_missing_keys)
+                select_keys = brite_select_keys.union(set(nonbrite_select_keys))
+                missing_keys = brite_missing_keys.union(
+                    set(nonbrite_missing_keys) if nonbrite_missing_keys else set())
             else:
                 select_keys = brite_select_keys
                 missing_keys = brite_missing_keys
 
-            return select_keys, missing_keys
+            return sorted(select_keys), (missing_keys if expect_functions else None)
 
         if self.all_brite_categories:
+            # Every level of every BRITE hierarchy is already represented in the table, so requested
+            # categories are matched exactly.
+            select_keys, missing_keys = select_exact_keys(gene_function_df, requested_keys)
+        else:
+            # Only the most specific BRITE categories are in the table, so requested categories
+            # higher in a hierarchy must be matched against the categories they encompass.
             select_keys, missing_keys = select_keys_given_higher_brite_categories(
                 gene_function_df, requested_keys)
-        else:
-            select_keys, missing_keys = select_keys(gene_function_df, requested_keys)
 
         if expect_functions and missing_keys:
             # Prepare and throw an error message.

--- a/anvio/codonusage.py
+++ b/anvio/codonusage.py
@@ -2312,6 +2312,10 @@ class MultiGenomeCodonUsage(object):
         if self.use_shared_function_sources is None:
             self.use_shared_function_sources = False
 
+        self.ignore_start_codons = A('ignore_start_codons')
+        if self.ignore_start_codons is None:
+            self.ignore_start_codons = False
+
         self.preload_genomes = A('preload_genomes')
         if self.preload_genomes is None:
             self.preload_genomes = False
@@ -2424,7 +2428,7 @@ class MultiGenomeCodonUsage(object):
                 genome_info['codon_to_amino_acid'] = self.args.codon_to_amino_acid
             else:
                 genome_info['codon_to_amino_acid'] = default_codon_amino_acid_dict
-            genome_info['ignore_start_codons'] = self.args.ignore_start_codons
+            genome_info['ignore_start_codons'] = self.ignore_start_codons
 
         # There are memory- and CPU-efficient ways of setting up the object. `preload_genomes` loads
         # all of the SingleGenomeCodonUsage objects into memory, allowing methods to save time by

--- a/anvio/codonusage.py
+++ b/anvio/codonusage.py
@@ -2532,6 +2532,7 @@ class MultiGenomeCodonUsage(object):
         reference_function_accessions=None,
         reference_function_names=None,
         expect_reference_functions=False,
+        reference_gene_caller_ids=None,
         gene_min_codons=0,
         function_min_codons=0,
         min_codon_filter='both',
@@ -2544,8 +2545,18 @@ class MultiGenomeCodonUsage(object):
         """This generator yields a genome name and CUB table dict from each genome.
 
         See the `SingleGenomeCodonUsage.get_codon_usage_bias` docstring for descriptions of each
-        parameter.
+        parameter. `reference_gene_caller_ids` is the one parameter that cannot be applied to more
+        than one genome, as gene caller IDs are specific to a contigs database.
         """
+        if reference_gene_caller_ids and len(self.genome_info_dict) > 1:
+            raise ConfigError(
+                f"Reference genes can only be selected by gene caller ID when a single genome is "
+                f"analyzed, but {pp(len(self.genome_info_dict))} genomes were provided. Gene "
+                f"caller IDs are specific to a contigs database, so the same IDs cannot "
+                f"meaningfully be sought in every genome. Reference genes can be selected across "
+                f"multiple genomes by function instead."
+            )
+
         # Rather than individually listing a slew of arguments when calling `get_codon_usage_bias`,
         # package them in a tidy kwargs dictionary.
         kwargs = {}


### PR DESCRIPTION
This PR contains key fixes to `anvi-get-codon-frequencies` and `anvi-get-codon-usage-bias`.

The flag `--ignore-start-codons` improves the accuracy of synonymous codon frequency calculations for gene sequences containing initiator GTG or TTG, which are otherwise wrongly treated like elongation codons for Val and Leu, respectively.

Genes can now be selected by higher BRITE category annotations, critical for the selection of ribosomal proteins as a reference in the calculation of certain codon usage bias metrics.