### PR TITLE
fix negative start position in keep-promoter mode of anvi-gen-pan-representative

### DIFF
--- a/anvio/panrep.py
+++ b/anvio/panrep.py
@@ -439,7 +439,7 @@ class PanRepresenter:
                         previous_gene_id = (gene_calls_data.get(first_id - 1) if first_id > min_valid_id else None)
                         next_gene_id = (gene_calls_data.get(last_id + 1) if last_id < max_valid_id else None)
 
-                        start = previous_gene_id["stop"] if previous_gene_id else 0
+                        start = (min(previous_gene_id["stop"], start)) if previous_gene_id else 0
                         stop = (max(last_gene_call["stop"], next_gene_id["start"]) if next_gene_id else len(contig_seq))
 
                     extracted = contig_seq[start:stop]


### PR DESCRIPTION
**Description:**
---
In keep-promoter mode, `anvi-gen-pan-representative` includes the flanking region of the target sequence (one or more genes) when extracting genes to build the supplementary contig. This means instead of extracting the sequence from the start position of the first target gene, it actually extracts from the stop position of the preceding gene.

**Bug:**
---
When the preceding gene overlaps the first target gene, its stop position falls after the target gene's start. Once coordinates are recalculated relative to the extraction start, the first gene's start position becomes negative.

**Fix:**
---
Set the start position to the lower of the two values: the preceding gene's stop or the first target gene's start. If no preceding gene exists, the target sequence is at the start of a contig, so the start position is 0.