### PR TITLE
Panic fixy for GenomeDescriptions

### DIFF
--- a/anvio/genomedescriptions.py
+++ b/anvio/genomedescriptions.py
@@ -363,7 +363,7 @@ class GenomeDescriptions(object):
         contigs_super = dbops.ContigsSuperclass(args, r=anvio.terminal.Run(verbose=False))
 
         if self.functions_are_available:
-            contigs_super.init_functions(requested_sources=requested_source_list)
+            contigs_super.init_functions(requested_sources=requested_source_list, dont_panic=True)
             function_calls_dict = contigs_super.gene_function_calls_dict
         else:
             function_calls_dict = {}


### PR DESCRIPTION
This PR offers a small fix for an issue that leads to a ConfigError when `anvi-gen-genomes-storage` is run on a list of contigs-db files that are annotated with different functional annotations.

Downstream steps of pangenomics in anvi'o is smart enough to retain only those function annotation sources that are common to all genomes, so it shouldn't lead to an error at this stage.