### PR TITLE
Check `anvi-draw-kegg-pathways` package dependencies before their import

### DIFF
--- a/anvio/cli/draw_kegg_pathways.py
+++ b/anvio/cli/draw_kegg_pathways.py
@@ -16,6 +16,35 @@ from anvio.argparse import ArgumentParser
 from anvio import A, K, __version__ as VERSION
 from anvio.metabolism.context import KeggContext
 from anvio.errors import ConfigError, FilesNPathsError
+
+
+def check_package_dependencies():
+    missing_packages = []
+    for package_name in ('Bio', 'reportlab', 'fitz'):
+        try:
+            importlib.import_module(package_name)
+        except ImportError:
+            missing_packages.append(package_name)
+
+    if missing_packages:
+        message = ', '.join(f"'{package_name}'" for package_name in missing_packages)
+        # Printed rather than raised: this runs at import time, where there is no handler to turn
+        # a ConfigError into the message alone rather than into a traceback.
+        print(ConfigError(
+            f"The following Python packages required to run `anvi-draw-kegg-pathways` could not be "
+            f"imported: {message}. All Python dependencies of anvi'o are described in its "
+            f"`pyproject.toml`, and can be installed by running the command `pip install -e .` in "
+            f"the top directory of the anvi'o codebase, which may have a location like "
+            f"'~/github/anvio' in your file system if you followed the anvio.org installation "
+            f"instructions."
+        ))
+        sys.exit(-1)
+
+# Checked before the import below rather than from within main: 'anvio.keggmapping' imports 'fitz'
+# and, through 'anvio.kgml', 'reportlab', so by the time main runs a missing one of those has
+# already reached the user as an ImportError traceback.
+check_package_dependencies()
+
 from anvio.keggmapping import (
     AGGREGATION_FUNCTIONS, DEFAULT_CENTERED_COLORMAP, DEFAULT_GROUP_TINT_SPAN,
     ELEMENT_NORMALIZATION_PHRASE, GROUP_COLORMAP_FROM_CATEGORY, GROUP_SCHEME_OPTIONS,
@@ -777,25 +806,6 @@ def get_args() -> Namespace:
 
     args = parser.get_args(parser)
     return args
-
-
-def check_package_dependencies():
-    missing_packages = []
-    for package_name in ('Bio', 'reportlab', 'fitz'):
-        try:
-            importlib.import_module(package_name)
-        except ImportError:
-            missing_packages.append(package_name)
-
-    if missing_packages:
-        message = ', '.join(f"'{package_name}'" for package_name in missing_packages)
-        raise ConfigError(
-            f"The following Python packages required to run `anvi-draw-kegg-pathways` could not be "
-            f"imported: {message}. All Python dependencies of anvi'o can be installed by running "
-            f"the command `pip install -r requirements.txt` in the top directory of the anvi'o "
-            f"codebase, which may have a location like '~/github/anvio' in your file system if you "
-            f"followed the anvio.org installation instructions."
-        )
 
 def check_kegg_data(args: Namespace) -> None:
     kegg_args = Namespace()
@@ -1879,7 +1889,6 @@ def main() -> None:
     args = get_args()
 
     try:
-        check_package_dependencies()
         check_kegg_data(args)
         consolidate_contigs_dbs(args)
 


### PR DESCRIPTION
`anvi-draw-kegg-pathways` has a `check_package_dependencies` that imports `Bio`, `reportlab`, and `fitz` and raises a `ConfigError` naming whichever are missing. It was called from `main()` — after the module's own from `keggmapping import …` had already run. `keggmapping.py` imports `fitz` on its line 6 and reaches `reportlab` through `kgml.py`, so a missing package killed the program during import and the message was unreachable. This PR moves the check above that import, which is the only place it can run in time. It now runs while the module is being imported by the CLI script, before `main()` and its `except ConfigError` exist, so it prints the error and exits itself — raising there would reach the user as a traceback with the message tacked on the end.

Also, the message drops `pip install -r requirements.txt`, which has pointed at a file that does not exist since `requirements.txt` and `setup.py` were removed.

'Bio' stays in the checked tuple but cannot fire, before or after this change: `biopython` is already pulled in one line earlier by from `anvio.argparse import ArgumentParser` → `utils.py:32`, whose own `except ModuleNotFoundError` exits with the generic "conda environment … not properly initialized" warning. Covering it would mean hoisting the check above the rest of the anvi'o imports.