### PR TITLE
rename the sra_download FASTQ output directory

### DIFF
--- a/anvio/docs/workflows/sra-download.md
+++ b/anvio/docs/workflows/sra-download.md
@@ -31,7 +31,7 @@ $ cat sra_download_config.json
     },
     "output_dirs": {
         "SRA_prefetch": "01_NCBI_SRA",
-        "FASTAS": "02_FASTA",
+        "FASTQ_DIR": "02_FASTQ",
         "LOGS_DIR": "00_LOGS"
     },
     "max_threads": "",

--- a/anvio/tests/run_workflow_tests_for_sra_download.sh
+++ b/anvio/tests/run_workflow_tests_for_sra_download.sh
@@ -37,27 +37,27 @@ anvi-run-workflow -w sra_download -c sra_download_config.json --save-workflow-gr
 # the list. Compressing FASTQ files by globbing on the accession would sweep this file up along
 # with the real ones, so it must still be sitting here, uncompressed, once the workflow is done.
 INFO "Planting a decoy FASTQ file to make sure accessions only claim their own reads"
-mkdir -p 02_FASTA
-touch 02_FASTA/SRR59656231_1.fastq
+mkdir -p 02_FASTQ
+touch 02_FASTQ/SRR59656231_1.fastq
 
 INFO "Running workflow graph sra_download workflow"
 anvi-run-workflow -w sra_download -c sra_download_config.json
 
 INFO "Making sure the decoy FASTQ file was left alone"
-ASSERT_FILE_EXISTS 02_FASTA/SRR59656231_1.fastq
-ASSERT_FILE_MISSING 02_FASTA/SRR59656231_1.fastq.gz
+ASSERT_FILE_EXISTS 02_FASTQ/SRR59656231_1.fastq
+ASSERT_FILE_MISSING 02_FASTQ/SRR59656231_1.fastq.gz
 
 INFO "Making sure every accession got the FASTQ files it was supposed to get"
-ASSERT_FILE_EXISTS 02_FASTA/ERR6450080_1.fastq.gz
-ASSERT_FILE_EXISTS 02_FASTA/ERR6450080_2.fastq.gz
-ASSERT_FILE_EXISTS 02_FASTA/ERR6450081_1.fastq.gz
-ASSERT_FILE_EXISTS 02_FASTA/ERR6450081_2.fastq.gz
-ASSERT_FILE_EXISTS 02_FASTA/SRR5965623.fastq.gz
+ASSERT_FILE_EXISTS 02_FASTQ/ERR6450080_1.fastq.gz
+ASSERT_FILE_EXISTS 02_FASTQ/ERR6450080_2.fastq.gz
+ASSERT_FILE_EXISTS 02_FASTQ/ERR6450081_1.fastq.gz
+ASSERT_FILE_EXISTS 02_FASTQ/ERR6450081_2.fastq.gz
+ASSERT_FILE_EXISTS 02_FASTQ/SRR5965623.fastq.gz
 
 INFO "Making sure no uncompressed FASTQ file was left behind"
-ASSERT_FILE_MISSING 02_FASTA/ERR6450080_1.fastq
-ASSERT_FILE_MISSING 02_FASTA/ERR6450081_1.fastq
-ASSERT_FILE_MISSING 02_FASTA/SRR5965623.fastq
+ASSERT_FILE_MISSING 02_FASTQ/ERR6450080_1.fastq
+ASSERT_FILE_MISSING 02_FASTQ/ERR6450081_1.fastq
+ASSERT_FILE_MISSING 02_FASTQ/SRR5965623.fastq
 
 # `Remove_unzipped_SRA_files` defaults to true, so the prefetched archives must be gone once the
 # reads have been extracted from them, while the marker files snakemake tracks in the very same

--- a/anvio/workflows/sra_download/__init__.py
+++ b/anvio/workflows/sra_download/__init__.py
@@ -51,13 +51,17 @@ class SRADownloadWorkflow(WorkflowSuperClass):
 
         # Directory structure for Snakemake workflow
         self.dirs_dict.update({"SRA_prefetch": "01_NCBI_SRA"})
-        self.dirs_dict.update({"FASTAS": "02_FASTA"})
+        self.dirs_dict.update({"FASTQ_DIR": "02_FASTQ"})
 
 
     def init(self):
         """Load the SRA_accession_list and creates a list of target files for the Snakemake workflow."""
 
+        self.migrate_legacy_fastas_dir_name()
+
         super().init()
+
+        self.warn_about_legacy_fastq_directory()
 
         # Load SRA_accession_list
         self.SRA_accession_list = self.get_param_value_from_config(['SRA_accession_list'])
@@ -89,10 +93,55 @@ class SRADownloadWorkflow(WorkflowSuperClass):
         self.target_files = self.get_target_files()
 
 
+    def migrate_legacy_fastas_dir_name(self):
+        """Accept the old `FASTAS` key in a config file's `output_dirs` section.
+
+        The directory holding the FASTQ files this workflow downloads used to be declared with
+        the key `FASTAS`. Config files written before the rename still use it, and the sanity
+        check for `output_dirs` would reject them as an unknown directory, so we quietly
+        translate the old key into the current one and let the user know."""
+
+        output_dirs = (self.config or {}).get('output_dirs') or {}
+
+        if 'FASTAS' not in output_dirs:
+            return
+
+        legacy_value = output_dirs.pop('FASTAS')
+        output_dirs.setdefault('FASTQ_DIR', legacy_value)
+
+        self.run.warning(f"The `output_dirs` section of your config file asks for a directory called "
+                         f"`FASTAS`. That key is now called `FASTQ_DIR`, since what this workflow puts "
+                         f"there are FASTQ files rather than FASTA files. Anvi'o will use your value "
+                         f"('{legacy_value}') for `FASTQ_DIR` and carry on, but please do rename the key "
+                         f"in your config file when you have a moment.")
+
+
+    def warn_about_legacy_fastq_directory(self):
+        """Point out output from an earlier run that lives under the old directory name.
+
+        Snakemake decides what work is left to do by looking for output files, so a run that
+        downloaded its reads into `02_FASTA` before the rename would look entirely unfinished
+        now and every accession would be downloaded a second time. Downloads are the expensive
+        part of this workflow, so it is worth saying something before that happens."""
+
+        fastq_dir = self.dirs_dict['FASTQ_DIR']
+        legacy_dir = '02_FASTA'
+
+        if fastq_dir == legacy_dir or not os.path.exists(legacy_dir) or os.path.exists(fastq_dir):
+            return
+
+        self.run.warning(f"Anvi'o found a directory called '{legacy_dir}' here, which is where this workflow "
+                         f"used to keep the FASTQ files it downloads. It now uses '{fastq_dir}' instead. If "
+                         f"'{legacy_dir}' holds reads from an earlier run, anvi'o will not see them and will "
+                         f"download everything again from scratch. To avoid that, either rename '{legacy_dir}' "
+                         f"to '{fastq_dir}', or add \"output_dirs\": {{\"FASTQ_DIR\": \"{legacy_dir}\"}} to your "
+                         f"config file to keep using the old location.")
+
+
     def get_target_files(self):
         """Get list of target files for snakemake target rule"""
 
-        target_files = [os.path.join(self.dirs_dict['FASTAS'], "generate_samples_txt.done")]
+        target_files = [os.path.join(self.dirs_dict['FASTQ_DIR'], "generate_samples_txt.done")]
 
         return target_files
 

--- a/anvio/workflows/sra_download/rules/download.smk
+++ b/anvio/workflows/sra_download/rules/download.smk
@@ -198,7 +198,7 @@ Threads:
         done=ancient(rules.check_md5sum.output.md5sum_DONE),
     output:
         FASTERQDUMP_DONE=touch(
-            os.path.join(dirs_dict["FASTAS"], "{accession}-fasterq-dump.done")
+            os.path.join(dirs_dict["FASTQ_DIR"], "{accession}-fasterq-dump.done")
         ),
         FASTERQDUMP_TEMP=temp(directory("FASTERQDUMP_TEMP/{accession}")),
     log:
@@ -210,7 +210,7 @@ Threads:
         nodes=M.T("fasterq_dump"),
     params:
         SRA_INPUT_DIR=os.path.join(dirs_dict["SRA_prefetch"], "{accession}"),
-        OUTPUT_DIR=dirs_dict["FASTAS"],
+        OUTPUT_DIR=dirs_dict["FASTQ_DIR"],
         REMOVE_SRA_FILES=remove_tmp,
     run:
         shell(
@@ -260,22 +260,22 @@ Inputs:
 - FASTQ file(s) from the output of the fasterq_dump rule
 
 Outputs:
-- gzipped FASTQ file(s) in the FASTAS directory
+- gzipped FASTQ file(s) in the FASTQ directory
 
 Params:
-- READS: the exact FASTQ file names this accession can have in the FASTAS directory
+- READS: the exact FASTQ file names this accession can have in the FASTQ directory
 
 Threads:
 - Number of threads specified in the M object
 
 example:
-    pigz --processes 8 --verbose 02_FASTA/ERR6450080_1.fastq >> 00_LOGS/ERR6450080_pigz.log 2>&1
+    pigz --processes 8 --verbose 02_FASTQ/ERR6450080_1.fastq >> 00_LOGS/ERR6450080_pigz.log 2>&1
 
 """
     input:
         done=ancient(rules.fasterq_dump.output.FASTERQDUMP_DONE),
     output:
-        done=touch(os.path.join(dirs_dict["FASTAS"], "{accession}-pigz.done")),
+        done=touch(os.path.join(dirs_dict["FASTQ_DIR"], "{accession}-pigz.done")),
     log:
         rule_log("pigz", "{accession}_pigz"),
     wildcard_constraints:
@@ -285,7 +285,7 @@ example:
         nodes=M.T("pigz"),
     params:
         READS=lambda wildcards: " ".join(
-            fastq_candidates(wildcards.accession, dirs_dict["FASTAS"])
+            fastq_candidates(wildcards.accession, dirs_dict["FASTQ_DIR"])
         ),
     shell:
         """
@@ -302,7 +302,7 @@ Inputs:
 - gziped FASTQ file(s) from the output of the pigz rule
 
 Outputs:
-- samples.txt and samples_single_reads.txt in the FASTAS directory
+- samples.txt and samples_single_reads.txt in the FASTQ directory
 
 Params:
 - ACCESSION: list of accessions
@@ -313,11 +313,11 @@ Threads:
 """
     input:
         targets=expand(
-            os.path.join(dirs_dict["FASTAS"], "{accession}-pigz.done"),
+            os.path.join(dirs_dict["FASTQ_DIR"], "{accession}-pigz.done"),
             accession=M.accessions_list,
         ),
     output:
-        done=touch(os.path.join(dirs_dict["FASTAS"], "generate_samples_txt.done")),
+        done=touch(os.path.join(dirs_dict["FASTQ_DIR"], "generate_samples_txt.done")),
     log:
         rule_log("generate_samples_txt", "generate_samples_txt"),
     threads: 1
@@ -325,7 +325,7 @@ Threads:
         nodes=1,
     params:
         ACCESSION=M.accessions_list,
-        OUTPUT_DIR=dirs_dict["FASTAS"],
+        OUTPUT_DIR=dirs_dict["FASTQ_DIR"],
     run:
         paired_reads = []
         single_reads = []


### PR DESCRIPTION
The `sra_download` workflow downloads sequencing reads and puts them in a directory called `02_FASTA`. WRONG DIR NAME.

It's now `02_FASTQ`, with the config key renamed from `FASTAS` to `FASTQ_DIR` so it matches the `*_DIR` naming every other directory key uses.

## Nothing breaks for existing users

The output directory is where the expensive part of this workflow lives. If anvi'o started looking in a new directory and didn't find the reads you already downloaded, it would download all of them again. So:

- **If your config file has an `output_dirs` section** (`--get-default-config` command always writes one), anvi'o reads the old `FASTAS` key, keeps using the directory you already had, and prints a note asking you to rename the key when convenient. Your runs continue exactly where they left off.
- **If it doesn't**, and anvi'o spots an `02_FASTA` directory from an earlier run, it warns you before doing anything and tells you the two ways to keep using it.

New configs generated from here on get `02_FASTQ`.