### PR TITLE
Pass the run / progress objects

### DIFF
--- a/anvio/dbops.py
+++ b/anvio/dbops.py
@@ -3700,7 +3700,7 @@ class PanGraphSuperclass(PanSuperclass):
         self.genome_distances = pan_graph_db.db.get_table_as_dict(t.pan_graph_genome_distances_table_name)
         self.states = pan_graph_db.db.get_table_as_dict(t.states_table_name)
 
-        self.pangenome_graph = PangenomeGraphManager()
+        self.pangenome_graph = PangenomeGraphManager(run=self.run, progress=self.progress)
         self.pangenome_graph_initialized = False
 
         # which genomes the in-memory graph currently covers. `init_pangenome_graph`
@@ -4036,7 +4036,7 @@ class PanGraphSuperclass(PanSuperclass):
 
         # a fresh graph every time so this function can be called again to change the
         # genome set without leaving nodes from a previous call behind
-        self.pangenome_graph = PangenomeGraphManager()
+        self.pangenome_graph = PangenomeGraphManager(run=self.run, progress=self.progress)
 
         nodes_kept = set()
         for node, data in self.nodes.items():

--- a/anvio/interactive.py
+++ b/anvio/interactive.py
@@ -3345,7 +3345,7 @@ class PangraphInteractive(PanGraphSuperclass):
         if not self.pan_graph_db_path:
             raise ConfigError("Unfortunately you can only use this program with a pangenome graph database.")
 
-        PanGraphSuperclass.__init__(self, self.args)
+        PanGraphSuperclass.__init__(self, self.args, r=self.run, p=self.progress)
 
         self.collections = ccollections.Collections()
         self.collections.populate_collections_dict(self.pan_graph_db_path)

--- a/anvio/pangenomegraphmanager.py
+++ b/anvio/pangenomegraphmanager.py
@@ -316,7 +316,7 @@ class PangenomeGraphManager():
         merged_edges = {}
         merged_groups = {}
         for cid in range(n_components):
-            pos, epos, grps = TopologicalLayout().run_synteny_layout_algorithm(
+            pos, epos, grps = TopologicalLayout(r=self.run, p=self.progress).run_synteny_layout_algorithm(
                 F=self.graph,
                 gene_cluster_grouping_threshold=gene_cluster_grouping_threshold,
                 groupcompress=groupcompress,

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -1758,7 +1758,7 @@ class PangenomeGraph():
         self.version = anvio.__pangraph__version__
         self.functional_annotation_sources_available = DBInfo(self.genomes_storage, expecting='genomestorage').get_functional_annotation_sources() or [] if self.genomes_storage else []
         self.seed = None
-        self.pangenome_graph = PangenomeGraphManager()
+        self.pangenome_graph = PangenomeGraphManager(run=self.run, progress=self.progress)
 
         self.newick = ''
         self.meta = {}
@@ -1814,7 +1814,7 @@ class PangenomeGraph():
     def layout_pangenome_graph(self):
         self.run.warning(None, header="Running maximum force layout algorithm", lc="green")
 
-        node_positions, edge_positions, node_groups = TopologicalLayout().run_synteny_layout_algorithm(
+        node_positions, edge_positions, node_groups = TopologicalLayout(r=self.run, p=self.progress).run_synteny_layout_algorithm(
             F=self.pangenome_graph.graph,
             gene_cluster_grouping_threshold=self.gene_cluster_grouping_threshold,
             groupcompress=self.groupcompress,


### PR DESCRIPTION
Simple fix to avoid over-reporting when `verbose=False` is passed by the client.