### PR TITLE
Hard link `anvi-draw-kegg-pathways` maps into a flat directory, renaming `symlink` to `all_maps`

### DIFF
--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -320,14 +320,15 @@ def get_args() -> Namespace:
     groupOUT.add_argument(
         '--categorize-files', action='store_true', default=False, help=
         "Categorize output files by pathway map within subdirectories corresponding to the BRITE "
-        "hierarchy of maps (see https://www.genome.jp/brite/br08901). Symlinks to these files are "
-        "also created for easier browsing. For example, if drawing a map file for 'Glycolysis / "
-        "Gluconeogenesis', '00010', then the file will be written to subdirectory "
-        "'Metabolism/Carbohydrate_metabolism' of the output directory, and a symlink with the same "
-        "basename as the file will be created in subdirectory 'symlink' of the output directory. "
-        "If drawing a map grid for 'Quorum sensing', '02024', then the file will be written to a "
-        "subdirectory named 'grid/Cellular_Processes/Cellular_community_prokaryotes', and a "
-        "symlink will be created in a subdirectory named 'grid/symlink'."
+        "hierarchy of maps (see https://www.genome.jp/brite/br08901). Links to these files are "
+        "also gathered in one directory for easier browsing. For example, if drawing a map file "
+        "for 'Glycolysis / Gluconeogenesis', '00010', then the file will be written to "
+        "subdirectory 'Metabolism/Carbohydrate_metabolism' of the output directory, and a link "
+        "with the same basename as the file will be created in subdirectory 'all_maps' of the "
+        "output directory. If drawing a map grid for 'Quorum sensing', '02024', then the file will "
+        "be written to a subdirectory named "
+        "'grid/Cellular_Processes/Cellular_community_prokaryotes', and a hard link will be created "
+        "in a subdirectory named 'grid/all_maps'."
     )
     groupOUT.add_argument(
         '--draw-individual-files', nargs='*', help=

--- a/anvio/docs/programs/anvi-draw-kegg-pathways.md
+++ b/anvio/docs/programs/anvi-draw-kegg-pathways.md
@@ -72,7 +72,7 @@ Map files are sorted into up to four subdirectories, one for each kind of map:
 
 Colorbars, which are keys to the colors of every map in the run, are written at the top of the output directory beside these subdirectories.
 
-Because the names in `individual` come from your own data, they are kept in that subdirectory of their own: a sample, genome, or group may be named anything at all — including `unified`, `grid`, `by_map`, `symlink`, or `Metabolism` — without ever colliding with a directory this program creates for itself.
+Because the names in `individual` come from your own data, they are kept in that subdirectory of their own: a sample, genome, or group may be named anything at all — including `unified`, `grid`, `by_map`, `all_maps`, or `Metabolism` — without ever colliding with a directory this program creates for itself.
 
 The one requirement is that a name becoming a subdirectory has to work as a directory name, so a name containing a path separator, such as `Rhizobium meliloti RU11/001`, is refused. This only applies to the sources that are actually drawn individually: a source summarized on the `unified` map contributes color rather than a path, so its name is never used as one, and a source left out of a subset requested with `--draw-individual-files` or `--draw-grid` is not checked either.
 
@@ -82,7 +82,7 @@ By default, an output file is named after the map's KEGG accession, e.g., `ko000
 
 ### File categorization
 
-The `--categorize-files` flag categorizes output map files into a subdirectory structure based on the KEGG [BRITE hierarchy of pathways](https://www.genome.jp/brite/br08901). For example, a `Glycolysis / Gluconeogenesis` map would be placed in a directory named `Metabolism/Carbohydrate_metabolism`, as would a `Citrate cycle (TCA cycle)` map, whereas an `RNA polymerase` map would be placed in a directory named `Genetic_Information_Processing/Transcription`. A subdirectory named `symlink` is also created with symbolic links to all of the categorized map files, allowing the files to be accessed from a single directory. This structure is built inside each of the subdirectories described above, so a categorized map of one sample would be found at, say, `individual/SAMPLE_1/Metabolism/Carbohydrate_metabolism/ko00010.pdf`.
+The `--categorize-files` flag categorizes output map files into a subdirectory structure based on the KEGG [BRITE hierarchy of pathways](https://www.genome.jp/brite/br08901). For example, a `Glycolysis / Gluconeogenesis` map would be placed in a directory named `Metabolism/Carbohydrate_metabolism`, as would a `Citrate cycle (TCA cycle)` map, whereas an `RNA polymerase` map would be placed in a directory named `Genetic_Information_Processing/Transcription`. These category directories are built inside each of the subdirectories described above, so a categorized map of one sample would be found at, say, `individual/SAMPLE_1/Metabolism/Carbohydrate_metabolism/ko00010.pdf`. Within `unified`, `individual`, and `grid`, a subdirectory named `all_maps` is created alongside them, holding a hard link to every one of that directory's maps so that they can also be reached from a single place.
 
 Here is a simple example of the output file structure produced with `--name-files` and `--categorize-files` in the course of `anvi-self-test --suite kegg-mapping` (with the `-o` option to save the temporary directories in the test from removal).
 

--- a/anvio/keggmapping.py
+++ b/anvio/keggmapping.py
@@ -242,8 +242,8 @@ GRID_SUBDIR = 'grid'
 COLLATED_SUBDIR = 'by_map'
 
 # Where '--categorize-files' nests map files in BRITE subdirectories, this subdirectory of links
-# gathers every one of them back into a single place to browse ('_symlink_map').
-FLAT_SUBDIR = 'symlink'
+# gathers every one of them back into a single place to browse ('_link_map_flat').
+FLAT_SUBDIR = 'all_maps'
 
 # The colorbar keying the maps of one individual source, written beside them in its directory.
 CATEGORY_COLORBAR_BASENAME = 'colorbar.pdf'
@@ -1000,7 +1000,7 @@ class Mapper:
 
         No name is reserved. Categories are drawn into '<output directory>/individual', which anvi'o
         creates for that purpose alone, so a category may be named after anything anvi'o puts in the
-        output directory itself — 'unified', 'grid', 'by_map', 'symlink', or a BRITE category such
+        output directory itself — 'unified', 'grid', 'by_map', 'all_maps', or a BRITE category such
         as 'Metabolism' — without the two ever meeting.
 
         Parameters
@@ -6360,28 +6360,25 @@ class Mapper:
         if self.pathway_categorization is None:
             return
 
-        self._symlink_map(output_dir, out_path)
+        self._link_map_flat(output_dir, out_path)
 
-    def _symlink_map(self, output_dir: str, map_path: str) -> None:
+    def _link_map_flat(self, output_dir: str, map_path: str) -> None:
         """
-        Make a symlink for a map file in a dedicated symlink directory.
+        Link to a map file from the flat directory, which gathers all maps in a single directory.
+
+        Where '--categorize-files' nests map files in BRITE subdirectories, the flat directory
+        contains all of the files for easier browsing.
 
         Parameters
         ==========
         output_dir : str
-            Path to the output directory in which the map file was drawn (potentially in a
-            subdirectory). A subdirectory called 'symlink' is created if it does not already exist.
+            Path to the output directory the map file was drawn in, whether directly or in a
+            subdirectory of it. The flat directory is made there if it does not already exist.
 
         map_path : str
-            Map file path to be symlinked.
+            Path of the map file to link to.
         """
-        symlink_dir = os.path.join(output_dir, FLAT_SUBDIR)
-        os.makedirs(symlink_dir, exist_ok=True)
-        map_basename = os.path.basename(map_path)
-        symlink_path = os.path.join(symlink_dir, map_basename)
-        if os.path.exists(symlink_path):
-            os.remove(symlink_path)
-        os.symlink(os.path.abspath(map_path), symlink_path)
+        self._link_map(map_path, os.path.join(output_dir, FLAT_SUBDIR, os.path.basename(map_path)))
 
     def _collate_maps_by_map(self, output_dir: str, categories: List[str]) -> int:
         """
@@ -6665,12 +6662,12 @@ class Mapper:
                     out_path = os.path.join(out_dir, pathway_basename)
                 self.grid_drawer.draw(in_paths, out_path, labels=labels)
                 if self.pathway_categorization is not None:
-                    self._symlink_map(grid_dir, out_path)
+                    self._link_map_flat(grid_dir, out_path)
                 drawn['grid'][pathway_number] = True
 
         self.progress.end()
 
-        # Remove individual maps and symlinks that were only needed for map grids.
+        # Remove individual maps and their links that were only needed for map grids.
         for path in paths_to_remove:
             os.remove(path)
         for category in set(draw_categories).difference(set(draw_files_categories)):

--- a/anvio/tests/run_component_tests_for_kegg_mapping.sh
+++ b/anvio/tests/run_component_tests_for_kegg_mapping.sh
@@ -149,7 +149,7 @@ printf 'accession\tconcentration\nC00031\t10\nC00031\t30\n' > draw_bad_repeated_
 
 # Samples named after the output directory's own subdirectories and after a BRITE category: these
 # are drawn under 'individual', so they cannot collide with anything anvi'o creates for itself.
-printf 'accession\tsample\nK00844\tMetabolism\nK00845\tsymlink\nK02358\tgrid\nK00844\tunified\n' > draw_kos_awkward_sample_names.reaction.txt
+printf 'accession\tsample\nK00844\tMetabolism\nK00845\tall_maps\nK02358\tgrid\nK00844\tunified\nK02358\tby_map\n' > draw_kos_awkward_sample_names.reaction.txt
 
 # A sample whose name cannot be a directory name, alongside one that can. Only a sample drawn on its
 # own maps becomes a subdirectory, so this file is fine until such maps are asked for it.
@@ -1083,8 +1083,8 @@ args+=( "--no-progress" )
 anvi-draw-kegg-pathways "${args[@]}"
 
 INFO "Testing samples whose names match the output directory's own subdirectories ('unified', \
-'grid', 'symlink') and a BRITE category ('Metabolism'), which are drawn under 'individual' and so \
-cannot collide with them"
+'grid', 'by_map', 'all_maps') and a BRITE category ('Metabolism'), which are drawn under \
+'individual' and so cannot collide with them"
 args=()
 args+=( "--reaction-txt" "draw_kos_awkward_sample_names.reaction.txt" )
 args+=( "--categorize-files" )
@@ -1162,9 +1162,18 @@ then
     echo "ERROR: gathering by map did not keep the BRITE subdirectories of the map."
     exit 1
 fi
-if [ -e ${collated_dir}/symlink ]
+if [ -e ${collated_dir}/all_maps ]
 then
     echo "ERROR: the flat directory of links was gathered as if it held maps of its own."
+    exit 1
+fi
+
+# The flat directory holds links to the categorized maps rather than copies of them.
+categorized_dir=${output_dir}/draw_txt_collate_by_map_categorized/unified
+if ! [ ${categorized_dir}/all_maps/ko00010_Glycolysis_Gluconeogenesis.pdf \
+    -ef ${categorized_dir}/Metabolism/Carbohydrate_metabolism/ko00010_Glycolysis_Gluconeogenesis.pdf ]
+then
+    echo "ERROR: the flat directory should hold a link to each categorized map, not a copy."
     exit 1
 fi
 


### PR DESCRIPTION
`--categorize-files` nests map files in BRITE subdirectories and also gathers every map into one flat directory so they can be browsed without descending the hierarchy. That directory was filled by `os.symlink(os.path.abspath(map_path), …)` — **absolute** targets. Move, rename, or copy the output directory (off a cluster, into a synced folder, into a tarball) and every entry in it either dangles or silently points back at the original tree.

This PR makes them hard links, which store no path at all and survive any move. A file browser also cannot tell them from real files, which matters because browsing is the directory's entire purpose. The directory called `symlink` is therefore renamed to `all_maps`.

```
unified/
├── Metabolism/Carbohydrate_metabolism/ko00010_Glycolysis_Gluconeogenesis.pdf
└── all_maps/ko00010_Glycolysis_Gluconeogenesis.pdf   ← same inode
```