### PR TITLE
Zero hit BAM profiling fixy

### DIFF
--- a/anvio/profiler.py
+++ b/anvio/profiler.py
@@ -1110,6 +1110,12 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.total_reads_kept = 0
         self.description_file_path = A('description')
 
+        # this will be set to `True` by `_apply_bam_index_prefilter` if there is not a single read
+        # in the BAM file that is mapped to any of the contigs we are interested in. in that case
+        # anvi'o will not profile anything, but will still generate a proper single profile database
+        # in which every contig and split has zero coverage
+        self.nothing_to_profile = False
+
         if self.fetch_filter:
             valid_fetch_filters = [k for k in constants.fetch_filters.keys() if k]
 
@@ -1288,19 +1294,47 @@ class BAMProfiler(dbops.ContigsSuperclass):
         else:
             eligible_contigs = all_contig_names
 
+        if self._user_specified_contigs_of_interest and not eligible_contigs:
+            _db.disconnect()
+            raise ConfigError("None of the contig names you have declared via `--contigs-of-interest` match to any of "
+                              "the contig names in your contigs database :/ Perhaps you have a typo, or you are using "
+                              "the wrong contigs database for this analysis?")
+
         # Contigs with coverage that are also eligible
         contigs_to_profile = contigs_with_coverage & eligible_contigs
         self._contigs_skipped_by_prefilter = eligible_contigs - contigs_to_profile
 
         if not contigs_to_profile:
+            # there is not a single read in this BAM file that is mapped to any of the contigs we
+            # care about. this is not an error: when one recruits reads from a large number of
+            # metagenomes using a small reference, some of those metagenomes will have nothing that
+            # matches it. so here anvi'o gives up on profiling, and lets the rest of the class know
+            # that every eligible contig (all of which are already in
+            # `self._contigs_skipped_by_prefilter`) will be backfilled with zero coverage by
+            # `store_zero_coverage_for_skipped_splits`. the resulting profile database is a
+            # first-class citizen: it has the same number of contigs, splits, and nucleotides as
+            # any other profile database generated from the same contigs database, thus it can be
+            # merged with them, and the sample will show up in downstream results with zero
+            # coverage everywhere.
             _db.disconnect()
+
+            self.nothing_to_profile = True
+
             if self._user_specified_contigs_of_interest:
-                raise ConfigError("None of the contigs you specified via `--contigs-of-interest` have any mapped "
-                                  "reads in the BAM file. The BAM file does contain reads mapped to other contigs, "
-                                  "but none of them match your list. There is nothing to profile here.")
+                self.run.warning("None of the contigs you specified via `--contigs-of-interest` have any mapped reads "
+                                 "in this BAM file (even though the BAM file does contain reads that are mapped to "
+                                 "other contigs). Anvi'o will still generate a single profile database for this "
+                                 "sample, but every contig in it will have zero coverage.",
+                                 header="NOTHING MAPPED TO YOUR CONTIGS OF INTEREST 🤷", lc="yellow")
             else:
-                raise ConfigError("None of the contigs in the BAM file have any mapped reads. There is nothing "
-                                  "to profile here.")
+                self.run.warning("There is not a single read in this BAM file that is mapped to any of the contigs in "
+                                 "your contigs database. Anvi'o will still generate a single profile database for this "
+                                 "sample so it can be merged with others and be visible in your downstream analyses, "
+                                 "but every contig in it will have zero coverage. If this is unexpected, you may want "
+                                 "to take a look at your mapping results.",
+                                 header="NOTHING MAPPED TO ANYTHING 🤷", lc="yellow")
+
+            return
 
         # Get split names for the contigs we will actually profile.
         # Uses a temp table + JOIN with parameterized inserts to avoid SQL injection
@@ -1478,7 +1512,11 @@ class BAMProfiler(dbops.ContigsSuperclass):
                                                          view_name=None if table_name.endswith('contigs') else view)
         elif self.input_file_path:
             self.init_profile_from_BAM()
-            if self.num_threads > 1 or self.args.force_multi:
+            if self.nothing_to_profile:
+                # there are no contigs to distribute among workers. the single-threaded code path
+                # will simply backfill zero coverage for every contig and split:
+                self.profile_single_thread()
+            elif self.num_threads > 1 or self.args.force_multi:
                 if self.num_splits > 200000 and self.num_threads > 20:
                     self.run.warning(f"We noticed that you have more than 200,000 splits and are using more than 20 "
                                      f"threads. In fact, you have {self.num_splits:,} splits and are using "
@@ -1504,7 +1542,11 @@ class BAMProfiler(dbops.ContigsSuperclass):
 
         self._log_mem("before clustering")
 
-        if self.contigs_shall_be_clustered:
+        if self.contigs_shall_be_clustered and self.nothing_to_profile:
+            self.run.warning("You asked anvi'o to cluster your contigs, but since there is not a single read in this "
+                             "BAM file that is mapped to any of them, there is no data to cluster them with. Anvi'o "
+                             "is skipping the hierarchical clustering step for this sample.")
+        elif self.contigs_shall_be_clustered:
             self.cluster_contigs()
 
         if self.bam:
@@ -1962,6 +2004,49 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.run.info('Number of reads in the BAM file', pp(int(self.num_reads_mapped)))
         self.run.info('Number of sequences in the contigs DB', pp(len(self.contig_names)))
 
+        if self.nothing_to_profile:
+            # `_apply_bam_index_prefilter` has already established that not a single read in this
+            # BAM file is mapped to any of our contigs. everything below sets the stage for
+            # `store_zero_coverage_for_skipped_splits` to do all the work: it will add every
+            # length-eligible contig and split to the profile database with zero coverage, and
+            # will increment the three `self` table variables anvi'o sets to zero here (which is
+            # critical, since `anvi-merge` requires them to be identical across profile databases).
+            if not set(self.contig_names) & self.contig_names_in_contigs_db:
+                raise ConfigError("Not only there are no reads in this BAM file that are mapped to any of your contigs, "
+                                  "but also not a single contig name in the BAM file matches to a contig name in your "
+                                  "contigs database. Which means you are most likely using a contigs database that has "
+                                  "nothing to do with this BAM file. Here is a contig name from your BAM file: '%s', and "
+                                  "here is one from your contigs database: '%s'. If they look like they should have "
+                                  "matched, you may have failed to fix your contig names in your FASTA file prior to "
+                                  "mapping, which is described here: %s"
+                                        % (self.contig_names[0] if len(self.contig_names) else 'N/A',
+                                           next(iter(self.contig_names_in_contigs_db), 'N/A'),
+                                           'http://goo.gl/Q9ChpS'))
+
+            self.contig_names = []
+            self.contig_lengths = []
+            self.contig_name_to_splits = {}
+            self.split_names = set([])
+            self.num_contigs = 0
+            self.num_splits = 0
+            self.total_length = 0
+
+            profile_db = dbops.ProfileDatabase(self.profile_db_path, quiet=True)
+            profile_db.db.set_meta_value('num_splits', self.num_splits)
+            profile_db.db.set_meta_value('num_contigs', self.num_contigs)
+            profile_db.db.set_meta_value('total_length', self.total_length)
+            profile_db.disconnect()
+
+            self.run.info('Contigs with at least one mapped read', 'None. Every contig will have zero coverage',
+                          mc='red', nl_after=1)
+
+            self.layer_additional_data['total_reads_mapped'] = self.num_reads_mapped
+            self.layer_additional_keys.append('total_reads_mapped')
+
+            self._log_mem("after BAM init")
+
+            return
+
         if self.contig_names_of_interest:
             contig_name_to_index = {name: i for i, name in enumerate(self.contig_names)}
             indexes = [contig_name_to_index[r] for r in self.contig_names_of_interest if r in contig_name_to_index]
@@ -2160,7 +2245,7 @@ class BAMProfiler(dbops.ContigsSuperclass):
     def profile_single_thread(self):
         """The main method for anvi-profile when num_threads is 1"""
 
-        if not self.contig_sequences:
+        if self.num_contigs and not self.contig_sequences:
             self.init_contig_sequences(contig_names_of_interest=set(self.contig_names))
 
         self._log_mem("after loading contig sequences")
@@ -2282,7 +2367,16 @@ class BAMProfiler(dbops.ContigsSuperclass):
         self.layer_additional_data['total_reads_kept'] = self.total_reads_kept
         self.layer_additional_keys.append('total_reads_kept')
 
-        self.check_contigs(num_contigs=received_contigs)
+        if not self.nothing_to_profile:
+            self.check_contigs(num_contigs=received_contigs)
+        elif not self.num_splits:
+            # nothing was profiled AND nothing was backfilled with zero coverage, which means the
+            # min/max contig length criteria have removed every single contig from consideration:
+            raise ConfigError("Anvi'o applied your min/max length criteria for contigs to filter out the bad ones "
+                              "and has bad news: not a single contig in your contigs database was greater than %s "
+                              "and smaller than %s nts :( So this profiling attempt did not really go anywhere. "
+                              "Please remove your half-baked output directory if it is still there: '%s'."
+                                    % (pp(self.min_contig_length), pp(self.max_contig_length), self.output_directory))
 
 
     def profile_multi_thread(self):


### PR DESCRIPTION
TIL that the commit 943655508 broke profiling of BAM files with 0 hits. which is quite a common need in large surveys. changes here fixes the issue while maintaining the pre-filter functionality as @FlorianTrigodet intended originally.