### PR TITLE
(Re)calculating graph display based on genomes of interest

### DIFF
--- a/anvio/bottleroutes.py
+++ b/anvio/bottleroutes.py
@@ -1710,10 +1710,18 @@ class BottleApplication(Bottle):
             groupcompress = payload['groupcompress']
             component = payload.get('component', 'CP_0001')
 
-            self.interactive.rerun_state(gene_cluster_grouping_threshold, groupcompress, max_edge_length_filter, component=component)
+            # The genomes the user currently has switched on. When this set shrinks, the
+            # graph is rebuilt as the subgraph those genomes induce and laid out afresh,
+            # so the picture reorganizes instead of merely hiding tracks. A missing key
+            # means "no subset asked for" (an older interface, or the full roster); an
+            # empty list means every genome was switched off, which rerun_state rejects.
+            genomes = payload.get('genomes')
+
+            self.interactive.rerun_state(gene_cluster_grouping_threshold, groupcompress, max_edge_length_filter,
+                                         component=component, genomes=genomes)
             return(json.dumps({'status': 0}))
-        except:
-            return(json.dumps({'status': 1}))
+        except Exception as e:
+            return(json.dumps({'status': 1, 'message': str(e)}))
 
 
     def get_pangraph_synteny_gene_cluster_alignment(self):

--- a/anvio/data/interactive/css/pangraph.css
+++ b/anvio/data/interactive/css/pangraph.css
@@ -231,7 +231,7 @@
     white-space: nowrap;
     flex: 1;
     min-width: 0;
-    font-size: 1.2em;
+    font-size: 1.0em;
     padding-left: 3px;
   }
 

--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -166,7 +166,7 @@ class PangenomeGraphUserInterface {
         var layer_color = $('#layer_color').attr('color');
         var back_color = $('#back_color').attr('color');
         var non_back_color = $('#non_back_color').attr('color');
-        var genome_size = this.genomes.length
+        var genome_size = this.active_genomes.length
         
         var theta = (end_angle - start_angle) / (this.global_x+1)
         
@@ -1486,6 +1486,16 @@ class PangenomeGraphUserInterface {
         new_settings_dict['maxlength'] = parseInt($('#maxlength')[0].value);
         new_settings_dict['groupcompress'] = parseFloat($('#groupcompress')[0].value);
         new_settings_dict['component'] = $('#component_select').val();
+        // Which genomes are switched on. Sending these lets the server rebuild the graph
+        // as the subgraph they induce and lay it out again, so switching a genome off
+        // reorganizes the picture instead of just hiding a track. Same as every other
+        // layout control here, it takes effect on the next Redraw.
+        new_settings_dict['genomes'] = this.genomes.filter(g => $('#flex' + g).prop('checked'));
+
+        if (!new_settings_dict['genomes'].length) {
+            toastr.warning('There is no such thing as a pangenome graph of zero genomes. Leave at least one of them on.', 'Nothing to draw');
+            return;
+        }
 
         if (JSON.stringify(this.settings_dict) !== JSON.stringify(new_settings_dict)) {
             this.rerun_JSON(new_settings_dict);
@@ -1594,7 +1604,7 @@ class PangenomeGraphUserInterface {
         var raw_type = this.data['nodes'][element_id]['type'];
         var gene_cluster = this.data['nodes'][element_id]['gene_cluster'];
         var num_genomes = Object.keys(this.data['nodes'][element_id]['gene_calls']).length;
-        var total_genomes = this.genomes.length;
+        var total_genomes = this.active_genomes.length;
 
         const type_labels = {
             'core':          'Core',
@@ -2182,7 +2192,7 @@ class PangenomeGraphUserInterface {
     
     main_draw() {
         var svg_core = this.generate_svg();
-        var genome_size = this.genomes.length;
+        var genome_size = this.active_genomes.length;
 
         // TODO this is just a temporary fix the whole generate_svg() has to be rewritten in either
         // createElementNS or raw html string fashion. FML.
@@ -2513,7 +2523,7 @@ class PangenomeGraphUserInterface {
         var rearranged_color = $('#rearranged_color').attr('color');
         var trna_color = $('#trna_color').attr('color');
 
-        var genome_size = this.genomes.length
+        var genome_size = this.active_genomes.length
         
         if ($('#flexsaturation').prop('checked') == true){
             var saturation = 1
@@ -2675,6 +2685,13 @@ class PangenomeGraphUserInterface {
         // this.layers = this.data['meta']['layers'].filter(item => item !== 'backbone');
         this.layers = this.data['meta']['layers'];
         this.genomes = this.data['meta']['genome_names'];
+        // The genomes the graph on screen is actually made of. `this.genomes` stays the
+        // full roster the db knows about, because the settings panel is built from it
+        // exactly once and has to keep a row for every genome so a hidden one can be
+        // switched back on. Anything that counts genomes -- prevalence shading, "N of M
+        // genomes" -- has to count these instead, or a subset graph reports its core
+        // nodes against a denominator that is no longer on the screen.
+        this.active_genomes = this.data['meta']['genomes_of_interest'] || this.genomes;
         this.functional_annotation_sources_available = this.data['meta']['gene_function_sources'];
 
         this.group_dict = {}

--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -1512,6 +1512,13 @@ class PangenomeGraphUserInterface {
             success: (data) => {
                 this.data = data['data'];
                 this.initialize_variables();
+                // Dropping genomes can dissolve a component or split one in two, so the
+                // dropdown is rebuilt here rather than only at startup. The server has
+                // already fallen back to the lowest-numbered component if the one we
+                // asked for is gone, so follow whatever it decided to send back.
+                this.populate_component_select();
+                new_settings_dict['component'] = this.data['meta']['component'];
+                $('#component_select').val(new_settings_dict['component']);
                 this.settings_dict = JSON.parse(JSON.stringify(new_settings_dict));
                 this.main_draw();
                 $('#svgbox').css('opacity', '');
@@ -2978,6 +2985,15 @@ class PangenomeGraphUserInterface {
             genome_order.push(genome);
         }
 
+        // Genome order lives in the DOM order of the rows, so restoring a state has to
+        // put them back in the order it was saved in -- otherwise an ordering survives
+        // the save but not the load.
+        const genomecolors = document.getElementById('genomecolors');
+        for (const genome of genome_order) {
+            const row = document.getElementById(genome + '_row');
+            if (row) genomecolors.appendChild(row);
+        }
+
         // imported_layers
         const il = state['imported_layers'] || {};
         for (const [layer, ldata] of Object.entries(il)) {
@@ -3569,6 +3585,20 @@ class PangenomeGraphUserInterface {
             } else {
                 $('#flex' + genome + 'layer').prop('checked', true);
             }
+        });
+
+        // Switch every genome off / back on at once. The graph is not redrawn here --
+        // like every other control in this panel, the change lands on the next Redraw.
+        // That is the point: deselect all, switch one genome on, Redraw, switch the next
+        // one on, Redraw, and the graph rebuilds and re-lays out at each step.
+        // `.trigger('change')` so the per-genome handler still does its bookkeeping
+        // (hiding the track, dropping the dendrogram); it only warns about the
+        // dendrogram once, since the first genome to go clears the checkbox.
+        $('#genomes-deselect-all').on('click', () => {
+            for (const genome of this.genomes) {
+                $('#flex' + genome).prop('checked', false).trigger('change');
+            }
+            toastr.info('All genomes are switched off. Switch at least one back on, then hit Redraw.', 'Genomes deselected');
         });
 
         $('#apply-track-defaults').on('click', () => {

--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -5303,8 +5303,11 @@ class PangenomeGraphUserInterface {
             return;
         }
 
+        // The rows are `.genome-row` (see initialize_user_interface). Filtering on any
+        // other class yields an empty list, which would quietly save a state with no
+        // genome settings in it at all.
         const genome_order = [...document.getElementById("genomecolors").children]
-            .filter(el => el.classList.contains("col-12"))
+            .filter(el => el.classList.contains("genome-row"))
             .map(el => el.id.replace('_row', ''));
 
         const genomes_state = {};

--- a/anvio/data/interactive/js/pangenome-graph.js
+++ b/anvio/data/interactive/js/pangenome-graph.js
@@ -3601,6 +3601,33 @@ class PangenomeGraphUserInterface {
             toastr.info('All genomes are switched off. Switch at least one back on, then hit Redraw.', 'Genomes deselected');
         });
 
+        // One handler for the whole row of ordering buttons; each carries its own key.
+        // Buttons whose key no numbers arrived for (the genomes storage is optional for
+        // anvi-display-pan-graph) are dropped rather than left there to do nothing.
+        const genome_stats = (this.data['meta'] && this.data['meta']['genome_stats']) || {};
+        $('.genome-order-btn').each(function () {
+            const key = $(this).data('order-key');
+            if (key === 'name') return;
+            const have_it = Object.values(genome_stats).some(v => Number.isFinite(v[key]));
+            if (!have_it) $(this).remove();
+        });
+
+        $('#genome-order-controls').on('click', '.genome-order-btn', (ev) => {
+            this.order_genomes($(ev.currentTarget).data('order-key'));
+        });
+
+        $('#genomes-order-descending').on('click', (ev) => {
+            $(ev.currentTarget).toggleClass('active');
+            // re-apply whatever ordering is on screen, now the other way round
+            this.order_genomes(this._genome_order_key || 'name');
+        });
+
+        $('#genomes-select-all').on('click', () => {
+            for (const genome of this.genomes) {
+                $('#flex' + genome).prop('checked', true).trigger('change');
+            }
+        });
+
         $('#apply-track-defaults').on('click', () => {
             const bgColor = $('#layer_color').attr('color');
             const lw = $('#track_line_width')[0].value;
@@ -3611,6 +3638,9 @@ class PangenomeGraphUserInterface {
             }
             this.main_draw();
         });
+        // which ordering the buttons last applied, so 'Descending' has something to flip
+        this._genome_order_key = null;
+
         this.settings_dict['condtr'] = JSON.parse(JSON.stringify(this.data['states']['graph_layout']['grouping_threshold']))
         this.settings_dict['maxlength'] = JSON.parse(JSON.stringify(this.data['states']['graph_layout']['max_edge_length']))
         this.settings_dict['groupcompress'] = JSON.parse(JSON.stringify(this.data['states']['graph_layout']['group_compression']))
@@ -3645,6 +3675,53 @@ class PangenomeGraphUserInterface {
         $("#redraw").removeClass("disabled");
         $("#settings-content").removeClass("settings-loading").addClass("settings-loading-cleared");
     }
+
+    order_genomes(key) {
+        // Reorders the genome list in the settings panel, which is where genome order
+        // actually lives -- the drawing code reads it back out of the DOM on every draw
+        // (see generate_svg's `edgecoloring`). Every genome is reordered, switched on or
+        // off, since the order is a property of the list rather than of the selection.
+        const stats = (this.data['meta'] && this.data['meta']['genome_stats']) || {};
+        const descending = $('#genomes-order-descending').hasClass('active');
+
+        const by_name = (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+
+        const sorted = this.genomes.slice().sort((a, b) => {
+            let cmp;
+            if (key === 'name') {
+                cmp = by_name(a, b);
+            } else {
+                // a genome with no number for this key sorts to the bottom either way,
+                // and ties fall back to the name so the result is never arbitrary
+                const va = (stats[a] || {})[key], vb = (stats[b] || {})[key];
+                const na = Number.isFinite(va) ? va : -Infinity;
+                const nb = Number.isFinite(vb) ? vb : -Infinity;
+                cmp = (na - nb) || by_name(a, b);
+            }
+            return descending ? -cmp : cmp;
+        });
+
+        const container = document.getElementById('genomecolors');
+        for (const genome of sorted) {
+            const row = document.getElementById(genome + '_row');
+            if (row) container.appendChild(row);
+        }
+
+        this._genome_order_key = key;
+
+        // The order no longer follows the dendrogram, so the dendrogram has to go --
+        // same rule the manual drag handler applies.
+        if ($('#flextree').prop('checked')) {
+            $('#flextree').prop('checked', false);
+            this.flextree_change({ currentTarget: document.getElementById('flextree') });
+            toastr.warning("As you have reordered the genomes, the dendrogram is removed from the display (anvi'o hopes you are happy).", 'Dendrogram removed');
+        }
+
+        // Ordering is a drawing concern only -- the graph itself is untouched, so this
+        // needs no trip to the server.
+        this.main_draw();
+    }
+
 
     flextree_change(instance) {
         if ($(instance.currentTarget).prop('checked') == true){

--- a/anvio/data/interactive/pangraph.html
+++ b/anvio/data/interactive/pangraph.html
@@ -742,6 +742,17 @@
                     </div>
 
                     <hr/>
+                    <div><span style="font-size:1.0em; color:#888; margin-right:3px;">Order genomes by | <button id="genomes-order-descending" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" title="Flip the direction of the ordering. Stays lit while descending is on, and re-applies the ordering you last picked.">Descending</button></span></div>
+                    <div id="genome-order-controls" class="d-flex flex-wrap align-items-center gap-1 mt-2 mb-1 px-1">
+                      <button class="genome-order-btn btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" data-order-key="name" title="Order the genome list by name, numbers read as numbers (HIMB122 before HIMB1485)">Name</button>
+                      <button class="genome-order-btn btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" data-order-key="num_synteny_gene_clusters" title="Order by how many synteny gene clusters each genome takes part in, counted across the whole pan-graph">SynGCs</button>
+                      <button class="genome-order-btn btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" data-order-key="num_contigs" title="Order by number of contigs">Contigs</button>
+                      <button class="genome-order-btn btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" data-order-key="total_length" title="Order by total genome length">Length</button>
+                      <button class="genome-order-btn btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" data-order-key="num_genes" title="Order by number of gene calls">Genes</button>
+                      <button class="genome-order-btn btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" data-order-key="gc_content" title="Order by GC content">GC</button>
+                    </div>
+
+                    <hr/>
                     <div class="d-flex align-items-center gap-2 mt-2 mb-1 px-1" style="font-size:0.8em; color:#888;">
                       <span>Genome tracks background color: </span>
                       <div class="pangraph-colorpicker" id="layer_color" color="#F5F5F5" style="background-color:#F5F5F5;"></div>

--- a/anvio/data/interactive/pangraph.html
+++ b/anvio/data/interactive/pangraph.html
@@ -736,6 +736,12 @@
                     </div>
 
                     <hr/>
+                    <div class="d-flex align-items-center gap-2 mt-2 mb-1 px-1">
+                      <button id="genomes-deselect-all" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" title="Switch every genome off, then bring them back one at a time and hit Redraw to watch the graph rebuild itself">Deselect all</button>
+                      <button id="genomes-select-all" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:1.0em;" title="Switch every genome back on">Select all</button>
+                    </div>
+
+                    <hr/>
                     <div class="d-flex align-items-center gap-2 mt-2 mb-1 px-1" style="font-size:0.8em; color:#888;">
                       <span>Genome tracks background color: </span>
                       <div class="pangraph-colorpicker" id="layer_color" color="#F5F5F5" style="background-color:#F5F5F5;"></div>

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3707,6 +3707,9 @@ class PanGraphSuperclass(PanSuperclass):
         # sets this; it is every genome in the db unless someone asked for a subset.
         self.genomes_of_interest = list(self.genome_names)
 
+        # lazily filled by `get_genome_stats`
+        self.genome_stats = None
+
         self.synteny_gene_clusters_gene_alignments_available = self.p_meta['gene_alignments_computed']
 
         if not self.synteny_gene_cluster_names:
@@ -3951,6 +3954,46 @@ class PanGraphSuperclass(PanSuperclass):
         return export_dict
 
     def init_pangenome_graph(self):
+    def get_genome_stats(self):
+        """Per-genome numbers the interface can sort its genome list by.
+
+        Everything here is computed over EVERY genome in the db and EVERY node in the
+        nodes table, deliberately -- NOT over whatever subset is currently on screen.
+        A genome's contig count is a property of the genome, and how many synteny gene
+        clusters it participates in is a property of the pan-graph; neither should
+        change because the user switched a different genome off. Keeping them fixed is
+        also what stops an ordering built on them from reshuffling underfoot as genomes
+        come and go.
+
+        `num_synteny_gene_clusters` always comes back. The rest are read from the
+        genomes storage, which is optional for `anvi-display-pan-graph`, so they are
+        simply absent when it was not provided -- the interface hides the buttons it
+        has no numbers for.
+        """
+        if self.genome_stats is not None:
+            return self.genome_stats
+
+        stats = {genome: {'num_synteny_gene_clusters': 0} for genome in self.genome_names}
+
+        for _, data in self.nodes.items():
+            for genome in json.loads(data['gene_calls_json']):
+                if genome in stats:
+                    stats[genome]['num_synteny_gene_clusters'] += 1
+
+        if self.genomes_storage_is_available:
+            keys = ['num_contigs', 'total_length', 'num_genes', 'gc_content',
+                    'percent_completion', 'percent_redundancy']
+            for genome, info in self.genomes_storage.genomes_info.items():
+                if genome not in stats:
+                    continue
+                for key in keys:
+                    if info.get(key) is not None:
+                        stats[genome][key] = info[key]
+
+        self.genome_stats = stats
+
+        return self.genome_stats
+
 
         for node, data in self.nodes.items():
             graph_data = {

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3953,7 +3953,6 @@ class PanGraphSuperclass(PanSuperclass):
 
         return export_dict
 
-    def init_pangenome_graph(self):
     def get_genome_stats(self):
         """Per-genome numbers the interface can sort its genome list by.
 
@@ -3995,11 +3994,65 @@ class PanGraphSuperclass(PanSuperclass):
         return self.genome_stats
 
 
+    def init_pangenome_graph(self, genomes_of_interest=None):
+        """Build the in-memory graph from the ``pan_graph_nodes``/``pan_graph_edges`` tables.
+
+        When `genomes_of_interest` is given, the graph is restricted to the subgraph
+        induced by those genomes: a node survives if at least one of them has a gene
+        call in it, and an edge survives if at least one of them walks it. Everything
+        the interface draws is derived from this graph downstream -- the layout comes
+        from `layout_all_components`, the regions and their backbone/variable calls
+        from `summarize_all_components` -- so a subset is laid out and summarized on
+        its own terms instead of inheriting the coordinates of the full genome set.
+        That is what makes it possible to watch a pangenome graph reorganize itself as
+        genomes come and go without recomputing anything from scratch.
+
+        Two things to keep in mind about what this is NOT. First, it is a subgraph of
+        the graph `anvi-pan-genome-graph` computed for ALL genomes in the pan-graph-db,
+        so the gene-endpoint fusion and remerge decisions baked into the node set still
+        reflect every one of those genomes -- this is not the same graph the engine
+        would build from the subset alone. Second, and in exchange, node ids stay
+        identical across subsets, which is precisely what makes successive subsets
+        comparable to one another.
+
+        Node types ARE recomputed, since 'core' has to mean "in every genome the user
+        is currently looking at" or the colors on the screen tell a lie.
+        """
+        if genomes_of_interest:
+            missing = sorted(set(genomes_of_interest) - set(self.genome_names))
+            if missing:
+                raise ConfigError(f"{len(missing)} of the genome names you asked this pan-graph to "
+                                  f"focus on are not in it: {', '.join(missing[:5])}"
+                                  f"{'...' if len(missing) > 5 else ''} :/")
+
+            # the db's genome order wins over whatever order the caller sent
+            requested = set(genomes_of_interest)
+            self.genomes_of_interest = [g for g in self.genome_names if g in requested]
+        else:
+            self.genomes_of_interest = list(self.genome_names)
+
+        genomes_to_keep = set(self.genomes_of_interest)
+        subsetting = len(genomes_to_keep) < len(self.genome_names)
+
+        # a fresh graph every time so this function can be called again to change the
+        # genome set without leaving nodes from a previous call behind
+        self.pangenome_graph = PangenomeGraphManager()
+
+        nodes_kept = set()
         for node, data in self.nodes.items():
+            gene_calls = json.loads(data['gene_calls_json'])
+            synteny = json.loads(data['synteny_position_json'])
+
+            if subsetting:
+                gene_calls = {g: v for g, v in gene_calls.items() if g in genomes_to_keep}
+                if not gene_calls:
+                    continue
+                synteny = {g: v for g, v in synteny.items() if g in genomes_to_keep}
+
             graph_data = {
                 'gene_cluster': data['gene_cluster_id'],
-                'gene_calls': json.loads(data['gene_calls_json']),
-                'synteny': json.loads(data['synteny_position_json']),
+                'gene_calls': gene_calls,
+                'synteny': synteny,
                 'type': data['node_type'],
                 'layer': self.items_additional_data_dict[node],
                 'position': (0, 0),
@@ -4008,11 +4061,24 @@ class PanGraphSuperclass(PanSuperclass):
                 'component_id': str(data['component_id']),
             }
             self.pangenome_graph.graph.add_node(node, **graph_data)
+            nodes_kept.add(node)
 
         for edge, data in self.edges.items():
+            genomes = json.loads(data['genomes_json'])
+            weight = data['weight']
+
+            if subsetting:
+                if data['source'] not in nodes_kept or data['target'] not in nodes_kept:
+                    continue
+                genomes = [g for g in genomes if g in genomes_to_keep]
+                if not genomes:
+                    continue
+                # the weight IS the number of genomes that walk this edge
+                weight = float(len(genomes))
+
             graph_data = {
-                'weight': data['weight'],
-                'genomes': json.loads(data['genomes_json']),
+                'weight': weight,
+                'genomes': genomes,
                 'name': edge,
                 'active': True,
                 'route': [],
@@ -4020,7 +4086,48 @@ class PanGraphSuperclass(PanSuperclass):
             }
             self.pangenome_graph.graph.add_edge(data['source'], data['target'], **graph_data)
 
+        if subsetting:
+            self.recompute_node_types()
+
         self.pangenome_graph_initialized = True
+
+
+    def recompute_node_types(self):
+        """Re-type the nodes of the current (subset) graph so that 'core' means "in
+        every genome currently in the graph" rather than "in every genome in the db".
+
+        The engine's `compute_node_types` does the actual work, in its 'global' scope,
+        with both of its inputs synthesized from the graph in memory:
+
+          * `line_to_genome` only matters here for the genome denominator, and the
+            function reads node membership from the mirrored `gene_calls` dicts, so a
+            self-map over the active genomes is all it needs.
+
+          * `gene_clusters` only feeds `parent_multi_copy`. Deriving it from the
+            surviving nodes means a genome counts as multi-copy for a parent GC when it
+            appears in two or more surviving super-nodes of that GC -- the same rule the
+            'component' scope uses. It differs from the pan-db-backed version, which
+            also counts genes that never made it into the graph, but this way the answer
+            follows from what the user is actually looking at.
+
+        `rna` is a call-type override the engine applied from the CONTIGS.dbs, which is
+        not something a genome subset can change, so those nodes keep their type.
+        """
+        from anvio.pangenomegraphengine import compute_node_types
+
+        G = self.pangenome_graph.graph
+
+        rna_nodes = {n for n, d in G.nodes(data=True) if d.get('type') == 'rna'}
+
+        line_to_genome = {g: g for g in self.genomes_of_interest}
+        gene_clusters = {(genome, gene_call): n.rsplit('_', 1)[0]
+                         for n, d in G.nodes(data=True)
+                         for genome, gene_call in d['gene_calls'].items()}
+
+        compute_node_types(G, line_to_genome, gene_clusters, scope='global')
+
+        for n in rna_nodes:
+            G.nodes[n]['type'] = 'rna'
 
     @property
     def gene_clusters(self):

--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3703,6 +3703,10 @@ class PanGraphSuperclass(PanSuperclass):
         self.pangenome_graph = PangenomeGraphManager()
         self.pangenome_graph_initialized = False
 
+        # which genomes the in-memory graph currently covers. `init_pangenome_graph`
+        # sets this; it is every genome in the db unless someone asked for a subset.
+        self.genomes_of_interest = list(self.genome_names)
+
         self.synteny_gene_clusters_gene_alignments_available = self.p_meta['gene_alignments_computed']
 
         if not self.synteny_gene_cluster_names:
@@ -3783,7 +3787,32 @@ class PanGraphSuperclass(PanSuperclass):
         self.p_meta['component'] = str(component)
 
 
-    def rerun_state(self, gene_cluster_grouping_threshold, groupcompress, max_edge_length_filter, component='CP_0001'):
+    def rerun_state(self, gene_cluster_grouping_threshold, groupcompress, max_edge_length_filter, component='CP_0001', genomes=None):
+        """Recompute the layout, and optionally the graph itself, for the interface.
+
+        `genomes` restricts the graph to a subset of the db's genomes (see
+        `init_pangenome_graph`). The graph is only rebuilt when that set actually
+        changed, so an ordinary redraw stays as cheap as it has always been.
+        """
+        # `None` means the caller didn't ask for a subset at all; an EMPTY list means
+        # they asked for nothing, which is a different thing and is an error.
+        if genomes is None:
+            requested = list(self.genome_names)
+        else:
+            unknown = sorted(set(genomes) - set(self.genome_names))
+            if unknown:
+                raise ConfigError(f"{len(unknown)} of the genomes you asked this pan-graph to show "
+                                  f"are not in it: {', '.join(unknown[:5])}"
+                                  f"{'...' if len(unknown) > 5 else ''} :/")
+
+            requested = [g for g in self.genome_names if g in set(genomes)]
+
+            if not requested:
+                raise ConfigError("There is no such thing as a pangenome graph of zero genomes, so "
+                                  "anvi'o is going to need you to leave at least one of them on :/")
+
+        if requested != self.genomes_of_interest:
+            self.init_pangenome_graph(genomes_of_interest=requested)
 
         args = argparse.Namespace(pan_or_profile_db=self.pan_graph_db_path, target_data_table="layer_orders")
         items_layer_order = TableForLayerOrders(args)
@@ -3807,6 +3836,14 @@ class PanGraphSuperclass(PanSuperclass):
         region_sides_df, _ = self.pangenome_graph.summarize_all_components(
             scope=self.p_meta.get('region_scope', 'global'))
         self._refresh_region_caches(region_sides_df)
+
+        # dropping genomes can dissolve a component entirely, so the one the
+        # interface last asked for may no longer be there to show
+        components = {str(d.get('component_id', 'CP_0001'))
+                      for _, d in self.pangenome_graph.graph.nodes(data=True)}
+        if str(component) not in components and components:
+            component = sorted(components, key=lambda cid: int(cid.split('_')[1]))[0]
+
         self.p_meta['component'] = str(component)
 
 
@@ -3895,6 +3932,13 @@ class PanGraphSuperclass(PanSuperclass):
 
         meta = dict(self.p_meta)
         meta['components_summary'] = components_summary
+
+        # `genome_names` stays the full roster the db knows about -- the settings panel
+        # is built from it once and must keep a row for every genome so a hidden one can
+        # be brought back. `genomes_of_interest` is the subset the graph on screen is
+        # actually made of, and it is what the drawing code should count against.
+        meta['genomes_of_interest'] = list(self.genomes_of_interest)
+        meta['genome_stats'] = self.get_genome_stats()
 
         export_dict = {
             'meta': meta,


### PR DESCRIPTION
Genome subsetting in the interface was not recalculating the graph shown, and it was causing some headaches. This PR allows the interactive genome subsetting in `anvi-display-pan-graph`.

With these changes, @ahenoch's `rerun_state` function now rebuilds a graph-to-be-displayed by dropping nodes/edges not covered by the requested genomes from the main graph, and by recomputing edge weights etc, re-laying it out, and keeping track of updated node types at all types (so 'core' reflects 'core' within the genomes shown). None of these affect summaries and underlying real data. These changes are (currently) only for visualization purposes.