### PR TITLE
Gather individual `anvi-draw-kegg-pathways` map files into a directory per map

### DIFF
--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -357,6 +357,21 @@ def get_args() -> Namespace:
         "maps in the grid."
     )
     groupOUT.add_argument(
+        '--collate-files-by-map', action='store_true', default=False, help=
+        "Gather the map files drawn by '--draw-individual-files' into a directory per map, each "
+        "holding one file per sample, group, contigs database, or pan genome named after it. This "
+        "is a second arrangement of the same files, standing beside the directory per source that "
+        "'--draw-individual-files' writes rather than replacing it, and it lets a single map be "
+        "compared across sources by stepping through one directory, as a file browser's preview "
+        "moves from one file to the next. For example, with samples 'A' through 'E', the "
+        "'Glycolysis / Gluconeogenesis' map would be gathered into a directory named "
+        "'by_map/kos_00010' holding files named 'A.pdf' through 'E.pdf', or "
+        "'by_map/kos_00010_Glycolysis_Gluconeogenesis' with '--name-files'. With "
+        "'--categorize-files', the BRITE subdirectories precede each map's directory, just as "
+        "they precede each map file elsewhere in the output. The gathered files are links to the "
+        "maps already drawn, so they take up no disk space of their own."
+    )
+    groupOUT.add_argument(
         '--draw-bare-maps', action='store_true', default=False, help=
         "By default, without this flag, only draw maps containing select input data. Even if "
         "pathway maps are given explicitly with '--pathway-numbers' (e.g., \"00010 01100\"), if "
@@ -792,6 +807,8 @@ def map_json_network_ko_data(args: Namespace, mapper: Mapper) -> None:
         unsupported_args.append('--draw-individual-files')
     if args.draw_grid is not None:
         unsupported_args.append('--draw-grid')
+    if args.collate_files_by_map:
+        unsupported_args.append('--collate-files-by-map')
     if args.reaction_colormap is not None:
         unsupported_args.append('--reaction-colormap')
     if args.compound_colormap is not None:
@@ -1996,10 +2013,43 @@ def main() -> None:
                 "must be provided."
             )
 
+        # One database and no '--reaction-colormap' takes the route below that draws only the
+        # 'unified' map: no individual maps, no grids. With a colormap it takes the route for
+        # several databases instead, which draws those too.
+        is_single_db_run = (
+            args.contigs_dbs is not None and
+            len(args.contigs_dbs) == 1 and
+            args.reaction_colormap is None
+        )
+
+        # Gathering the individual maps by map is a second arrangement of files that have to exist,
+        # so the flag is refused wherever the run draws none of them and it would otherwise go
+        # quietly ignored. Wherever a run does draw them, it is honored however few they are: one
+        # database or one sample gives a directory per map holding a single file, which is no less
+        # than '--draw-individual-files' gives there on its own. A reaction-network-JSON run is left
+        # to its own dispatcher, which refuses this flag along with the rest of the family, for want
+        # of any categories at all to draw individually.
+        if args.collate_files_by_map and args.reaction_network_json is None:
+            if args.draw_individual_files is None:
+                raise ConfigError(
+                    "'--collate-files-by-map' gathers the maps drawn for individual contigs "
+                    "databases, genomes, samples, or groups into a directory per map, but none "
+                    "were asked for. Please add '--draw-individual-files', or drop this flag."
+                )
+            if is_single_db_run:
+                raise ConfigError(
+                    "'--collate-files-by-map' gathers the maps drawn for individual contigs "
+                    "databases into a directory per map, but a lone database drawn in a single "
+                    "color has no individual maps to gather: the one map it draws per pathway is "
+                    "already the whole of the data. Please provide the other databases to compare "
+                    "it to, or drop this flag."
+                )
+
         mapper = Mapper(kegg_dir=args.kegg_dir,
                         overwrite_output=args.overwrite_output_destinations,
                         name_files=args.name_files,
-                        categorize_files=args.categorize_files)
+                        categorize_files=args.categorize_files,
+                        collate_files_by_map=args.collate_files_by_map)
         performed = False
 
         if is_txt_run:
@@ -2010,11 +2060,7 @@ def main() -> None:
             map_json_network_ko_data(args, mapper)
             performed = True
 
-        if (
-            args.contigs_dbs is not None and
-            len(args.contigs_dbs) == 1 and
-            args.reaction_colormap is None
-        ):
+        if is_single_db_run:
             map_single_contigs_db_ko_data(args, mapper)
             performed = True
         elif args.contigs_dbs is not None:

--- a/anvio/docs/programs/anvi-draw-kegg-pathways.md
+++ b/anvio/docs/programs/anvi-draw-kegg-pathways.md
@@ -61,17 +61,18 @@ This program requires the path to a directory as an argument to `-o` or `--outpu
 
 ### Directory layout
 
-Map files are sorted into up to three subdirectories, one for each kind of map:
+Map files are sorted into up to four subdirectories, one for each kind of map:
 
 |Subdirectory|Contents|
 |:--|:--|
 |`unified`|The type of map drawn from all of the data at once. With a single source — a %(kegg-reaction-txt)s and/or %(kegg-compound-txt)s with no `sample` column, one %(contigs-db)s, or one %(reaction-network-json)s — these maps per pathway are the only ones drawn.|
 |`individual`|One subdirectory per data source, named after it: each sample of a text file, each contigs database, each genome of a pangenome, or, when they are grouped with a %(groups-txt)s file, each group instead. Drawn on request with `--draw-individual-files`.|
 |`grid`|The map grids, each showing the `unified` map alongside the individual ones. Drawn on request with `--draw-grid`.|
+|`by_map`|The same individual maps arranged the other way round: one subdirectory per map, each holding one file per data source, named after it. Written on request with `--collate-files-by-map`.|
 
 Colorbars, which are keys to the colors of every map in the run, are written at the top of the output directory beside these subdirectories.
 
-Because the names in `individual` come from your own data, they are kept in that subdirectory of their own: a sample, genome, or group may be named anything at all — including `unified`, `grid`, `symlink`, or `Metabolism` — without ever colliding with a directory this program creates for itself.
+Because the names in `individual` come from your own data, they are kept in that subdirectory of their own: a sample, genome, or group may be named anything at all — including `unified`, `grid`, `by_map`, `symlink`, or `Metabolism` — without ever colliding with a directory this program creates for itself.
 
 The one requirement is that a name becoming a subdirectory has to work as a directory name, so a name containing a path separator, such as `Rhizobium meliloti RU11/001`, is refused. This only applies to the sources that are actually drawn individually: a source summarized on the `unified` map contributes color rather than a path, so its name is never used as one, and a source left out of a subset requested with `--draw-individual-files` or `--draw-grid` is not checked either.
 
@@ -86,6 +87,14 @@ The `--categorize-files` flag categorizes output map files into a subdirectory s
 Here is a simple example of the output file structure produced with `--name-files` and `--categorize-files` in the course of `anvi-self-test --suite kegg-mapping` (with the `-o` option to save the temporary directories in the test from removal).
 
 ![Output options](../../images/anvi-draw-kegg-pathways/output_options.png){:.center-img .width-50}
+
+### Gathering files by map
+
+`--draw-individual-files` writes one subdirectory per data source, each holding that source's whole set of maps. That is the right arrangement for reading everything about one sample, and the wrong one for comparing a single map across samples, which means opening one file in each of those subdirectories. The `--collate-files-by-map` flag adds the transposed view: a subdirectory named after each map, holding one file per source, named after the source.
+
+With samples `A` through `E`, `by_map/kos_00010` holds `A.pdf` through `E.pdf`, `by_map/kos_00020` holds another five files, and so on. Selecting everything in one of those subdirectories and stepping through it with a file browser's preview shows the colors of a single map changing from sample to sample, like an animation. Files are sorted by the name of their source, so name your samples in the order in which you would like to step through them.
+
+This is a second arrangement of the same files rather than a replacement: the subdirectory per source stays where it is, and the gathered files are links to the maps already drawn there, so they take up no disk space of their own. `--name-files` and `--categorize-files` apply here as they do elsewhere in the output, so with both of them a gathered map would be found at, say, `by_map/Metabolism/Carbohydrate_metabolism/kos_00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf`.
 
 ## Mapping reaction and compound occurrence
 

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -230,14 +230,23 @@ CLAMPED_MAX_PREFIX = '≥ '
 # needs, so it is the one that stays.
 MIN_TICK_SEPARATION_FRACTION = 0.08
 
-# Subdirectories of the output directory, one per role a map file can have: the map pooling every
-# source, the map of one individual source, and the grid comparing them. Every name directly in the
-# output directory is therefore anvi'o's own, while the names that come from user data — samples,
-# contigs databases, genomes, groups — are confined to 'individual', where they cannot collide with
-# anything anvi'o creates for itself.
+# Subdirectories of the output directory, one per role a map file can have: the map unifying every
+# source, the map of one individual source, and the grid comparing them. A fourth holds those
+# individual maps a second time, arranged into a directory per map rather than per source. Every
+# name directly in the output directory is therefore anvi'o's own, while the names that come from
+# user data — samples, contigs databases, genomes, groups — are confined to 'individual', where
+# they cannot collide with anything anvi'o creates for itself.
 UNIFIED_SUBDIR = 'unified'
 INDIVIDUAL_SUBDIR = 'individual'
 GRID_SUBDIR = 'grid'
+COLLATED_SUBDIR = 'by_map'
+
+# Where '--categorize-files' nests map files in BRITE subdirectories, this subdirectory of links
+# gathers every one of them back into a single place to browse ('_symlink_map').
+FLAT_SUBDIR = 'symlink'
+
+# The colorbar keying the maps of one individual source, written beside them in its directory.
+CATEGORY_COLORBAR_BASENAME = 'colorbar.pdf'
 
 class Mapper:
     """
@@ -268,6 +277,10 @@ class Mapper:
         Categorize output files by pathway map within subdirectories corresponding to the BRITE
         hierarchy of maps (see https://www.genome.jp/brite/br08901).
 
+    collate_files_by_map : bool
+        Alongside the maps drawn for each individual source in a directory of its own, gather those
+        same maps into a directory per map, each holding one file per source.
+
     pathway_categorization : dict[str, list[str]]
         Maps pathway numbers to categorization, with categories listed from general to specific.
 
@@ -295,6 +308,7 @@ class Mapper:
         overwrite_output: bool = FORCE_OVERWRITE,
         name_files: bool = False,
         categorize_files: bool = False,
+        collate_files_by_map: bool = False,
         run: terminal.Run = terminal.Run(),
         progress: terminal.Progress = terminal.Progress(),
         quiet: bool = QUIET
@@ -316,6 +330,10 @@ class Mapper:
         categorize_files : bool, False
             Categorize output files by pathway map within subdirectories corresponding to the BRITE
             hierarchy of maps (see https://www.genome.jp/brite/br08901).
+
+        collate_files_by_map : bool, False
+            Alongside the maps drawn for each individual source in a directory of its own, gather
+            those same maps into a directory per map, each holding one file per source.
 
         run : anvio.terminal.Run, anvio.terminal.Run()
             This object prints run information to the terminal.
@@ -365,6 +383,7 @@ class Mapper:
 
         self.name_files = name_files
         self.categorize_files = categorize_files
+        self.collate_files_by_map = collate_files_by_map
         self.pathway_categorization = self._categorize_pathways() if categorize_files else None
         self.overwrite_output = overwrite_output
         self.run = run
@@ -971,7 +990,9 @@ class Mapper:
         output directory, and once map grids are drawn the subdirectories of categories that were
         only needed for a grid are deleted ('_draw_map_grids'). A name that is not a plain directory
         name would therefore write, or delete, outside the output directory: names come from a text
-        file's 'sample' column or a groups file, so they cannot be trusted to be safe paths.
+        file's 'sample' column or a groups file, so they cannot be trusted to be safe paths. The
+        same names become file names where the maps are gathered by map rather than by category
+        ('_collate_maps_by_map'), which the very same requirement makes safe.
 
         Only the categories actually getting maps are checked, since a category summarized on the
         'unified' map alone contributes color rather than a path, and its name is never joined onto
@@ -979,8 +1000,8 @@ class Mapper:
 
         No name is reserved. Categories are drawn into '<output directory>/individual', which anvi'o
         creates for that purpose alone, so a category may be named after anything anvi'o puts in the
-        output directory itself -- 'unified', 'grid', 'symlink', or a BRITE category such as
-        'Metabolism' -- without the two ever meeting.
+        output directory itself — 'unified', 'grid', 'by_map', 'symlink', or a BRITE category such
+        as 'Metabolism' — without the two ever meeting.
 
         Parameters
         ==========
@@ -4302,7 +4323,7 @@ class Mapper:
                 group_specs, category_color_priorities, category_scale_top = (
                     group_layer_membership[category]
                 )
-                colorbar_path = os.path.join(category_output_dir, 'colorbar.pdf')
+                colorbar_path = os.path.join(category_output_dir, CATEGORY_COLORBAR_BASENAME)
                 if group_colormap_scheme == 'by_count_continuous':
                     # The same color per count that the discrete bands assign, shown as a gradient
                     # across the ramp from the lowest count to the highest rather than as one labeled
@@ -4375,6 +4396,16 @@ class Mapper:
                 source_type=grid_source_type if grid_source_type is not None else category_noun
             )
 
+        # The individual maps are gathered only once nothing else stands to change them: drawing the
+        # grids deletes the maps that were drawn as grid panels alone, along with the directories of
+        # the categories that were never asked for individually.
+        collated_count = 0
+        if self.collate_files_by_map and draw_files_categories:
+            self.progress.new(f"Gathering the maps of each {category_noun}")
+            self.progress.update("...")
+            collated_count = self._collate_maps_by_map(output_dir, draw_files_categories)
+            self.progress.end()
+
         count = sum(drawn['unified'].values()) if drawn['unified'] else 0
         self.run.info(
             f"Number of 'unified' maps drawn incorporating data from all {unified_plural}", count
@@ -4384,6 +4415,10 @@ class Mapper:
                 sum(d.values()) if d else 0 for d in drawn['individual'].values()
             ) if drawn['individual'] else 0
             self.run.info(f"Number of maps drawn for individual {category_noun}s", count)
+            if self.collate_files_by_map:
+                self.run.info(
+                    f"Number of maps gathered across individual {category_noun}s", collated_count
+                )
         count = sum(drawn['grid'].values()) if drawn['grid'] else 0
         self.run.info("Number of map grids drawn", count)
 
@@ -6346,13 +6381,95 @@ class Mapper:
         map_path : str
             Map file path to be symlinked.
         """
-        symlink_dir = os.path.join(output_dir, 'symlink')
+        symlink_dir = os.path.join(output_dir, FLAT_SUBDIR)
         os.makedirs(symlink_dir, exist_ok=True)
         map_basename = os.path.basename(map_path)
         symlink_path = os.path.join(symlink_dir, map_basename)
         if os.path.exists(symlink_path):
             os.remove(symlink_path)
         os.symlink(os.path.abspath(map_path), symlink_path)
+
+    def _collate_maps_by_map(self, output_dir: str, categories: List[str]) -> int:
+        """
+        Gather the maps drawn for individual categories into a directory per map.
+
+        Each map gets a directory holding one file per category, named after the category, so that a
+        single map can be compared across categories by stepping through one directory — the way a
+        file browser's preview moves from one file to the next — rather than by opening a file in
+        each category's own directory.
+
+        Every file gathered is a link to a map already drawn under 'individual', so this second
+        arrangement costs no disk space of its own.
+
+        Which maps to gather is read off the drawn files themselves rather than rebuilt from pathway
+        numbers, so it can neither disagree with what was drawn nor lose track of where
+        '--categorize-files' put it: a map's place within a category's directory becomes its place
+        here, BRITE subdirectories and all.
+
+        Parameters
+        ==========
+        output_dir : str
+            Path to the output directory holding the 'individual' subdirectory.
+
+        categories : List[str]
+            Names of the categories whose maps are gathered, each a subdirectory of 'individual'.
+
+        Returns
+        =======
+        int
+            The number of maps gathered, which is the number of directories written.
+        """
+        collated_dir = os.path.join(output_dir, COLLATED_SUBDIR)
+        map_dirs: Set[str] = set()
+        for category in categories:
+            self.progress.update(category)
+            category_dir = os.path.join(output_dir, INDIVIDUAL_SUBDIR, category)
+            for dir_path, subdir_names, basenames in os.walk(category_dir):
+                # Everything a category's directory holds is one of its maps, save for the colorbar
+                # keying them and the flat directory of links to those very same maps.
+                if FLAT_SUBDIR in subdir_names:
+                    subdir_names.remove(FLAT_SUBDIR)
+                relative_dir = os.path.relpath(dir_path, category_dir)
+                for basename in basenames:
+                    map_name, extension = os.path.splitext(basename)
+                    if extension != '.pdf' or basename == CATEGORY_COLORBAR_BASENAME:
+                        continue
+                    map_dir = os.path.normpath(os.path.join(collated_dir, relative_dir, map_name))
+                    map_dirs.add(map_dir)
+                    self._link_map(
+                        os.path.join(dir_path, basename),
+                        os.path.join(map_dir, f'{category}{extension}')
+                    )
+        return len(map_dirs)
+
+    def _link_map(self, map_path: str, link_path: str) -> None:
+        """
+        Link from elsewhere in the output to a map file that has already been drawn.
+
+        A hard link is made, which a file browser cannot tell from the map file itself and which
+        survives the output directory being moved or renamed. Where the filesystem refuses a hard
+        link, a relative symbolic link stands in: a file browser follows it just as readily, and it
+        holds for as long as the two files keep their places within the output directory.
+
+        Parameters
+        ==========
+        map_path : str
+            Path to the map file that was drawn.
+
+        link_path : str
+            Path of the link to make. Its directory is created if it does not already exist, and
+            whatever the path may already hold is replaced.
+        """
+        link_dir = os.path.dirname(link_path)
+        os.makedirs(link_dir, exist_ok=True)
+        # 'lexists' rather than 'exists', so that a link an earlier run left broken is replaced
+        # rather than left in place for the call below to trip over.
+        if os.path.lexists(link_path):
+            os.remove(link_path)
+        try:
+            os.link(map_path, link_path)
+        except OSError:
+            os.symlink(os.path.relpath(map_path, link_dir), link_path)
 
     def _draw_map_grids(
         self,
@@ -6478,7 +6595,7 @@ class Mapper:
                         )
                     paths_to_remove.append(out_path)
                     if self.categorize_files:
-                        paths_to_remove.append(os.path.join(out_dir, 'symlink', pathway_basename))
+                        paths_to_remove.append(os.path.join(out_dir, FLAT_SUBDIR, pathway_basename))
 
             self.progress = progress
             self.run = run

--- a/anvio/tests/run_component_tests_for_kegg_mapping.sh
+++ b/anvio/tests/run_component_tests_for_kegg_mapping.sh
@@ -1114,8 +1114,109 @@ args+=( "--draw-individual-files" "SAMPLE_1" )
 args+=( "--no-progress" )
 anvi-draw-kegg-pathways "${args[@]}"
 
+INFO "Testing gathering the maps of individual samples into a directory per map, so that one map \
+can be stepped through sample by sample"
+args=()
+args+=( "--reaction-txt" "draw_kos_samples.reaction.txt" )
+args+=( "--output-dir" ${output_dir}/draw_txt_collate_by_map )
+args+=( "--pathway-numbers" "${pathway_numbers[@]}" )
+args+=( "--draw-individual-files" )
+args+=( "--collate-files-by-map" )
+args+=( "--no-progress" )
+anvi-draw-kegg-pathways "${args[@]}"
+
+for sample in SAMPLE_1 SAMPLE_2 SAMPLE_3
+do
+    if [ ! -s ${output_dir}/draw_txt_collate_by_map/by_map/kos_00010/${sample}.pdf ]
+    then
+        echo "ERROR: the map gathered by map is missing the file of ${sample}."
+        exit 1
+    fi
+done
+
+# The gathered files are links to the maps already drawn rather than copies of them.
+if ! [ ${output_dir}/draw_txt_collate_by_map/by_map/kos_00010/SAMPLE_1.pdf \
+    -ef ${output_dir}/draw_txt_collate_by_map/individual/SAMPLE_1/kos_00010.pdf ]
+then
+    echo "ERROR: a map gathered by map should be a link to the map drawn for the sample."
+    exit 1
+fi
+
+INFO "Testing that gathering by map keeps the BRITE subdirectories and the named files used \
+everywhere else in the output, and leaves the flat directory of links out of it"
+args=()
+args+=( "--reaction-txt" "draw_kos_samples.reaction.txt" )
+args+=( "--output-dir" ${output_dir}/draw_txt_collate_by_map_categorized )
+args+=( "--pathway-numbers" "${pathway_numbers[@]}" )
+args+=( "--name-files" )
+args+=( "--categorize-files" )
+args+=( "--draw-individual-files" )
+args+=( "--draw-grid" )
+args+=( "--collate-files-by-map" )
+args+=( "--no-progress" )
+anvi-draw-kegg-pathways "${args[@]}"
+
+collated_dir=${output_dir}/draw_txt_collate_by_map_categorized/by_map
+if [ ! -s ${collated_dir}/Metabolism/Carbohydrate_metabolism/kos_00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf ]
+then
+    echo "ERROR: gathering by map did not keep the BRITE subdirectories of the map."
+    exit 1
+fi
+if [ -e ${collated_dir}/symlink ]
+then
+    echo "ERROR: the flat directory of links was gathered as if it held maps of its own."
+    exit 1
+fi
+
+INFO "Testing that gathering by map takes only the maps of the groups asked for individually, and \
+neither the colorbar beside them nor the maps drawn as grid panels alone"
+args=()
+args+=( "--reaction-txt" "draw_kos_samples.reaction.txt" )
+args+=( "--groups-txt" "draw-sample-group-information.txt" )
+args+=( "--group-threshold" "0" )
+args+=( "--output-dir" ${output_dir}/draw_txt_collate_by_map_groups )
+args+=( "--pathway-numbers" "${pathway_numbers[@]}" )
+args+=( "--draw-individual-files" "G1" )
+args+=( "--draw-grid" )
+args+=( "--collate-files-by-map" )
+args+=( "--no-progress" )
+anvi-draw-kegg-pathways "${args[@]}"
+
+collated_dir=${output_dir}/draw_txt_collate_by_map_groups/by_map
+if [ ! -s ${collated_dir}/kos_00010/G1.pdf ]
+then
+    echo "ERROR: the group asked for individually was not gathered by map."
+    exit 1
+fi
+if [ -e ${collated_dir}/kos_00010/G2.pdf ]
+then
+    echo "ERROR: a group drawn as a grid panel alone was gathered by map."
+    exit 1
+fi
+if [ -e ${collated_dir}/colorbar ]
+then
+    echo "ERROR: a group's colorbar was gathered by map as if it were one of its maps."
+    exit 1
+fi
+
 INFO "Testing that the draw-kegg-pathways text file input rejects invalid files and argument \
 combinations (each command below is expected to fail)"
+
+if anvi-draw-kegg-pathways --reaction-txt draw_kos_samples.reaction.txt \
+    --collate-files-by-map \
+    --output-dir ${output_dir}/draw_txt_bad --overwrite-output-destinations --no-progress > /dev/null 2>&1
+then
+    echo "ERROR: gathering by map with no individual maps to gather should have failed."
+    exit 1
+fi
+
+if anvi-draw-kegg-pathways --reaction-txt draw_kos.reaction.txt \
+    --draw-individual-files --collate-files-by-map \
+    --output-dir ${output_dir}/draw_txt_bad --overwrite-output-destinations --no-progress > /dev/null 2>&1
+then
+    echo "ERROR: gathering by map for a file with no 'sample' column should have failed."
+    exit 1
+fi
 
 if anvi-draw-kegg-pathways --reaction-txt draw_kos_unusable_sample_names.reaction.txt \
     --draw-individual-files \
@@ -1747,6 +1848,15 @@ if anvi-draw-kegg-pathways --pan-db TEST-PAN.db --genomes-storage TEST-GENOMES.d
     --output-dir ${output_dir}/draw_db_bad --overwrite-output-destinations --no-progress > /dev/null 2>&1
 then
     echo "ERROR: '--group-colormap-scheme' on an ungrouped pangenome should have failed."
+    exit 1
+fi
+
+# A single database is drawn on one map per pathway, leaving no individual maps to gather by map.
+if anvi-draw-kegg-pathways --contigs-dbs E_faecalis_6240.db \
+    --draw-individual-files --collate-files-by-map \
+    --output-dir ${output_dir}/draw_db_bad --overwrite-output-destinations --no-progress > /dev/null 2>&1
+then
+    echo "ERROR: gathering by map for a single contigs database should have failed."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

`--draw-individual-files` writes one subdirectory per data source (sample, group, contigs database, or pan genome), each holding that source's whole set of maps. That is the right arrangement for reading everything about one sample, and the wrong one for comparing a single map across samples, as it requires opening one file in each of those subdirectories, one at a time.

This PR adds `--collate-files-by-map`, which arranges the same files the other way round: a subdirectory per map, holding one file per source, named after the source. A file browser's preview can step through the colors of one map changing sample to sample, like an animation.

## Output

```
<out>/by_map/kos_00010/A.pdf
<out>/by_map/kos_00010/B.pdf
<out>/by_map/kos_00020/A.pdf
...
```

`--name-files` and `--categorize-files` apply as they do everywhere else in the output, so with both of these flags:

```
<out>/by_map/Metabolism/Carbohydrate_metabolism/kos_00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf
```

This is a second arrangement rather than a replacement — `individual/` stays where it is, and the gathered files are hard links to the maps already drawn there, so they cost no disk space. A hard link is indistinguishable from a real file to a file browser and survives output directories being moved on the same drive. Where a filesystem refuses a hard link, a relative symlink stands in.

`by_map` sits beside `unified`/`individual`/`grid` at the top of the output directory rather than inside `individual/`, preserving the structure that every name directly in the output directory is automatically produced by anvi'o while user-supplied names are limited to directory names in `individual/`.