### PR TITLE
Performance fixies for genome tree calcuations from pangenome graphs

### DIFF
--- a/anvio/pangenomegraphmanager.py
+++ b/anvio/pangenomegraphmanager.py
@@ -748,43 +748,39 @@ class PangenomeGraphManager():
         # order (process-dependent) would reshuffle the genome ordering every run.
         genome_names = sorted(set(it.chain(*[list(d.keys()) for node, d in self.graph.nodes(data='gene_calls')])))
 
-        X = np.zeros([len(genome_names), len(genome_names)])
-        min_pair = max_pair = None
-        min_dist = float('inf')
-        max_dist = float('-inf')
-        for genome_i, genome_j in it.combinations(genome_names, 2):
-            nodes_similar = 0
-            edges_similar = 0
-            nodes_unsimilar = 0
-            edges_unsimilar = 0
-            for _, data in self.graph.nodes(data=True):
-                if genome_i in data['gene_calls'].keys() and genome_j in data['gene_calls'].keys():
-                    nodes_similar += 1
-                elif genome_i in data['gene_calls'].keys() or genome_j in data['gene_calls'].keys():
-                    nodes_unsimilar += 1
-            for _, _, data in self.graph.edges(data=True):
-                edge_genomes = set(data.get('genomes', []))
-                if genome_i in edge_genomes and genome_j in edge_genomes:
-                    edges_similar += 1
-                elif genome_i in edge_genomes or genome_j in edge_genomes:
-                    edges_unsimilar += 1
+        # The distance between two genomes is the Jaccard distance over the set of graph
+        # elements, and the entire matrix is simply a single dot product, as in, there is
+        # no reason to loop over pairs of genomes here (see commit logs for these lines
+        # for details).
+        genome_index = {genome_name: i for i, genome_name in enumerate(genome_names)}
 
-            i = genome_names.index(genome_i)
-            j = genome_names.index(genome_j)
+        # one row per graph element (nodes first, then edges), one column per genome
+        memberships = [d or {} for _, d in self.graph.nodes(data='gene_calls')] \
+                    + [d.get('genomes') or [] for _, _, d in self.graph.edges(data=True)]
 
-            elements_similar = nodes_similar + edges_similar
-            elements_unsimilar = nodes_unsimilar + edges_unsimilar
+        M = np.zeros((len(memberships), len(genome_names)))
+        for row, members in enumerate(memberships):
+            columns = [genome_index[genome_name] for genome_name in members if genome_name in genome_index]
+            if columns:
+                M[row, columns] = 1.0
 
-            d = elements_unsimilar / (elements_similar + elements_unsimilar)
-            X[i][j] = d
-            X[j][i] = d
+        num_shared = M.T @ M                                    # elements both genomes are in
+        num_elements = M.sum(axis=0)                            # elements each genome is in
+        num_total = num_elements[:, None] + num_elements[None, :]
+        num_union = num_total - num_shared                      # similar + unsimilar
 
-            if d < min_dist:
-                min_dist, min_pair = d, (genome_i, genome_j)
-            if d > max_dist:
-                max_dist, max_pair = d, (genome_i, genome_j)
+        # building a sparse distance matrix here
+        X = np.divide(num_total - 2 * num_shared, num_union, out=np.zeros_like(num_union), where=num_union > 0)
+        np.fill_diagonal(X, 0.0)
 
-        if min_pair is not None:
+        if len(genome_names) > 1:
+            upper_i, upper_j = np.triu_indices(len(genome_names), k=1)
+            distances = X[upper_i, upper_j]
+            argmin, argmax = distances.argmin(), distances.argmax()
+            min_dist, max_dist = distances[argmin], distances[argmax]
+            min_pair = (genome_names[upper_i[argmin]], genome_names[upper_j[argmin]])
+            max_pair = (genome_names[upper_i[argmax]], genome_names[upper_j[argmax]])
+
             self.run.info('Smallest distance', f"d({min_pair[0]},{min_pair[1]}) = {round(min_dist, 3)}")
             self.run.info('Largest distance',  f"d({max_pair[0]},{max_pair[1]}) = {round(max_dist, 3)}")
             self.run.info_single("full matrix written to the pan-graph-db", cut_after=None)

--- a/anvio/panops.py
+++ b/anvio/panops.py
@@ -2282,13 +2282,23 @@ class PangenomeGraph():
         self.progress.update('...')
 
         table_for_distances = TableForGenomeDistances(self.pan_graph_db_path, run=self.run, progress=self.progress)
-        for genome_a in self.distance_matrix.index:
-            for genome_b in self.distance_matrix.columns:
+
+        # iterating over the underlying numpy array rather than asking pandas for
+        # `.loc[genome_a, genome_b]` per cell is over 10x faster for large genome
+        # sets  (pandas posion everything for a negligible convenience and Meren
+        # believes that we should get rid of pandas entirely from anvi'o, but
+        # that is a separate discussion):
+        genome_names_a = list(self.distance_matrix.index)
+        genome_names_b = list(self.distance_matrix.columns)
+        distances = self.distance_matrix.to_numpy()
+
+        for i, genome_a in enumerate(genome_names_a):
+            for j, genome_b in enumerate(genome_names_b):
                 if genome_a == genome_b:
                     continue
                 table_for_distances.add({'genome_a': genome_a,
                                          'genome_b': genome_b,
-                                         'distance': float(self.distance_matrix.loc[genome_a, genome_b])})
+                                         'distance': float(distances[i, j])})
 
         self.progress.end()
 


### PR DESCRIPTION
There are two changes in this PR.

One is a small speed gain, the other is a significant one -- here they are starting with the big change:

Calculating the distance between two genomes to compute a dendrogram from pan-graph was causing extremely long wait times in my 1,300 genome set (it sounds stupid, but actually it was very useful to find some bottlenecks in the code and focus on them). What happened here is the following: we were looping over all genome pairs in the now-replaced code in `anvio/pangenomegraphmanager.py` (i.e., every node and every edge for every pair of genomes to rebuild a `set(edge['genomes'])` object in its most inner loop). Which brought us to the realm of `O(N^3)` complexities. As a result, calculating the dendrogram for my 1,300 genomes took over 5 minutes (which didn't sit well with me). The alternative in this PR below simply vectorizes this step, and produces a bit-identical distance matrix in about 1% of a second for the same set of genomes (yay math).

The other change is a small switch from the poisonous pandas to torturous numpy, which turns a 8-second long process into fractions of a second when large numbers of genomes involved.