### PR TITLE
Name `anvi-draw-kegg-pathways` map files after their KEGG accession

### DIFF
--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -309,13 +309,13 @@ def get_args() -> Namespace:
         '--name-files', action='store_true', default=False, help=
         "Include the pathway name along with the number in output map file names. For example, in "
         "drawing KO presence/absence data, by default, the 'Glycolysis / Gluconeogenesis' map "
-        "would be saved to a file named 'kos_00010.pdf', but, with this flag, the map would be "
-        "saved to a file named 'kos_00010_Glycolysis_Gluconeogenesis.pdf'. To further illustrate "
-        "how special characters in pathway names are translated to characters in file paths, the "
-        "file name for 'Glycosylphosphatidylinositol (GPI)-anchor biosynthesis' would be "
-        "'kos_00563_Glycosylphosphatidylinositol_(GPI)_anchor_biosynthesis.pdf', and the file name "
+        "would be saved to a file named 'ko00010.pdf', but, with this flag, the map would be saved "
+        "to a file named 'ko00010_Glycolysis_Gluconeogenesis.pdf'. To further illustrate how "
+        "special characters in pathway names are translated to characters in file paths, the file "
+        "name for 'Glycosylphosphatidylinositol (GPI)-anchor biosynthesis' would be "
+        "'ko00563_Glycosylphosphatidylinositol_(GPI)_anchor_biosynthesis.pdf', and the file name "
         "for 'Biosynthesis of 12-, 14- and 16-membered macrolides' would be "
-        "'kos_00522_Biosynthesis_of_12_14_and_16_membered_macrolides.pdf' with this flag."
+        "'ko00522_Biosynthesis_of_12_14_and_16_membered_macrolides.pdf' with this flag."
     )
     groupOUT.add_argument(
         '--categorize-files', action='store_true', default=False, help=
@@ -365,8 +365,8 @@ def get_args() -> Namespace:
         "compared across sources by stepping through one directory, as a file browser's preview "
         "moves from one file to the next. For example, with samples 'A' through 'E', the "
         "'Glycolysis / Gluconeogenesis' map would be gathered into a directory named "
-        "'by_map/kos_00010' holding files named 'A.pdf' through 'E.pdf', or "
-        "'by_map/kos_00010_Glycolysis_Gluconeogenesis' with '--name-files'. With "
+        "'by_map/ko00010' holding files named 'A.pdf' through 'E.pdf', or "
+        "'by_map/ko00010_Glycolysis_Gluconeogenesis' with '--name-files'. With "
         "'--categorize-files', the BRITE subdirectories precede each map's directory, just as "
         "they precede each map file elsewhere in the output. The gathered files are links to the "
         "maps already drawn, so they take up no disk space of their own."

--- a/anvio/docs/programs/anvi-draw-kegg-pathways.md
+++ b/anvio/docs/programs/anvi-draw-kegg-pathways.md
@@ -78,11 +78,11 @@ The one requirement is that a name becoming a subdirectory has to work as a dire
 
 ### File names
 
-By default, output file names contain the ID of each map, e.g., `kos_00010.pdf` for `Glycolysis / Gluconeogenesis`. The `--name-files` flag attaches a simplified version of the pathway name to the file name, e.g., `kos_00010_Glycolysis_Gluconeogenesis.pdf`.
+By default, an output file is named after the map's KEGG accession, e.g., `ko00010.pdf` for `Glycolysis / Gluconeogenesis`. The `--name-files` flag attaches a simplified version of the pathway name to the file name, e.g., `ko00010_Glycolysis_Gluconeogenesis.pdf`.
 
 ### File categorization
 
-The `--categorize-files` flag categorizes output map files into a subdirectory structure based on the KEGG [BRITE hierarchy of pathways](https://www.genome.jp/brite/br08901). For example, a `Glycolysis / Gluconeogenesis` map would be placed in a directory named `Metabolism/Carbohydrate_metabolism`, as would a `Citrate cycle (TCA cycle)` map, whereas an `RNA polymerase` map would be placed in a directory named `Genetic_Information_Processing/Transcription`. A subdirectory named `symlink` is also created with symbolic links to all of the categorized map files, allowing the files to be accessed from a single directory. This structure is built inside each of the subdirectories described above, so a categorized map of one sample would be found at, say, `individual/SAMPLE_1/Metabolism/Carbohydrate_metabolism/kos_00010.pdf`.
+The `--categorize-files` flag categorizes output map files into a subdirectory structure based on the KEGG [BRITE hierarchy of pathways](https://www.genome.jp/brite/br08901). For example, a `Glycolysis / Gluconeogenesis` map would be placed in a directory named `Metabolism/Carbohydrate_metabolism`, as would a `Citrate cycle (TCA cycle)` map, whereas an `RNA polymerase` map would be placed in a directory named `Genetic_Information_Processing/Transcription`. A subdirectory named `symlink` is also created with symbolic links to all of the categorized map files, allowing the files to be accessed from a single directory. This structure is built inside each of the subdirectories described above, so a categorized map of one sample would be found at, say, `individual/SAMPLE_1/Metabolism/Carbohydrate_metabolism/ko00010.pdf`.
 
 Here is a simple example of the output file structure produced with `--name-files` and `--categorize-files` in the course of `anvi-self-test --suite kegg-mapping` (with the `-o` option to save the temporary directories in the test from removal).
 
@@ -92,9 +92,9 @@ Here is a simple example of the output file structure produced with `--name-file
 
 `--draw-individual-files` writes one subdirectory per data source, each holding that source's whole set of maps. That is the right arrangement for reading everything about one sample, and the wrong one for comparing a single map across samples, which means opening one file in each of those subdirectories. The `--collate-files-by-map` flag adds the transposed view: a subdirectory named after each map, holding one file per source, named after the source.
 
-With samples `A` through `E`, `by_map/kos_00010` holds `A.pdf` through `E.pdf`, `by_map/kos_00020` holds another five files, and so on. Selecting everything in one of those subdirectories and stepping through it with a file browser's preview shows the colors of a single map changing from sample to sample, like an animation. Files are sorted by the name of their source, so name your samples in the order in which you would like to step through them.
+With samples `A` through `E`, `by_map/ko00010` holds `A.pdf` through `E.pdf`, `by_map/ko00020` holds another five files, and so on. Selecting everything in one of those subdirectories and stepping through it with a file browser's preview shows the colors of a single map changing from sample to sample, like an animation. Files are sorted by the name of their source, so name your samples in the order in which you would like to step through them.
 
-This is a second arrangement of the same files rather than a replacement: the subdirectory per source stays where it is, and the gathered files are links to the maps already drawn there, so they take up no disk space of their own. `--name-files` and `--categorize-files` apply here as they do elsewhere in the output, so with both of them a gathered map would be found at, say, `by_map/Metabolism/Carbohydrate_metabolism/kos_00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf`.
+This is a second arrangement of the same files rather than a replacement: the subdirectory per source stays where it is, and the gathered files are links to the maps already drawn there, so they take up no disk space of their own. `--name-files` and `--categorize-files` apply here as they do elsewhere in the output, so with both of them a gathered map would be found at, say, `by_map/Metabolism/Carbohydrate_metabolism/ko00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf`.
 
 ## Mapping reaction and compound occurrence
 

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -2895,7 +2895,7 @@ class Mapper:
             False.
         """
         # Find the numeric IDs of the maps to draw.
-        pathway_numbers = self._find_maps(output_dir, 'kos', patterns=pathway_numbers)
+        pathway_numbers = self._find_maps(output_dir, patterns=pathway_numbers)
 
         filesnpaths.gen_output_directory(output_dir, progress=self.progress, run=self.run)
 
@@ -3947,7 +3947,7 @@ class Mapper:
             )
 
         unified_dir = os.path.join(output_dir, UNIFIED_SUBDIR)
-        pathway_numbers = self._find_maps(unified_dir, 'kos', patterns=pathway_numbers)
+        pathway_numbers = self._find_maps(unified_dir, patterns=pathway_numbers)
         filesnpaths.gen_output_directory(output_dir, progress=self.progress, run=self.run)
 
         drawn: Dict[Literal['unified', 'individual', 'grid'], Dict] = {
@@ -6132,19 +6132,15 @@ class Mapper:
                 f"'{pan_db}'"
             )
 
-    def _find_maps(self, output_dir: str, prefix: str, patterns: List[str] = None) -> List[str]:
+    def _find_maps(self, output_dir: str, patterns: List[str] = None) -> List[str]:
         """
-        Find the numeric IDs of maps to draw given the file prefix, checking that the map can be
-        drawn in the target output direcotry.
+        Find the numeric IDs of maps to draw, checking that the map can be drawn in the target
+        output directory.
 
         Parameters
         ==========
         output_dir : str
             Path to the output directory in which pathway map PDF files are drawn.
-
-        prefix : str
-            Output filenames are formatted as <prefix>_<pathway_number>.pdf or
-            <prefix>_<pathway_number>_<pathway_name>.pdf.
 
         patterns : List[str], None
             Regex patterns of pathway numbers, which are five digits.
@@ -6173,8 +6169,7 @@ class Mapper:
 
         if not self.overwrite_output:
             for pathway_number in pathway_numbers:
-                pathway_name = f'_{self._name_pathway(pathway_number)}' if self.name_files else ''
-                out_basename = f'{prefix}_{pathway_number}{pathway_name}.pdf'
+                out_basename = self._map_basename(pathway_number)
                 if self.pathway_categorization is None:
                     out_path = os.path.join(output_dir, out_basename)
                 else:
@@ -6350,8 +6345,7 @@ class Mapper:
             Path to the output directory in which the pathway map PDF file is drawn. The directory
             is created if it does not exist.
         """
-        pathway_name = f'_{self._name_pathway(pathway.number)}' if self.name_files else ''
-        out_basename = f'kos_{pathway.number}{pathway_name}.pdf'
+        out_basename = self._map_basename(pathway.number)
 
         if self.pathway_categorization is None:
             out_dir = output_dir
@@ -6575,8 +6569,7 @@ class Mapper:
                 if set(drawn_category.values()) != set([True, False]):
                     continue
 
-                pathway_name = f'_{self._name_pathway(pathway_number)}' if self.name_files else ''
-                pathway_basename = f'kos_{pathway_number}{pathway_name}.pdf'
+                pathway_basename = self._map_basename(pathway_number)
                 for category, drawn_map in drawn_category.items():
                     if drawn_map:
                         continue
@@ -6633,8 +6626,7 @@ class Mapper:
 
         for pathway_number in pathway_numbers:
             self.progress.update(pathway_number)
-            pathway_name = f'_{self._name_pathway(pathway_number)}' if self.name_files else ''
-            pathway_basename = f'kos_{pathway_number}{pathway_name}.pdf'
+            pathway_basename = self._map_basename(pathway_number)
             unified_dir = os.path.join(output_dir, UNIFIED_SUBDIR)
             if self.pathway_categorization is None:
                 unified_map_path = os.path.join(unified_dir, pathway_basename)
@@ -6740,6 +6732,31 @@ class Mapper:
             self._zero_out_compound_rectangles(pathway)
 
         return pathway
+
+    def _map_basename(self, pathway_number: str) -> str:
+        """
+        Name the output file of a pathway map.
+
+        The name is the map's KEGG accession — its number under the 'ko' prefix of the reference
+        KGML files the maps are drawn from — and, with 'name_files', the pathway name as well.
+
+        Every context that draws a map or goes looking for one names it here, so the same map is
+        named the same under 'unified', 'individual', and 'grid'. That is how a grid finds the
+        panels it is made of.
+
+        Parameters
+        ==========
+        pathway_number : str
+            ID number of the pathway, which is five digits.
+
+        Returns
+        =======
+        str
+            The file name, e.g. 'ko00010.pdf', or 'ko00010_Glycolysis_Gluconeogenesis.pdf' where
+            file names carry pathway names.
+        """
+        pathway_name = f'_{self._name_pathway(pathway_number)}' if self.name_files else ''
+        return f'ko{pathway_number}{pathway_name}.pdf'
 
     def _name_pathway(self, pathway_number: str) -> str:
         """

--- a/anvio/tests/run_component_tests_for_kegg_mapping.sh
+++ b/anvio/tests/run_component_tests_for_kegg_mapping.sh
@@ -1127,7 +1127,7 @@ anvi-draw-kegg-pathways "${args[@]}"
 
 for sample in SAMPLE_1 SAMPLE_2 SAMPLE_3
 do
-    if [ ! -s ${output_dir}/draw_txt_collate_by_map/by_map/kos_00010/${sample}.pdf ]
+    if [ ! -s ${output_dir}/draw_txt_collate_by_map/by_map/ko00010/${sample}.pdf ]
     then
         echo "ERROR: the map gathered by map is missing the file of ${sample}."
         exit 1
@@ -1135,8 +1135,8 @@ do
 done
 
 # The gathered files are links to the maps already drawn rather than copies of them.
-if ! [ ${output_dir}/draw_txt_collate_by_map/by_map/kos_00010/SAMPLE_1.pdf \
-    -ef ${output_dir}/draw_txt_collate_by_map/individual/SAMPLE_1/kos_00010.pdf ]
+if ! [ ${output_dir}/draw_txt_collate_by_map/by_map/ko00010/SAMPLE_1.pdf \
+    -ef ${output_dir}/draw_txt_collate_by_map/individual/SAMPLE_1/ko00010.pdf ]
 then
     echo "ERROR: a map gathered by map should be a link to the map drawn for the sample."
     exit 1
@@ -1157,7 +1157,7 @@ args+=( "--no-progress" )
 anvi-draw-kegg-pathways "${args[@]}"
 
 collated_dir=${output_dir}/draw_txt_collate_by_map_categorized/by_map
-if [ ! -s ${collated_dir}/Metabolism/Carbohydrate_metabolism/kos_00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf ]
+if [ ! -s ${collated_dir}/Metabolism/Carbohydrate_metabolism/ko00010_Glycolysis_Gluconeogenesis/SAMPLE_1.pdf ]
 then
     echo "ERROR: gathering by map did not keep the BRITE subdirectories of the map."
     exit 1
@@ -1183,12 +1183,12 @@ args+=( "--no-progress" )
 anvi-draw-kegg-pathways "${args[@]}"
 
 collated_dir=${output_dir}/draw_txt_collate_by_map_groups/by_map
-if [ ! -s ${collated_dir}/kos_00010/G1.pdf ]
+if [ ! -s ${collated_dir}/ko00010/G1.pdf ]
 then
     echo "ERROR: the group asked for individually was not gathered by map."
     exit 1
 fi
-if [ -e ${collated_dir}/kos_00010/G2.pdf ]
+if [ -e ${collated_dir}/ko00010/G2.pdf ]
 then
     echo "ERROR: a group drawn as a grid panel alone was gathered by map."
     exit 1


### PR DESCRIPTION
`anvi-draw-kegg-pathways` wrote its map files as `kos_00010.pdf`, or `kos_00010_Glycolysis_Gluconeogenesis.pdf` with `--name-files`. That `kos_` prefix is a fossil that was meant to distinguish maps colored by KOs from those colored by other data — a feature that was not yet implemented. With the addition of the compound layer and the availability of KEGG Reaction accession input, the hardcoded 'kos_' prefix is inaccurate.

This PR replaces `kos_#####` with the map's actual KEGG accession, `ko#####`, which is also the name of the reference KGML that anvi'o draws on (`ko00010.xml`). Here are the four output contexts in which the map accession occurs:

```
unified/ko00010.pdf
individual/SAMPLE_1/Metabolism/Carbohydrate_metabolism/ko00010_Glycolysis_Gluconeogenesis.pdf
grid/ko00010.pdf
by_map/ko00010/SAMPLE_1.pdf
```