### PR TITLE
Index pooling rather than naive rescanning

### DIFF
--- a/anvio/pangenomegraphengine.py
+++ b/anvio/pangenomegraphengine.py
@@ -15,6 +15,8 @@ edge-reversal step is needed.
 import csv
 import os
 import random
+
+from heapq import heappush, heappop
 from argparse import Namespace
 from collections import Counter, defaultdict, deque
 
@@ -1715,33 +1717,112 @@ class PangenomeGraphEngine():
             pool.append([u, v, w, score, support, mean, li_u, li_v])
         pool.sort(key=lambda r: r[5], reverse=True)
 
-        def take_bucket(must_touch_g):
-            bucket, indices = [], []
-            for idx, row in enumerate(pool):
-                if must_touch_g and (row[6] not in in_g_lines
-                                     and row[7] not in in_g_lines):
-                    continue
-                bucket.append(row)
-                indices.append(idx)
-                if len(bucket) >= top_k:
-                    break
-            return bucket, indices
+        # Pool index! `take_bucket` has to yield the first `top_k` surviving
+        # rows *in ranking order* whose endpoint lines touch the frontier, and
+        # a naive rescan from position 0 re-examines the same un-usable head
+        # rows on every iteration: rows whose BOTH endpoints are still off the
+        # graph are skipped but never consumed, so on a dense pangenome the
+        # head can hold tens of thousands of such rows and the loop degrades
+        # to O(len(pool) * head_depth), taking HOURS of scanning a graph that
+        # takes seconds to build :/ Meren ran into this issue when he was working
+        # with a pangemoe of around 3,000 loci with only four genes. Even though
+        # every single edge betwen two nodes were pixel-percect, the loop wouldn't
+        # end.
+        #
+        # The solution below is a hybrid:
+        #
+        #   * rows_of_line  : line -> ranking positions of its rows, so a line
+        #                     joining the graph can hand its rows to the frontier
+        #   * frontier      : min-heap of ranking positions that touch in_g_lines,
+        #                     popping in ranking order exactly as the scan did
+        #   * alive         : tombstones. Consumed rows are marked, not popped,
+        #                     which also drops the O(n) list.pop(idx) memmove
+        #   * cursor        : monotone pointer for the must_touch_g=False fallback
+        #
+        # Deep down I know that there is a much better solution here, but since
+        # the current one is simple enough to address the problem that we will
+        # rarely end up dealing with, and it is working much faster than the naive scan,
+        # I will leave it in its current form rather than trying to optimize it further.
+        n_rows = len(pool)
+        alive = bytearray([1]) * n_rows
+        n_alive = n_rows
+        rows_of_line = defaultdict(list)
+        for idx, row in enumerate(pool):
+            rows_of_line[row[6]].append(idx)
+            rows_of_line[row[7]].append(idx)
 
-        total_pool = len(pool)
+        frontier = []
+        queued = bytearray(n_rows)
+        cursor = 0
+
+        def line_joined(li):
+            """Hand a newly committed line's surviving rows to the frontier."""
+            for idx in rows_of_line.get(li, ()):
+                if alive[idx] and not queued[idx]:
+                    queued[idx] = 1
+                    heappush(frontier, idx)
+
+        def take_bucket_touching():
+            """First `top_k` surviving rows, in ranking order, touching the frontier."""
+            picked = []
+            while frontier and len(picked) < top_k:
+                idx = heappop(frontier)
+                queued[idx] = 0
+                if alive[idx]:
+                    picked.append(idx)
+            return picked
+
+        def take_bucket_any():
+            """First `top_k` surviving rows, in ranking order, ignoring the frontier."""
+            nonlocal cursor
+            picked = []
+            idx = cursor
+            while idx < n_rows and len(picked) < top_k:
+                if alive[idx]:
+                    picked.append(idx)
+                idx += 1
+            while cursor < n_rows and not alive[cursor]:
+                cursor += 1
+            return picked
+
+        seen_lines = set()
+        n_seen = 0
+
+        total_pool = n_rows
         self.progress.new("Pangenome fusion", progress_total_items=total_pool)
         processed = 0
-        while pool:
+        while n_alive:
+            # Lines commit in several branches below -- including inside
+            # _try_commit_tie_line -- so instead of hooking every call site we
+            # diff the set whenever its size changed and hand the newly
+            # committed lines' rows to the frontier. The diff runs at most
+            # len(lines) times over the whole loop.
+            if len(in_g_lines) != n_seen:
+                for li in (in_g_lines - seen_lines):
+                    line_joined(li)
+                seen_lines = set(in_g_lines)
+                n_seen = len(in_g_lines)
+
             if not in_g_lines:
-                bucket, indices = take_bucket(must_touch_g=False)
+                bucket = take_bucket_any()
             else:
-                bucket, indices = take_bucket(must_touch_g=True)
+                bucket = take_bucket_touching()
                 if not bucket:
-                    bucket, indices = take_bucket(must_touch_g=False)
+                    bucket = take_bucket_any()
                     if not bucket:
                         break
             pick = rng.randrange(len(bucket))
-            u, v, w, score, support, mean, li_u, li_v = bucket[pick]
-            pool.pop(indices[pick])
+            chosen = bucket[pick]
+            for idx in bucket:
+                # Only the picked row is consumed; the rest stay in the pool.
+                if idx != chosen and not queued[idx]:
+                    queued[idx] = 1
+                    heappush(frontier, idx)
+            u, v, w, score, support, mean, li_u, li_v = pool[chosen]
+            alive[chosen] = 0
+            n_alive -= 1
+            while cursor < n_rows and not alive[cursor]:
+                cursor += 1
             processed += 1
             if processed & 0x3FF == 0:
                 self.progress.update(f"lines {pp(len(in_g_lines))}/{pp(len(lines))}  "


### PR DESCRIPTION
I ran into a significant performance issue, and this PR addresses that. Pinging @ahenoch since he may want to be aware of this.

Something that worked on 3,012 loci stopped working when I removed 5 of those loci that made the graph complicated. My removal of those genomes dramatically simplified the graph, but actually in this case it was worse for the algorithm, so it took hours and hours for something that should have taken seconds. And it was then I realized we had a N*log(N^4) scale problem at our hands.

Buckle up for fun. While building the pangenome graph, especially when we are dealing with edges, the inner take_bucket() scans the ranked edge pool to make decisions. But every time it runs into a new edge, it scans the bucket from position zero, and because it skips (but never consumes) edges whose both endpoint contigs are still off the graph, the same tens of thousands of head rows get re-examined hundreds of thousands of times for a relatively small set of genomes which turns into hundreds of millions of comparison, which turns a few seconds work into hours of wait.

This solution indexes the pool instead of rescanning it. It has map to connect lines to row positions, a min-heap of the positions that touch the current frontier (so edges still pop in exact ranking order), and tombstones in place of list.pop(idx). It does not change anything, but comes with about 2 orders of magnitude speed difference in pangenome graphs with MANY overlapping edges.

There is a much deeper issue here that I didn't want to address. In my case with these loci, the pool holds hundreds of thousands of edges to build a 100-node graph (literally).. The pool grows with the square of the genome count while the answer stays tiny, and those edges carry only a few distinct ranking scores with tens of thousands of them remain tied. Collapsing redundant within-gene-cluster edges before fusion, AND adding tie-breaking resolution to the ranking would shrink the work at the source and, just as importantly, stop tiny input changes like removing a few genomes from the analysis to silently reshuffle which edges get seen first.

But this is such a niche problem, I don't think we need to go that deep into the realm of kitchen sinks (this already is a bit of a kitchen sink at this stage as it is). This change will likely be enough for over 99.99% of the applications of this algorithm.